### PR TITLE
fix(ld-typo): add reset for css component

### DIFF
--- a/src/liquid/components/ld-typo/ld-typo.css
+++ b/src/liquid/components/ld-typo/ld-typo.css
@@ -11,7 +11,7 @@
     color: var(--ld-typo-text-brand-color);
   }
 
-  /* Reset within the shadow DOM. */
+  /* Reset within the shadow DOM */
   .ld-typo {
     color: inherit;
     margin: 0;
@@ -21,6 +21,11 @@
 :host,
 .ld-typo {
   --ld-typo-text-brand-color: var(--ld-thm-primary);
+}
+
+/* Reset for CSS component */
+:where(.ld-typo) {
+  margin: 0;
 }
 
 .ld-typo,


### PR DESCRIPTION
# Description

This PR adds a reset to the ld-typo CSS component, making sure that margins on paragraphs with the `ld-typo` class are reset (with a specificity of zero), so that the CSS component behaves consistently with its WebComponent counterpart.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you've added and run to verify your changes. 
Provide instructions, so we can reproduce. 
Please also list any relevant details for your test configuration.

- [x] tested manually

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
