### PR TITLE
fix: conditionally disconnect attribute observer

### DIFF
--- a/src/liquid/components/ld-button/ld-button.tsx
+++ b/src/liquid/components/ld-button/ld-button.tsx
@@ -116,7 +116,7 @@ export class LdButton implements InnerFocusable, ClonesAttributes {
     this.el.removeEventListener('click', this.handleClick, {
       capture: true,
     })
-    this.attributesObserver.disconnect()
+    this.attributesObserver?.disconnect()
   }
 
   private clickHiddenButton() {

--- a/src/liquid/components/ld-checkbox/ld-checkbox.tsx
+++ b/src/liquid/components/ld-checkbox/ld-checkbox.tsx
@@ -188,7 +188,7 @@ export class LdCheckbox implements InnerFocusable, ClonesAttributes {
   }
 
   disconnectedCallback() {
-    this.attributesObserver.disconnect()
+    this.attributesObserver?.disconnect()
   }
 
   render() {

--- a/src/liquid/components/ld-input/ld-input.tsx
+++ b/src/liquid/components/ld-input/ld-input.tsx
@@ -312,7 +312,7 @@ export class LdInput implements InnerFocusable, ClonesAttributes {
   }
 
   disconnectedCallback() {
-    this.attributesObserver.disconnect()
+    this.attributesObserver?.disconnect()
   }
 
   render() {

--- a/src/liquid/components/ld-label/ld-label.tsx
+++ b/src/liquid/components/ld-label/ld-label.tsx
@@ -56,7 +56,7 @@ export class LdLabel implements ClonesAttributes {
   }
 
   disconnectedCallback() {
-    this.attributesObserver.disconnect()
+    this.attributesObserver?.disconnect()
   }
 
   render() {

--- a/src/liquid/components/ld-radio/ld-radio.tsx
+++ b/src/liquid/components/ld-radio/ld-radio.tsx
@@ -219,7 +219,7 @@ export class LdRadio implements InnerFocusable, ClonesAttributes {
   }
 
   disconnectedCallback() {
-    this.attributesObserver.disconnect()
+    this.attributesObserver?.disconnect()
   }
 
   render() {

--- a/src/liquid/components/ld-toggle/ld-toggle.tsx
+++ b/src/liquid/components/ld-toggle/ld-toggle.tsx
@@ -179,7 +179,7 @@ export class LdToggle implements InnerFocusable, ClonesAttributes {
   }
 
   disconnectedCallback() {
-    this.attributesObserver.disconnect()
+    this.attributesObserver?.disconnect()
   }
 
   render() {

--- a/src/liquid/components/ld-typo/ld-typo.tsx
+++ b/src/liquid/components/ld-typo/ld-typo.tsx
@@ -127,7 +127,7 @@ export class LdTypo implements ClonesAttributes {
   }
 
   disconnectedCallback() {
-    this.attributesObserver.disconnect()
+    this.attributesObserver?.disconnect()
   }
 
   render() {


### PR DESCRIPTION
# Description

`this.attributeObserver` is sometimes undefined at the time that the `disconnectedCallback` is being called. This PR checks, if `this.attributeObserver˚ is defined, before calling its `disconnect` method.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] tested manually

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes