### PR TITLE
feat(ld-menu): add ld-menu component

### DIFF
--- a/src/liquid/components/ld-menu/ld-menu-item/ld-menu-item.css
+++ b/src/liquid/components/ld-menu/ld-menu-item/ld-menu-item.css
@@ -1,0 +1,50 @@
+:host {
+  --ld-menu-item-height: 3.125rem;
+  --ld-menu-item-border-width: 0.1875rem;
+  --ld-menu-item-bg-color-active: var(--ld-thm-primary-active);
+  --ld-menu-item-bg-color-focus: var(--ld-thm-primary-focus);
+  --ld-menu-item-bg-color-hover: var(--ld-thm-primary-hover);
+  --ld-menu-item-selected-border-color: var(--ld-thm-secondary);
+  --ld-menu-item-text-color: var(--ld-col-wht);
+
+  display: contents;
+}
+
+.ld-menu-item {
+  font: var(--ld-typo-body-m);
+  text-decoration: none;
+}
+
+.ld-menu-item--tab {
+  align-items: center;
+  box-sizing: border-box;
+  color: var(--ld-menu-item-text-color);
+  display: flex;
+  height: var(--ld-menu-item-height);
+  padding: 0 var(--ld-sp-16);
+  border: solid transparent;
+  border-width: var(--ld-menu-item-border-width) 0;
+
+  &:focus:focus-visible {
+    background-color: var(--ld-menu-item-bg-color-focus);
+  }
+
+  @media (hover: hover) {
+    &:hover {
+      background-color: var(--ld-menu-item-bg-color-hover);
+    }
+  }
+
+  &:active {
+    background-color: var(--ld-menu-item-bg-color-active);
+  }
+
+  &.ld-menu-item--selected {
+    border-bottom-color: var(--ld-menu-item-selected-border-color);
+  }
+}
+
+/* TODO: remove when sub-menus are supported */
+::slotted(ld-menu) {
+  display: none;
+}

--- a/src/liquid/components/ld-menu/ld-menu-item/ld-menu-item.tsx
+++ b/src/liquid/components/ld-menu/ld-menu-item/ld-menu-item.tsx
@@ -1,0 +1,53 @@
+import { Component, h, Prop, Element } from '@stencil/core'
+// import { cloneAttributes } from 'src/liquid/utils/cloneAttributes'
+import { getClassNames } from 'src/liquid/utils/getClassNames'
+
+/**
+ * @internal
+ * @virtualProp ref - reference to component
+ * @virtualProp {string | number} key - for tracking the node's identity when working with lists
+ * @part list - `ul` element wrapping the menu items slot
+ */
+@Component({
+  assetsDirs: ['assets'],
+  tag: 'ld-menu-item',
+  styleUrl: 'ld-menu-item.css',
+  shadow: true,
+})
+export class LdMenuItem {
+  @Element() el: HTMLElement
+
+  /** URL that the menu item points to. */
+  @Prop() href?: string
+
+  /** URL that the menu item points to. */
+  @Prop() linkTitle?: string
+
+  /** Orientation of the menu items. */
+  @Prop() mode: 'tab' | 'list' = 'list'
+
+  /** Is this the currently selected menu item? */
+  @Prop() selected?: boolean
+
+  render() {
+    const cl = getClassNames([
+      'ld-menu-item',
+      `ld-menu-item--${this.mode}`,
+      this.selected && 'ld-menu-item--selected',
+    ])
+
+    return (
+      <li>
+        <a
+          class={cl}
+          part="link"
+          title={this.linkTitle}
+          href={this.href}
+          // {...cloneAttributes.call(this, ['link-title'])}
+        >
+          <slot />
+        </a>
+      </li>
+    )
+  }
+}

--- a/src/liquid/components/ld-menu/ld-menu.css
+++ b/src/liquid/components/ld-menu/ld-menu.css
@@ -1,0 +1,13 @@
+:host {
+  --ld-menu-height: 3.125rem;
+}
+
+.ld-menu__items {
+  display: flex;
+  list-style: none;
+  padding: 0;
+
+  :host(.ld-menu--vertical) & {
+    flex-direction: column;
+  }
+}

--- a/src/liquid/components/ld-menu/ld-menu.tsx
+++ b/src/liquid/components/ld-menu/ld-menu.tsx
@@ -1,0 +1,48 @@
+import { Component, Host, h, Prop, Element, Watch } from '@stencil/core'
+import { getClassNames } from 'src/liquid/utils/getClassNames'
+
+/**
+ * @internal
+ * @virtualProp ref - reference to component
+ * @virtualProp {string | number} key - for tracking the node's identity when working with lists
+ * @part list - `ul` element wrapping the menu items slot
+ */
+@Component({
+  assetsDirs: ['assets'],
+  tag: 'ld-menu',
+  styleUrl: 'ld-menu.css',
+  shadow: true,
+})
+export class LdMenu {
+  @Element() el: HTMLElement
+
+  /** Orientation of the menu items. */
+  @Prop() orientation: 'vertical' | 'horizontal' = 'vertical'
+
+  /** Title of the menu. */
+  @Prop() menuTitle?: string
+
+  @Watch('orientation')
+  componentWillLoad() {
+    if (this.orientation === 'horizontal') {
+      this.el
+        .querySelectorAll<HTMLLdMenuItemElement>(':scope > ld-menu-item')
+        .forEach((ldMenuItem) => {
+          ldMenuItem.mode = 'tab'
+        })
+    }
+  }
+
+  render() {
+    const cl = getClassNames(['ld-menu', `ld-menu--${this.orientation}`])
+
+    return (
+      <Host class={cl} role="navigation">
+        {this.menuTitle && <p class="ld-menu__title">{this.menuTitle}</p>}
+        <ul class="ld-menu__items" part="list">
+          <slot />
+        </ul>
+      </Host>
+    )
+  }
+}


### PR DESCRIPTION
# Description

Adds a menu component for use inside the `ld-header` component, as well as for example for context menus.

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [ ] tested manually
- [ ] other:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes