### PR TITLE
fix(ld-button): remove Safari button styles when type prop is used

### DIFF
--- a/src/liquid/components/ld-button/ld-button.css
+++ b/src/liquid/components/ld-button/ld-button.css
@@ -1,4 +1,5 @@
 :host {
+  appearance: none !important; /* Safari browser reset */
   display: inline-flex;
 
   > :where(.ld-button) {


### PR DESCRIPTION
# Description

This fix prevents Safari from applying button styles to the `ld-button` host element, when a `type` prop is set.

Fixes #249

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] tested manually

# Checklist:

- [x] My code follows the style guidelines of this project
- [] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes