### PR TITLE
Fix/radio and checkbox

### DIFF
--- a/src/liquid/components/ld-checkbox/ld-checkbox.tsx
+++ b/src/liquid/components/ld-checkbox/ld-checkbox.tsx
@@ -93,7 +93,6 @@ export class LdCheckbox implements InnerFocusable {
     }
 
     this.checked = !this.checked
-    this.el.dispatchEvent(new Event('input', { bubbles: true, composed: true }))
   }
 
   componentWillLoad() {

--- a/src/liquid/components/ld-checkbox/test/ld-checkbox.e2e.ts
+++ b/src/liquid/components/ld-checkbox/test/ld-checkbox.e2e.ts
@@ -242,4 +242,35 @@ describe('ld-checkbox', () => {
       expect(checked).toBe(false)
     })
   })
+
+  it('emits input event', async () => {
+    const page = await getPageWithContent(
+      `
+      <form id="example-form" novalidate>
+        <ld-checkbox id="example-form-terms" name="terms" required checked></ld-checkbox>
+      </form>
+      <script>
+        const form = document.querySelector('#example-form')
+        const ldCheckbox = document.querySelector('#example-form-terms')
+        function validateInput() {
+          if (!form.terms.checked) {
+            ldCheckbox.setAttribute('invalid', 'true')
+            return false
+          }
+          ldCheckbox.removeAttribute('invalid')
+          return true
+        }
+        ldCheckbox.addEventListener('input', ev => {
+          validateInput()
+        })
+      </script>`
+    )
+    const ldCheckbox = await page.find('ld-checkbox')
+    expect(ldCheckbox).not.toHaveAttribute('invalid')
+
+    ldCheckbox.click()
+    await page.waitForChanges()
+
+    expect(ldCheckbox).toHaveAttribute('invalid')
+  })
 })

--- a/src/liquid/components/ld-checkbox/test/ld-checkbox.spec.ts
+++ b/src/liquid/components/ld-checkbox/test/ld-checkbox.spec.ts
@@ -90,20 +90,6 @@ describe('ld-checkbox', () => {
     expect(spyBlur).toHaveBeenCalled()
   })
 
-  it('emits input event on click', async () => {
-    const page = await newSpecPage({
-      components: [LdCheckbox],
-      html: `<ld-checkbox></ld-checkbox>`,
-    })
-    const ldCheckbox = page.root
-
-    const spyInput = jest.fn()
-    ldCheckbox.addEventListener('input', spyInput)
-    ldCheckbox.click()
-
-    expect(spyInput).toHaveBeenCalled()
-  })
-
   it('allows to set inner focus', async () => {
     const page = await newSpecPage({
       components: [LdCheckbox],

--- a/src/liquid/components/ld-radio/ld-radio.tsx
+++ b/src/liquid/components/ld-radio/ld-radio.tsx
@@ -120,7 +120,6 @@ export class LdRadio implements InnerFocusable {
     }
 
     this.checked = true
-    this.el.dispatchEvent(new Event('input', { bubbles: true, composed: true }))
   }
 
   private focusAndSelect(dir: 'next' | 'prev') {
@@ -128,7 +127,7 @@ export class LdRadio implements InnerFocusable {
       (ldRadio) => ldRadio.getAttribute('name') === this.name
     )
     ldRadios.forEach((ldRadio, index) => {
-      if (ldRadio === ((this.el as unknown) as HTMLLdRadioElement)) {
+      if (ldRadio === (this.el as unknown as HTMLLdRadioElement)) {
         const targetLdRadio = ldRadios[index + (dir === 'next' ? 1 : -1)]
         if (targetLdRadio) {
           targetLdRadio.focusInner()

--- a/src/liquid/components/ld-radio/test/ld-radio.e2e.ts
+++ b/src/liquid/components/ld-radio/test/ld-radio.e2e.ts
@@ -227,4 +227,38 @@ describe('ld-radio', () => {
       expect(checked).toBe(false)
     })
   })
+
+  it('emits input event', async () => {
+    const page = await getPageWithContent(
+      `
+      <form id="example-form" novalidate>
+        <ld-radio value="orange" name="fruit" required invalid></ld-radio>
+        <ld-radio value="banana" name="fruit" required invalid></ld-radio>
+      </form>
+      <script>
+        const orangeRadio = document.querySelector('#example-form ld-radio:first-of-type')
+        const bananaRadio = document.querySelector('#example-form ld-radio:last-of-type')
+        function validateInput() {
+          value = orangeRadio.checked || bananaRadio.checked
+          if (!value) {
+            orangeRadio.setAttribute('invalid', 'true')
+            bananaRadio.setAttribute('invalid', 'true')
+            return false
+          }
+          orangeRadio.removeAttribute('invalid')
+          bananaRadio.removeAttribute('invalid')
+          return true
+        }
+        orangeRadio.addEventListener('input', validateInput)
+        bananaRadio.addEventListener('input', validateInput)
+      </script>`
+    )
+    const ldRadioOrange = await page.find('ld-radio[value="orange"]')
+    expect(ldRadioOrange).toHaveAttribute('invalid')
+
+    ldRadioOrange.click()
+    await page.waitForChanges()
+
+    expect(ldRadioOrange).not.toHaveAttribute('invalid')
+  })
 })

--- a/src/liquid/components/ld-radio/test/ld-radio.spec.ts
+++ b/src/liquid/components/ld-radio/test/ld-radio.spec.ts
@@ -90,20 +90,6 @@ describe('ld-radio', () => {
     expect(spyBlur).toHaveBeenCalled()
   })
 
-  it('emits input event on click', async () => {
-    const page = await newSpecPage({
-      components: [LdRadio],
-      html: `<ld-radio />`,
-    })
-    const ldRadio = page.root
-
-    const spyInput = jest.fn()
-    ldRadio.addEventListener('input', spyInput)
-    ldRadio.click()
-
-    expect(spyInput).toHaveBeenCalled()
-  })
-
   it('allows to set inner focus', async () => {
     const page = await newSpecPage({
       components: [LdRadio],


### PR DESCRIPTION
# Description

This PR fixes an issue where clicking on a checkbox or radio button triggers two input events, one from the input element inside the shadow DOM and the other custom (not trusted) one from the host element itself.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I replaced the unit test that was testing the custom event dispatch with an e2e test which is testing the native event dispatch.

- [x] e2e test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
