### PR TITLE
refactor(ld-input-message): use new color vars

### DIFF
--- a/src/liquid/components/ld-input-message/ld-input-message.css
+++ b/src/liquid/components/ld-input-message/ld-input-message.css
@@ -1,5 +1,8 @@
 :host,
 .ld-input-message {
+  --ld-input-message-valid-text-col: var(--ld-thm-success);
+  --ld-input-message-error-text-col: var(--ld-thm-error);
+
   display: inline-flex;
   align-items: flex-start;
   font: var(--ld-typo-body-s);
@@ -8,12 +11,12 @@
 
 :host(.ld-input-message--valid),
 .ld-input-message--valid {
-  color: var(--ld-col-rg-default);
+  color: var(--ld-input-message-valid-text-col);
 }
 
 :host(.ld-input-message--error),
 .ld-input-message--error {
-  color: var(--ld-col-rr-default);
+  color: var(--ld-input-message-error-text-col);
 }
 
 .ld-input-message__icon {


### PR DESCRIPTION
This looks good, as soon as the updated success theme color vars from #71 are merged.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes