### PR TITLE
fix(clone-attributes): determining attributes from props is unnecessary and causes issues

### DIFF
--- a/src/liquid/components/ld-button/test/__snapshots__/ld-button.spec.ts.snap
+++ b/src/liquid/components/ld-button/test/__snapshots__/ld-button.spec.ts.snap
@@ -79,6 +79,16 @@ exports[`ld-button brand-color (secondary) 1`] = `
 </ld-button>
 `;
 
+exports[`ld-button clones attributes to inner button 1`] = `
+<ld-button aria-label="yolo" hidden="" size="sm">
+  <mock:shadow-root>
+    <button aria-label="yolo" aria-live="polite" class="ld-button ld-button--sm" hidden="" part="button focusable">
+      <slot></slot>
+    </button>
+  </mock:shadow-root>
+</ld-button>
+`;
+
 exports[`ld-button danger 1`] = `
 <ld-button mode="danger">
   <mock:shadow-root>

--- a/src/liquid/components/ld-button/test/ld-button.spec.ts
+++ b/src/liquid/components/ld-button/test/ld-button.spec.ts
@@ -340,4 +340,12 @@ describe('ld-button', () => {
     })
     expect(page.root).toMatchSnapshot()
   })
+
+  it('clones attributes to inner button', async () => {
+    const page = await newSpecPage({
+      components: [LdButton],
+      html: `<ld-button size="sm" aria-label="yolo" hidden></ld-button>`,
+    })
+    expect(page.root).toMatchSnapshot()
+  })
 })

--- a/src/liquid/utils/cloneAttributes.ts
+++ b/src/liquid/utils/cloneAttributes.ts
@@ -8,39 +8,18 @@ export function cloneAttributes(attributesToIgnore: string[] = []) {
     ...attributesToIgnore,
   ])
 
-  // Get attributes from props.
-  const attributesFromProps = {}
-  for (const key in this) {
-    // Component props are getters. Getters don't have a descriptor.
-    // So we can check for component props as follows:
-    if (
-      !Object.getOwnPropertyDescriptor(this, key) &&
-      this[key] !== undefined &&
-      this[key] !== null
-    ) {
-      const attrName = key.replaceAll(/([A-Z])/g, '-$1').toLowerCase()
-
-      if (!attributesToIgnoreSet.has(attrName)) {
-        attributesFromProps[attrName] = this[key]
-      }
-    }
-  }
-
   // Get attributes not in props.
-  const attributesNotInProps = {}
+  const attributesToClone = {}
   for (const attr of this.el.attributes) {
-    if (
-      attr.name in attributesFromProps ||
-      attributesToIgnoreSet.has(attr.name)
-    ) {
+    if (attributesToIgnoreSet.has(attr.name)) {
       continue
     }
-    attributesNotInProps[attr.name] = attr.value
+    const valueToClone = attr.value === '' ? true : attr.value
+    attributesToClone[attr.name] = valueToClone
   }
 
   // Update cloned attributes state.
-  const allAttributes = { ...attributesFromProps, ...attributesNotInProps }
-  this.clonedAttributes = allAttributes
+  this.clonedAttributes = attributesToClone
 
   // Set up attributes observer.
   const callback = (mutationsList) => {


### PR DESCRIPTION
# Description

Seems like the cloneAttributes utility can be simplified in a way that there is no need to determine attributes to clone to a element contained in the shadow dom via props. This fixes the linked issue. 

Fixes #190

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you've added and run to verify your changes. 
Provide instructions, so we can reproduce. 
Please also list any relevant details for your test configuration.

- [x] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
