### PR TITLE
fix(ld-button): reset margin for safari

### DIFF
--- a/src/liquid/components/ld-button/ld-button.css
+++ b/src/liquid/components/ld-button/ld-button.css
@@ -24,6 +24,7 @@
   --ld-button-gap-lg: 1.1875rem;
   background-color: var(--ld-button-bg-color, var(--ld-thm-primary));
   box-sizing: border-box;
+  margin: 0;
   position: relative;
   font: var(--ld-typo-body-m);
   border: 0;


### PR DESCRIPTION
# Description

In Safari the button has a default margin of a few pixels. This PR includes a reset for the ld-button margin.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Manual test in Safari

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
