### PR TITLE
fix(ld-input): let textarea inherit max/min sizes

### DIFF
--- a/src/liquid/components/ld-input/ld-input.css
+++ b/src/liquid/components/ld-input/ld-input.css
@@ -160,7 +160,10 @@
 
   > textarea {
     height: 100%;
+    max-height: inherit;
     min-height: inherit;
+    max-width: inherit;
+    min-width: inherit;
   }
 
   ::slotted(ld-button),


### PR DESCRIPTION
# Description

Makes the textarea inherit max/min-width/height values. This is necessary to give the developer the possibility to prevent horizontal and/or vertical resizing of the textarea.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes