### PR TITLE
docs(docs-main): show component dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "watch:styles:components": "chokidar src/liquid/components/**/*.css -c 'yarn build:styles:docs:components'"
   },
   "dependencies": {
-    "@stencil/core": "^2.12.0",
+    "@stencil/core": "^2.12.1",
     "tether": "^2.0.0"
   },
   "license": "SEE LICENSE IN LICENSE.md",
@@ -117,6 +117,7 @@
     "lint-staged": "^10.5.4",
     "live-server": "^1.2.1",
     "markdown-it-anchor": "^7.1.0",
+    "markdown-it-replace-link": "^1.1.0",
     "mutation-observer": "^1.0.3",
     "node-fetch": "^2.6.2",
     "npm-run-all": "^4.1.5",

--- a/src/docs/components/docs-main/docs-main.css
+++ b/src/docs/components/docs-main/docs-main.css
@@ -8,18 +8,19 @@
       > p,
       > ol,
       > ul,
-      > #css-variables + table,
-      > #properties + table,
-      > #events + table,
-      > #slots + table {
+      > [id^='css-variables'] + table,
+      > [id^='properties'] + table,
+      > [id^='events'] + table,
+      > [id^='slots'] + table,
+      > [id^='methods'] ~ h3 {
         code {
           box-shadow: inset 0 0 0 var(--ld-sp-1) var(--ld-col-neutral-100);
           background-color: var(--ld-col-neutral-010);
         }
       }
 
-      #css-variables + table td,
-      #properties + table td {
+      [id^='css-variables'] + table td,
+      [id^='properties'] + table td {
         &:first-of-type,
         &:nth-of-type(2),
         &:nth-of-type(4) {
@@ -78,17 +79,18 @@
       > p,
       > ol,
       > ul,
-      > #css-variables + table,
-      > #properties + table,
-      > #events + table,
-      > #slots + table {
+      > [id^='css-variables'] + table,
+      > [id^='properties'] + table,
+      > [id^='events'] + table,
+      > [id^='slots'] + table,
+      > [id^='methods'] ~ h3 {
         code {
           box-shadow: inset 0 0 0 var(--ld-sp-1) var(--ld-col-neutral-400);
           background-color: var(--ld-col-neutral-600);
         }
       }
 
-      #properties + table td {
+      [id^='properties'] + table td {
         &:first-of-type,
         &:nth-of-type(2),
         &:nth-of-type(4) {
@@ -102,7 +104,7 @@
         }
       }
 
-      #css-variables + table td {
+      [id^='css-variables'] + table td {
         &:first-of-type,
         &:nth-of-type(3) {
           code {
@@ -213,8 +215,12 @@
       border: 0;
       height: var(--ld-sp-1);
 
-      &:last-of-type + p {
+      &:last-of-type {
         display: none;
+
+        & + p {
+          display: none;
+        }
       }
     }
 
@@ -232,16 +238,18 @@
       margin-top: var(--ld-sp-40);
     }
 
-    #shadow-parts,
-    #shadow-parts + table,
-    #dependencies,
-    #depends-on,
-    #depends-on + ul,
-    #used-by,
-    #used-by + ul,
-    #graph,
+    /*
     .mermaid,
-    .mermaid + hr {
+    .mermaid + hr,
+    [id^='dependencies'],
+    [id^='used-by'],
+    [id^='used-by'] + ul,
+    [id^='depends-on'],
+    [id^='depends-on'] + ul*/
+    [id^='graph'],
+    [id^='graph'] + pre,
+    [id^='shadow-parts'],
+    [id^='shadow-parts'] + table {
       display: none;
     }
 
@@ -353,7 +361,7 @@
       }
     }
 
-    > #properties + table {
+    > [id^='properties'] + table {
       --table-min-width: 72rem;
 
       td,
@@ -411,7 +419,7 @@
       }
     }
 
-    > #css-variables + table {
+    > [id^='css-variables'] + table {
       --table-min-width: 62rem;
 
       td,
@@ -456,7 +464,7 @@
       }
     }
 
-    > #events + table {
+    > [id^='events'] + table {
       --table-min-width: 64rem;
 
       td,
@@ -480,9 +488,10 @@
       }
     }
 
-    > #methods {
+    > [id^='methods'] {
       ~ h3 code {
         font: var(--ld-typo-body-s);
+        line-height: 1;
         font-weight: 400;
         font-family: 'Source Code Pro', Consolas, Monaco, 'Ubuntu Mono',
           monospace;
@@ -492,7 +501,7 @@
       }
     }
 
-    > #slots + table {
+    > [id^='slots'] + table {
       --table-min-width: 50rem;
 
       td,
@@ -506,10 +515,10 @@
       }
     }
 
