### PR TITLE
fix(ld-input): cannot focus year on safari

### DIFF
--- a/src/liquid/components/ld-input/ld-input.tsx
+++ b/src/liquid/components/ld-input/ld-input.tsx
@@ -309,7 +309,9 @@ export class LdInput implements InnerFocusable, ClonesAttributes {
 
     if (target.closest('ld-button')) return
 
-    this.input.focus()
+    if (this.el.shadowRoot.activeElement !== this.input) {
+      this.input.focus()
+    }
 
     if (target === this.el) {
       this.input.dispatchEvent(new MouseEvent('click', { bubbles: false }))

--- a/src/liquid/components/ld-input/test/ld-input.spec.ts
+++ b/src/liquid/components/ld-input/test/ld-input.spec.ts
@@ -187,6 +187,25 @@ describe('ld-input', () => {
     expect(input.focus).toHaveBeenCalledTimes(2)
   })
 
+  it('does not focus the input on click of non-interactive elment inside the component if already focused', async () => {
+    const page = await newSpecPage({
+      components: [LdInput],
+      html: `<ld-input><span slot="end"><span id="banana">🍌</span></span></ld-input>`,
+    })
+    const ldInput = page.root
+    const banana = ldInput.querySelector('#banana') as HTMLElement
+    const input = ldInput.shadowRoot.querySelector('input')
+
+    const doc = ldInput.shadowRoot as unknown as { activeElement: Element }
+    doc.activeElement = input
+
+    input.focus = jest.fn()
+    banana.dispatchEvent(new Event('click', { bubbles: true }))
+    ldInput.dispatchEvent(new Event('click'))
+
+    expect(input.focus).not.toHaveBeenCalled()
+  })
+
   it('forwards click to input (default)', async () => {
     const { root } = await newSpecPage({
       components: [LdInput],


### PR DESCRIPTION
# Description

This PR fixes issue where the focus is forced to the date component of the date picker when clicking the year component on Safari.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] unit tests
- [x] tested manually

**Test Configuration**:

- browsers: Safari, Opera

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
