### PR TITLE
Fix/radio checkbox select

### DIFF
--- a/src/liquid/components/ld-checkbox/ld-checkbox.tsx
+++ b/src/liquid/components/ld-checkbox/ld-checkbox.tsx
@@ -93,6 +93,14 @@ export class LdCheckbox implements InnerFocusable {
     }
 
     this.checked = !this.checked
+
+    if (!ev.isTrusted) {
+      // This happens, when a click event is dispatched on the host element
+      // from the outside i.e. on click on a parent ld-label element.
+      this.el.dispatchEvent(
+        new Event('input', { bubbles: true, composed: true })
+      )
+    }
   }
 
   componentWillLoad() {

--- a/src/liquid/components/ld-checkbox/test/ld-checkbox.spec.ts
+++ b/src/liquid/components/ld-checkbox/test/ld-checkbox.spec.ts
@@ -90,6 +90,20 @@ describe('ld-checkbox', () => {
     expect(spyBlur).toHaveBeenCalled()
   })
 
+  it('emits input event on click', async () => {
+    const page = await newSpecPage({
+      components: [LdCheckbox],
+      html: `<ld-checkbox></ld-checkbox>`,
+    })
+    const ldCheckbox = page.root
+
+    const spyInput = jest.fn()
+    ldCheckbox.addEventListener('input', spyInput)
+    ldCheckbox.click()
+
+    expect(spyInput).toHaveBeenCalled()
+  })
+
   it('allows to set inner focus', async () => {
     const page = await newSpecPage({
       components: [LdCheckbox],

--- a/src/liquid/components/ld-radio/ld-radio.tsx
+++ b/src/liquid/components/ld-radio/ld-radio.tsx
@@ -120,6 +120,14 @@ export class LdRadio implements InnerFocusable {
     }
 
     this.checked = true
+
+    if (!ev.isTrusted) {
+      // This happens, when a click event is dispatched on the host element
+      // from the outside i.e. on click on a parent ld-label element.
+      this.el.dispatchEvent(
+        new Event('input', { bubbles: true, composed: true })
+      )
+    }
   }
 
   private focusAndSelect(dir: 'next' | 'prev') {

--- a/src/liquid/components/ld-radio/test/ld-radio.spec.ts
+++ b/src/liquid/components/ld-radio/test/ld-radio.spec.ts
@@ -90,6 +90,20 @@ describe('ld-radio', () => {
     expect(spyBlur).toHaveBeenCalled()
   })
 
+  it('emits input event on click', async () => {
+    const page = await newSpecPage({
+      components: [LdRadio],
+      html: `<ld-radio />`,
+    })
+    const ldRadio = page.root
+
+    const spyInput = jest.fn()
+    ldRadio.addEventListener('input', spyInput)
+    ldRadio.click()
+
+    expect(spyInput).toHaveBeenCalled()
+  })
+
   it('allows to set inner focus', async () => {
     const page = await newSpecPage({
       components: [LdRadio],

--- a/src/liquid/components/ld-select/ld-select.tsx
+++ b/src/liquid/components/ld-select/ld-select.tsx
@@ -10,6 +10,7 @@ import {
   State,
   Watch,
   EventEmitter,
+  Method,
 } from '@stencil/core'
 import Tether from 'tether'
 import { LdSelectPopper } from './ld-select-popper/ld-select-popper'
@@ -28,7 +29,7 @@ type SelectOption = { value: string; text: string }
   styleUrl: 'ld-select.css',
   shadow: true,
 })
-export class LdSelect {
+export class LdSelect implements InnerFocusable {
   @Element() el: HTMLElement
 
   private selectRef!: HTMLElement
@@ -128,9 +129,9 @@ export class LdSelect {
   handleTypeAhead(newQuery?: string) {
     if (!newQuery) return
 
-    const options = (Array.from(
+    const options = Array.from(
       this.listboxRef.querySelectorAll('ld-option-internal')
-    ) as unknown) as LdOptionInternal[]
+    ) as unknown as LdOptionInternal[]
     const values = options.map((option) => option.value)
     let index = values.findIndex(
       (value) => value.toLowerCase().indexOf(newQuery.toLowerCase()) === 0
@@ -180,6 +181,14 @@ export class LdSelect {
    */
   @Event({ bubbles: true, cancelable: false, composed: true })
   focusout: EventEmitter<string[]>
+
+  /** Sets focus on the trigger button. */
+  @Method()
+  async focusInner() {
+    if (!this.disabled) {
+      this.triggerRef.focus()
+    }
+  }
 
   private isOverflowing() {
     return (
@@ -282,7 +291,7 @@ export class LdSelect {
   }
 
   private updatePopperShadowHeight() {
-    const ldPopper = (this.listboxRef as unknown) as LdSelectPopper
+    const ldPopper = this.listboxRef as unknown as LdSelectPopper
     ldPopper.updateShadowHeight(
       `calc(100% + ${this.triggerRef.getBoundingClientRect().height}px)`
     )
@@ -338,9 +347,8 @@ export class LdSelect {
     if (!initialized) {
       children = this.el.querySelectorAll('ld-option')
     } else {
-      children = this.internalOptionsContainerRef.querySelectorAll(
-        'ld-option-internal'
-      )
+      children =
+        this.internalOptionsContainerRef.querySelectorAll('ld-option-internal')
     }
 
     if (!children.length) {
@@ -351,7 +359,7 @@ export class LdSelect {
 
     const selectedChildren = Array.from<HTMLElement>(children).filter(
       (child) => {
-        return ((child as unknown) as LdOptionInternal).selected
+        return (child as unknown as LdOptionInternal).selected
       }
     )
 
@@ -466,7 +474,7 @@ export class LdSelect {
   private clearSelection() {
     Array.from(this.listboxRef.querySelectorAll('ld-option-internal')).forEach(
       (option) => {
-        ;((option as unknown) as LdOptionInternal).selected = false
+        ;(option as unknown as LdOptionInternal).selected = false
       }
     )
     this.selected = []
@@ -490,14 +498,14 @@ export class LdSelect {
 
     if (!this.multiple) {
       // Deselect currently selected option, if it's not the target option.
-      ;((Array.from(
-        this.listboxRef.querySelectorAll('ld-option-internal')
-      ) as unknown) as HTMLOptionElement[]).forEach((option) => {
+      ;(
+        Array.from(
+          this.listboxRef.querySelectorAll('ld-option-internal')
+        ) as unknown as HTMLOptionElement[]
+      ).forEach((option) => {
         if (
           option !==
-          ((target.closest(
-            'ld-option-internal'
-          ) as unknown) as HTMLOptionElement)
+          (target.closest('ld-option-internal') as unknown as HTMLOptionElement)
         ) {
           option.selected = false
         }
@@ -539,12 +547,12 @@ export class LdSelect {
   private handleEnd(ev) {
     // Move focus to the last option.
     ev.preventDefault()
-    const options = (Array.from(
+    const options = Array.from(
       this.listboxRef.querySelectorAll('ld-option-internal')
-    ) as unknown) as LdOptionInternal[]
+    ) as unknown as LdOptionInternal[]
     if (
       document.activeElement !==
-      ((options[options.length - 1] as unknown) as HTMLElement)
+      (options[options.length - 1] as unknown as HTMLElement)
     ) {
       options[options.length - 1].focusOption()
     }
@@ -563,7 +571,7 @@ export class LdSelect {
         )
       }
       ldOption.focusOption()
-      const ldOptionHTMLEl = (ldOption as unknown) as HTMLElement
+      const ldOptionHTMLEl = ldOption as unknown as HTMLElement
       if (!ldOptionHTMLEl.hasAttribute('selected')) {
         ldOptionHTMLEl.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }))
       }
@@ -670,8 +678,8 @@ export class LdSelect {
         ) {
           this.selectAndFocus(
             ev,
-            (document.activeElement
-              .previousElementSibling as unknown) as LdOptionInternal
+            document.activeElement
+              .previousElementSibling as unknown as LdOptionInternal
           )
           return
         }

--- a/src/liquid/components/ld-select/readme.md
+++ b/src/liquid/components/ld-select/readme.md
@@ -1254,6 +1254,19 @@ The `ld-select` Web Component provides a low level API for integrating it with t
 | `input`    | Emitted with an array of selected values when an alteration to the selection is committed by the user. | `CustomEvent<string[]>` |
 
 
+## Methods
+
+### `focusInner() => Promise<void>`
+
+Sets focus on the trigger button.
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+
 ## Slots
 
 | Slot     | Description                                    |

--- a/src/liquid/components/ld-select/test/ld-select.spec.ts
+++ b/src/liquid/components/ld-select/test/ld-select.spec.ts
@@ -25,7 +25,7 @@ global.MutationObserver = TriggerableMutationObserver as MutationObserver
 
 class FocusManager {
   focus(el) {
-    const doc = (document as unknown) as { activeElement: Element }
+    const doc = document as unknown as { activeElement: Element }
     doc.activeElement = el
   }
 }
@@ -58,8 +58,8 @@ async function getInternalOptions(page: SpecPage) {
 
 function getShadow(page: SpecPage) {
   const ldSelect = page.root
-  const doc = (document as unknown) as { activeElement: Element }
-  const shadowDoc = (ldSelect.shadowRoot as unknown) as {
+  const doc = document as unknown as { activeElement: Element }
+  const shadowDoc = ldSelect.shadowRoot as unknown as {
     activeElement: Element
   }
   return {
@@ -101,9 +101,8 @@ describe('ld-select', () => {
       '.ld-select-popper'
     )
     const slottedOptions = ldSelect.querySelectorAll('ld-option')
-    const internalOptions = ldSelectPopper.querySelectorAll(
-      'ld-option-internal'
-    )
+    const internalOptions =
+      ldSelectPopper.querySelectorAll('ld-option-internal')
 
     expect(ldSelectEl.classList.contains('ld-select--expanded')).toBeTruthy()
     expect(slottedOptions.length).toEqual(2)
@@ -211,9 +210,8 @@ describe('ld-select', () => {
 
     const ldSelectPopper = await page.body.querySelector('ld-select-popper')
 
-    const internalOptions = ldSelectPopper.querySelectorAll(
-      'ld-option-internal'
-    )
+    const internalOptions =
+      ldSelectPopper.querySelectorAll('ld-option-internal')
 
     expect(internalOptions.length).toEqual(2)
 
@@ -427,7 +425,7 @@ describe('ld-select', () => {
 
     ldInternalOptions[0].focus = jest.fn(focusManager.focus)
     ldInternalOptions[1].focus = jest.fn(focusManager.focus)
-    const doc = (document as unknown) as { activeElement: Element }
+    const doc = document as unknown as { activeElement: Element }
 
     doc.activeElement = internalOptions[1]
     ldInternalOptions[1].dispatchEvent(
@@ -474,9 +472,8 @@ describe('ld-select', () => {
     await triggerPopperWithClick(page)
 
     const ldSelectPopper = await page.body.querySelector('ld-select-popper')
-    const selectPopper = ldSelectPopper.shadowRoot.querySelector(
-      '.ld-select-popper'
-    )
+    const selectPopper =
+      ldSelectPopper.shadowRoot.querySelector('.ld-select-popper')
 
     expect(
       selectPopper.classList.contains('ld-select-popper--detached')
@@ -564,7 +561,7 @@ describe('ld-select', () => {
       `,
     })
 
-    const doc = (document as unknown) as { activeElement: Element }
+    const doc = document as unknown as { activeElement: Element }
     const ldSelect = page.root
     const btnTrigger = ldSelect.shadowRoot.querySelector(
       '.ld-select__btn-trigger'
@@ -590,7 +587,7 @@ describe('ld-select', () => {
       `,
     })
 
-    const doc = (document as unknown) as { activeElement: Element }
+    const doc = document as unknown as { activeElement: Element }
     const ldSelect = await page.root
     const btnTrigger = ldSelect.shadowRoot.querySelector(
       '.ld-select__btn-trigger'
@@ -617,7 +614,7 @@ describe('ld-select', () => {
       `,
     })
 
-    const doc = (document as unknown) as { activeElement: Element }
+    const doc = document as unknown as { activeElement: Element }
     const ldSelect = await page.root
     const btnTrigger = ldSelect.shadowRoot.querySelector(
       '.ld-select__btn-trigger'
@@ -1806,7 +1803,7 @@ describe('ld-select', () => {
   it('displays more indicator with maxRows prop set in multiple mode', async () => {
     jest
       .spyOn(
-        (LdSelect.prototype as unknown) as { isOverflowing },
+        LdSelect.prototype as unknown as { isOverflowing },
         'isOverflowing'
       )
       .mockImplementation(() => true)
@@ -1848,7 +1845,7 @@ describe('ld-select', () => {
 
     jest
       .spyOn(
-        (LdSelect.prototype as unknown) as { isOverflowing },
+        LdSelect.prototype as unknown as { isOverflowing },
         'isOverflowing'
       )
       .mockImplementation(() => false)
@@ -1991,5 +1988,26 @@ describe('ld-select', () => {
     await page.waitForChanges()
 
     expect(page.body).toMatchSnapshot()
+  })
+
+  it('implements focus inner', async () => {
+    const page = await newSpecPage({
+      components,
+      html: `
+        <ld-select placeholder="Pick a fruit" name="fruit" popper-class="ld-select__popper--fruits">
+          <ld-option value="apple">Apple</ld-option>
+          <ld-option value="banana">Banana</ld-option>
+        </ld-select>
+      `,
+    })
+
+    const ldSelect = page.root
+    const btnTrigger = ldSelect.shadowRoot.querySelector(
+      '.ld-select__btn-trigger'
+    )
+    ;(btnTrigger as HTMLElement).focus = jest.fn(focusManager.focus)
+
+    await page.root.focusInner()
+    expect((btnTrigger as HTMLElement).focus).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
# Description

This PR adds a focusInner method to the select component preventing an exception thrown when a label that wraps an ld-select is clicked.
It also changes the click handlers on the ld-radio and ld-checkbox components, such that both emit an input event in case their host element receives a click event from the outside i.e. from a label.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
