### PR TITLE
ci: add bin folder to artifacts

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -56,12 +56,14 @@ jobs:
       #    github-token: ${{ secrets.GITHUB_TOKEN }}
       #    lcov-file: ./coverage/lcov.info
 
-      - name: Archive dist artifacts
+      - name: Archive bin_dist artifacts
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/rc'
         uses: actions/upload-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: bin_dist
+          path: |
+            bin
+            dist
           retention-days: 1
 
       - name: Archive dist_docs artifacts
@@ -122,11 +124,11 @@ jobs:
         env:
           CI: true
 
-      - name: Download dist artifacts
+      - name: Download bin_dist artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: bin_dist
+          path: /
 
       - name: Semantic Release
         if: success()


### PR DESCRIPTION
# Description

(Hopefully) fixes the CI build that does yet exclude the `bin/` folder from the build artifacts.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes