### PR TITLE
fix(css-reset): make css reset work in safari

### DIFF
--- a/src/docs/global/styles/reset.css
+++ b/src/docs/global/styles/reset.css
@@ -1,11 +1,12 @@
-/*! minireset.css v0.0.6 | MIT License | github.com/jgthms/minireset.css */
+* {
+  &:where(:not(.docs-example__show *):not(.ld-tether-element *)) {
+    box-sizing: border-box;
+  }
+}
 html,
 body {
   margin: 0;
   padding: 0;
-}
-html {
-  box-sizing: border-box;
 }
 
 p,
@@ -55,13 +56,6 @@ input,
 select {
   &:where(:not(.docs-example__show *):not(.ld-tether-element *)) {
     margin: 0;
-  }
-}
-*,
-*::before,
-*::after {
-  &:where(:not(.docs-example__show *):not(.ld-tether-element *)) {
-    box-sizing: inherit;
   }
 }
 img,


### PR DESCRIPTION
# Description

Fixes css reset for Safari.
Safari doesn't accept `inherit` as a value for `box-sizing` for some reason.
Also it doesn't like a wildcard selector in combination with pseudo classes for whatever reason.
Removing the latter doesn't seem to have any negative impact on the looks of the documentation page.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