-    > #css-variables + table,
-    > #properties + table,
-    > #events + table,
-    > #slots + table {
+    > [id^='css-variables'] + table,
+    > [id^='properties'] + table,
+    > [id^='events'] + table,
+    > [id^='slots'] + table {
       font: var(--ld-typo-body-m);
 
       thead,
@@ -525,7 +534,7 @@
       }
     }
 
-    > #components ~ #status ~ table {
+    > [id^='components'] ~ [id^='status'] ~ table {
       td,
       th {
         width: var(--table-cell-width-sm);
@@ -567,17 +576,31 @@
   }
 }
 
-#properties + table::after {
+[id^='properties'] + table::after {
   content: '* required';
 }
 
-#slots,
-#events,
-#properties,
-#shadow-parts {
+[id^='slots'],
+[id^='events'],
+[id^='properties'],
+[id^='shadow-parts'] {
   + table + hr {
     display: none;
   }
+}
+
+.language-mermaid {
+  & + hr {
+    display: none;
+  }
+
+  code > :nth-last-child(-n + 3) {
+    display: none;
+  }
+}
+
+[id^='returns'] + p + hr {
+  display: none;
 }
 
 .header-anchor {

--- a/src/docs/components/docs-main/docs-main.css
+++ b/src/docs/components/docs-main/docs-main.css
@@ -238,14 +238,6 @@
       margin-top: var(--ld-sp-40);
     }
 
-    /*
-    .mermaid,
-    .mermaid + hr,
-    [id^='dependencies'],
-    [id^='used-by'],
-    [id^='used-by'] + ul,
-    [id^='depends-on'],
-    [id^='depends-on'] + ul*/
     [id^='graph'],
     [id^='graph'] + pre,
     [id^='shadow-parts'],

--- a/src/docs/components/docs-topbar/docs-topbar.css
+++ b/src/docs/components/docs-topbar/docs-topbar.css
@@ -51,7 +51,6 @@
 }
 
 .docs-topbar__headline-link {
-  flex-grow: 1;
   text-decoration: none;
 }
 

--- a/src/docs/layouts/docs-layout/docs-layout.css
+++ b/src/docs/layouts/docs-layout/docs-layout.css
@@ -34,6 +34,8 @@ body {
   font-family: var(--ld-font-body);
   display: flex;
   min-height: 100vh;
+  position: relative;
+  z-index: 0;
 
   &.hydrated {
     visibility: visible !important;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1207,10 +1207,10 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@stencil/core@^2.12.0":
-  version "2.12.0"
-  resolved "https://registry.yarnpkg.com/@stencil/core/-/core-2.12.0.tgz#5b12517dd367908026692d3b00fa1aab39638ab9"
-  integrity sha512-hQlQKh5CUJe8g3L5avLLsfgVu95HMS2LToTtS7gpvvP0eKes1VvAC56uhI+vH4u44GZl9ck/g1rJBVRmMWu0LA==
+"@stencil/core@^2.12.1":
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/@stencil/core/-/core-2.12.1.tgz#92364d3e57337b8d36dd9b70cfbed2833929f22d"
+  integrity sha512-u24TZ+FEvjnZt5ZgIkLjLpUNsO6Ml3mUZqwmqk81w6RWWz75hgB5p4RFI5rvuErFeh2xvMIGo+pNdG24XUBz1A==
 
 "@stencil/eslint-plugin@^0.3.1":
   version "0.3.1"
@@ -7259,6 +7259,11 @@ markdown-it-anchor@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/markdown-it-anchor/-/markdown-it-anchor-7.1.0.tgz#30fb21497bf59e83ff4d1ddc052d821962e2489e"
   integrity sha512-loQggrwsIkkP7TOrESvmYkV2ikbQNNKhHcWyqC7/C2CmfHl1tkUizJJU8C5aGgg7J6oXVQJx17gk7i47tNn/lQ==
+
+markdown-it-replace-link@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/markdown-it-replace-link/-/markdown-it-replace-link-1.1.0.tgz#cab2343eb27928db1c836e10cd518aaf60a0bd50"
+  integrity sha512-P+4D/Z16utgQVjMumA5W3lMbxWYk4iwg1Fk59wShFm7MRgzbjJm++tvI18LdYwiG8CKNA1TFWvHcbtehvMuViA==
 
 markdown-it@^12.3.2:
   version "12.3.2"


### PR DESCRIPTION
# Description

This PR adds dependency information to the component documentation. For that to work it includes am 11ty config tweak which transforms relative links to absolute ones. Also this PR fixes minor layout issues in the docs.

## Type of change

- [x] Documentation improvement

# How Has This Been Tested?

- [x] tested manually; ⚠️ I haven't tested the effects of the change in an environment with a different base path than `/` (on GitHub pages), but am confident it will work. However, please review carefully! ⚠️

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
