### PR TITLE
fix(ld-tooltip): remove stopPropagation for mouse events on triggerType hover

### DIFF
--- a/src/liquid/components/ld-tooltip/ld-tooltip.tsx
+++ b/src/liquid/components/ld-tooltip/ld-tooltip.tsx
@@ -206,9 +206,8 @@ export class LdTooltip {
     }
   }
 
-  private handleToggleTrigger = (event: MouseEvent) => {
+  private handleToggleTrigger = () => {
     if (this.triggerType === 'hover' || this.disabled) {
-      event.stopPropagation()
       return
     }
 


### PR DESCRIPTION
# Description

Fix a bug that prevented tooltip triggers from having their own onClick event listeners.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] tested manually

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes