### PR TITLE
fix(ld-tooltip): move arrow into shadow dom

### DIFF
--- a/src/liquid/components/ld-tooltip/ld-tooltip-popper/ld-tooltip-popper.css
+++ b/src/liquid/components/ld-tooltip/ld-tooltip-popper/ld-tooltip-popper.css
@@ -56,12 +56,6 @@
       --ld-tooltip-distance-from-trigger: calc(
         var(--ld-tooltip-arrow-size) + var(--ld-sp-8)
       );
-
-      &:before {
-        border: var(--ld-tooltip-arrow-size) solid transparent;
-        content: '';
-        position: absolute;
-      }
     }
   }
 
@@ -80,7 +74,7 @@
 
   &.ld-tether-element-attached-bottom {
     :host(&) {
-      &:before {
+      .ld-tooltip__arrow {
         bottom: var(--ld-tooltip-arrow-offset);
       }
     }
@@ -92,7 +86,7 @@
             var(--ld-tooltip-offset-y)
         );
 
-        &:before {
+        .ld-tooltip__arrow {
           border-top-color: var(--tooltip-bg-col);
           top: 100%;
         }
@@ -101,8 +95,10 @@
   }
 
   &.ld-tether-element-attached-center {
-    :host(&):before {
-      left: calc(50% - var(--ld-tooltip-arrow-size));
+    :host(&) {
+      .ld-tooltip__arrow {
+        left: calc(50% - var(--ld-tooltip-arrow-size));
+      }
     }
   }
 
@@ -112,7 +108,7 @@
         var(--ld-tooltip-offset-x) + var(--ld-tooltip-distance-from-trigger)
       );
 
-      &:before {
+      .ld-tooltip__arrow {
         border-right-color: var(--tooltip-bg-col);
         right: 100%;
       }
@@ -120,14 +116,16 @@
   }
 
   &.ld-tether-element-attached-middle {
-    :host(&):before {
-      top: calc(50% - var(--ld-tooltip-arrow-size));
+    :host(&) {
+      .ld-tooltip__arrow {
+        top: calc(50% - var(--ld-tooltip-arrow-size));
+      }
     }
   }
 
   &.ld-tether-element-attached-right {
     :host(&) {
-      &:before {
+      .ld-tooltip__arrow {
         right: var(--ld-tooltip-arrow-offset);
       }
     }
@@ -139,7 +137,7 @@
             var(--ld-tooltip-offset-x)
         );
 
-        &:before {
+        .ld-tooltip__arrow {
           border-left-color: var(--tooltip-bg-col);
           left: 100%;
         }
@@ -152,8 +150,7 @@
       margin-top: calc(
         var(--ld-tooltip-distance-from-trigger) + var(--ld-tooltip-offset-y)
       );
-
-      &:before {
+      .ld-tooltip__arrow {
         border-bottom-color: var(--tooltip-bg-col);
         bottom: 100%;
       }
@@ -191,4 +188,9 @@
       }
     }
   }
+}
+
+.ld-tooltip__arrow {
+  border: var(--ld-tooltip-arrow-size) solid transparent;
+  position: absolute;
 }

--- a/src/liquid/components/ld-tooltip/ld-tooltip-popper/ld-tooltip-popper.tsx
+++ b/src/liquid/components/ld-tooltip/ld-tooltip-popper/ld-tooltip-popper.tsx
@@ -31,6 +31,7 @@ export class LdTooltipPopper {
         ])}
         role="tooltip"
       >
+        {this.arrow && <span class="ld-tooltip__arrow" />}
         <slot />
       </Host>
     )

--- a/src/liquid/components/ld-tooltip/test/__snapshots__/ld-tooltip.spec.ts.snap
+++ b/src/liquid/components/ld-tooltip/test/__snapshots__/ld-tooltip.spec.ts.snap
@@ -79,6 +79,7 @@ exports[`ld-tooltip renders with arrow 1`] = `
     </button>
     <ld-tooltip-popper aria-hidden="true" class="ld-tooltip ld-tooltip--with-arrow ld-tooltip--with-default-trigger" id="ld-tooltip-3" part="popper" role="tooltip">
       <mock:shadow-root>
+        <span class="ld-tooltip__arrow"></span>
         <slot></slot>
       </mock:shadow-root>
       <slot></slot>


### PR DESCRIPTION
# Description

This PR replaces the pseudo element which was used for the tooltip arrow in lite DOM with a span element used within the shadow DOM. This fixes an issue where reset styles, specifically tailwind preflight styles, override border related styles on pseudo elements, which results in the arrow not showing at all.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] unit tests
- [x] e2e tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
