### PR TITLE
fix(ld-icon): make sure shadow dom style element is not removed

### DIFF
--- a/src/liquid/components/ld-icon/ld-icon.tsx
+++ b/src/liquid/components/ld-icon/ld-icon.tsx
@@ -32,8 +32,15 @@ export class LdIcon {
     const div = document.createElement('div')
     const iconString = await fetchIcon(this.name)
 
-    div.innerHTML = iconString.replace('<svg', '<svg part="icon"')
-    this.element.shadowRoot.innerHTML = ''
+    div.innerHTML = iconString.replace(
+      '<svg',
+      '<svg class="ld-icon__svg" part="icon"'
+    )
+    Array.from(this.element.shadowRoot.children).forEach((child) => {
+      if (child.tagName !== 'STYLE') {
+        this.element.shadowRoot.removeChild(child)
+      }
+    })
     this.element.shadowRoot.appendChild(div.firstChild)
   }
 

--- a/src/liquid/components/ld-tabs/ld-tab/ld-tab.css
+++ b/src/liquid/components/ld-tabs/ld-tab/ld-tab.css
@@ -49,6 +49,8 @@
   min-height: var(--ld-tab-min-height);
   color: var(--ld-tab-text-col);
   background-color: var(--ld-tab-bg-col);
+  box-sizing: border-box;
+  margin: 0;
 
   &[aria-disabled='true'] {
     color: var(--ld-tab-disabled-text-col);


### PR DESCRIPTION
# Description

This PR resolves a regression which has been introduced with 16605f068c9d7f87a929d0585d4b92df99661a9a
Safari seems to add style tags to the shadow DOM while other browsers (such as Opera and Chrome) do not do this. This fix makes sure no style tags are removed in the shadow DOM.

Fixes #124

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual testing in Safari and Opera.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
