### PR TITLE
fix(ld-radio): change selection with arrow buttons

### DIFF
--- a/src/liquid/components/ld-radio/ld-radio.tsx
+++ b/src/liquid/components/ld-radio/ld-radio.tsx
@@ -77,13 +77,13 @@ export class LdRadio implements InnerFocusable {
       case 'ArrowUp':
       case 'ArrowLeft': {
         ev.preventDefault()
-        this.focusRadio('prev')
+        this.focusAndSelect('prev')
         return
       }
       case 'ArrowDown':
       case 'ArrowRight': {
         ev.preventDefault()
-        this.focusRadio('next')
+        this.focusAndSelect('next')
         return
       }
     }
@@ -123,13 +123,17 @@ export class LdRadio implements InnerFocusable {
     this.el.dispatchEvent(new Event('input', { bubbles: true, composed: true }))
   }
 
-  private focusRadio(dir: 'next' | 'prev') {
+  private focusAndSelect(dir: 'next' | 'prev') {
     const ldRadios = Array.from(document.querySelectorAll('ld-radio')).filter(
       (ldRadio) => ldRadio.getAttribute('name') === this.name
     )
     ldRadios.forEach((ldRadio, index) => {
       if (ldRadio === ((this.el as unknown) as HTMLLdRadioElement)) {
-        ldRadios[index + (dir === 'next' ? 1 : -1)]?.focusInner()
+        const targetLdRadio = ldRadios[index + (dir === 'next' ? 1 : -1)]
+        if (targetLdRadio) {
+          targetLdRadio.focusInner()
+          targetLdRadio.click()
+        }
       }
     })
   }
@@ -174,6 +178,11 @@ export class LdRadio implements InnerFocusable {
           {...cloneAttributes(this.el)}
           disabled={this.disabled}
           checked={this.checked}
+          tabIndex={
+            this.checked
+              ? parseInt(this.el.getAttribute('tabindex')) || undefined
+              : -1
+          }
         />
         <div part="dot" class="ld-radio__dot"></div>
         <div class="ld-radio__box" part="box"></div>

--- a/src/liquid/components/ld-radio/test/__snapshots__/ld-radio.spec.ts.snap
+++ b/src/liquid/components/ld-radio/test/__snapshots__/ld-radio.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`ld-radio creates hidden input field, if inside a form 1`] = `
 <ld-radio class="ld-radio" part="root">
   <mock:shadow-root>
-    <input part="input focusable" type="radio">
+    <input part="input focusable" tabindex="-1" type="radio">
     <div class="ld-radio__dot" part="dot"></div>
     <div class="ld-radio__box" part="box"></div>
   </mock:shadow-root>
@@ -14,7 +14,7 @@ exports[`ld-radio creates hidden input field, if inside a form 1`] = `
 exports[`ld-radio danger 1`] = `
 <ld-radio class="ld-radio ld-radio--danger" mode="danger" part="root">
   <mock:shadow-root>
-    <input part="input focusable" type="radio">
+    <input part="input focusable" tabindex="-1" type="radio">
     <div class="ld-radio__dot" part="dot"></div>
     <div class="ld-radio__box" part="box"></div>
   </mock:shadow-root>
@@ -24,7 +24,7 @@ exports[`ld-radio danger 1`] = `
 exports[`ld-radio disabled 1`] = `
 <ld-radio class="ld-radio" disabled="" part="root">
   <mock:shadow-root>
-    <input disabled="" part="input focusable" type="radio">
+    <input disabled="" part="input focusable" tabindex="-1" type="radio">
     <div class="ld-radio__dot" part="dot"></div>
     <div class="ld-radio__box" part="box"></div>
   </mock:shadow-root>
@@ -34,7 +34,7 @@ exports[`ld-radio disabled 1`] = `
 exports[`ld-radio heighlight 1`] = `
 <ld-radio class="ld-radio ld-radio--highlight" mode="highlight" part="root">
   <mock:shadow-root>
-    <input part="input focusable" type="radio">
+    <input part="input focusable" tabindex="-1" type="radio">
     <div class="ld-radio__dot" part="dot"></div>
     <div class="ld-radio__box" part="box"></div>
   </mock:shadow-root>
@@ -44,7 +44,7 @@ exports[`ld-radio heighlight 1`] = `
 exports[`ld-radio renders 1`] = `
 <ld-radio class="ld-radio" part="root">
   <mock:shadow-root>
-    <input part="input focusable" type="radio">
+    <input part="input focusable" tabindex="-1" type="radio">
     <div class="ld-radio__dot" part="dot"></div>
     <div class="ld-radio__box" part="box"></div>
   </mock:shadow-root>
@@ -54,7 +54,7 @@ exports[`ld-radio renders 1`] = `
 exports[`ld-radio tone 1`] = `
 <ld-radio class="ld-radio ld-radio--dark" part="root" tone="dark">
   <mock:shadow-root>
-    <input part="input focusable" type="radio">
+    <input part="input focusable" tabindex="-1" type="radio">
     <div class="ld-radio__dot" part="dot"></div>
     <div class="ld-radio__box" part="box"></div>
   </mock:shadow-root>

--- a/src/liquid/components/ld-radio/test/ld-radio.spec.ts
+++ b/src/liquid/components/ld-radio/test/ld-radio.spec.ts
@@ -145,13 +145,13 @@ describe('ld-radio', () => {
     expect(ldRadios[3].getAttribute('checked')).not.toBe(null)
   })
 
-  it('moves focus', async () => {
+  it('moves focus and selection', async () => {
     const page = await newSpecPage({
       components: [LdRadio],
       html: `
-        <ld-radio name="foo" />
-        <ld-radio name="bar" />
         <ld-radio name="foo" checked />
+        <ld-radio name="bar" />
+        <ld-radio name="foo" />
         <ld-radio name="baz" />
         <ld-radio name="foo" />
       `,
@@ -161,6 +161,9 @@ describe('ld-radio', () => {
     const radios = ldRadios.map((ldRadio) =>
       ldRadio.shadowRoot.querySelector('input')
     )
+    ldRadios.forEach((ldRadio) => {
+      ldRadio.click = jest.fn()
+    })
     radios.forEach((radio) => {
       radio.focus = jest.fn()
     })
@@ -169,6 +172,12 @@ describe('ld-radio', () => {
       new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
     ) // nothing shall happen
     await page.waitForChanges()
+
+    expect(ldRadios[0].click).toHaveBeenCalledTimes(0)
+    expect(ldRadios[1].click).toHaveBeenCalledTimes(0)
+    expect(ldRadios[2].click).toHaveBeenCalledTimes(0)
+    expect(ldRadios[3].click).toHaveBeenCalledTimes(0)
+    expect(ldRadios[4].click).toHaveBeenCalledTimes(0)
 
     expect(radios[0].focus).toHaveBeenCalledTimes(0)
     expect(radios[1].focus).toHaveBeenCalledTimes(0)
@@ -181,6 +190,12 @@ describe('ld-radio', () => {
     )
     await page.waitForChanges()
 
+    expect(ldRadios[0].click).toHaveBeenCalledTimes(0)
+    expect(ldRadios[1].click).toHaveBeenCalledTimes(0)
+    expect(ldRadios[2].click).toHaveBeenCalledTimes(1)
+    expect(ldRadios[3].click).toHaveBeenCalledTimes(0)
+    expect(ldRadios[4].click).toHaveBeenCalledTimes(0)
+
     expect(radios[0].focus).toHaveBeenCalledTimes(0)
     expect(radios[1].focus).toHaveBeenCalledTimes(0)
     expect(radios[2].focus).toHaveBeenCalledTimes(1)
@@ -192,6 +207,12 @@ describe('ld-radio', () => {
     )
     await page.waitForChanges()
 
+    expect(ldRadios[0].click).toHaveBeenCalledTimes(0)
+    expect(ldRadios[1].click).toHaveBeenCalledTimes(0)
+    expect(ldRadios[2].click).toHaveBeenCalledTimes(1)
+    expect(ldRadios[3].click).toHaveBeenCalledTimes(0)
+    expect(ldRadios[4].click).toHaveBeenCalledTimes(1)
+
     expect(radios[0].focus).toHaveBeenCalledTimes(0)
     expect(radios[1].focus).toHaveBeenCalledTimes(0)
     expect(radios[2].focus).toHaveBeenCalledTimes(1)
@@ -203,6 +224,12 @@ describe('ld-radio', () => {
     )
     await page.waitForChanges()
 
+    expect(ldRadios[0].click).toHaveBeenCalledTimes(0)
+    expect(ldRadios[1].click).toHaveBeenCalledTimes(0)
+    expect(ldRadios[2].click).toHaveBeenCalledTimes(1)
+    expect(ldRadios[3].click).toHaveBeenCalledTimes(0)
+    expect(ldRadios[4].click).toHaveBeenCalledTimes(1)
+
     expect(radios[0].focus).toHaveBeenCalledTimes(0)
     expect(radios[1].focus).toHaveBeenCalledTimes(0)
     expect(radios[2].focus).toHaveBeenCalledTimes(1)
@@ -213,6 +240,12 @@ describe('ld-radio', () => {
       new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true })
     )
     await page.waitForChanges()
+
+    expect(ldRadios[0].click).toHaveBeenCalledTimes(0)
+    expect(ldRadios[1].click).toHaveBeenCalledTimes(0)
+    expect(ldRadios[2].click).toHaveBeenCalledTimes(2)
+    expect(ldRadios[3].click).toHaveBeenCalledTimes(0)
+    expect(ldRadios[4].click).toHaveBeenCalledTimes(1)
 
     expect(radios[0].focus).toHaveBeenCalledTimes(0)
     expect(radios[1].focus).toHaveBeenCalledTimes(0)
@@ -225,6 +258,12 @@ describe('ld-radio', () => {
     )
     await page.waitForChanges()
 
+    expect(ldRadios[0].click).toHaveBeenCalledTimes(1)
+    expect(ldRadios[1].click).toHaveBeenCalledTimes(0)
+    expect(ldRadios[2].click).toHaveBeenCalledTimes(2)
+    expect(ldRadios[3].click).toHaveBeenCalledTimes(0)
+    expect(ldRadios[4].click).toHaveBeenCalledTimes(1)
+
     expect(radios[0].focus).toHaveBeenCalledTimes(1)
     expect(radios[1].focus).toHaveBeenCalledTimes(0)
     expect(radios[2].focus).toHaveBeenCalledTimes(2)
@@ -235,6 +274,12 @@ describe('ld-radio', () => {
       new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true })
     )
     await page.waitForChanges()
+
+    expect(ldRadios[0].click).toHaveBeenCalledTimes(1)
+    expect(ldRadios[1].click).toHaveBeenCalledTimes(0)
+    expect(ldRadios[2].click).toHaveBeenCalledTimes(2)
+    expect(ldRadios[3].click).toHaveBeenCalledTimes(0)
+    expect(ldRadios[4].click).toHaveBeenCalledTimes(1)
 
     expect(radios[0].focus).toHaveBeenCalledTimes(1)
     expect(radios[1].focus).toHaveBeenCalledTimes(0)


### PR DESCRIPTION
# Description

The web component now behaves just like the native input radio element when using arrow keys.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
