### PR TITLE
docs: Adds Astro Sandbox to docs

### DIFF
--- a/src/docs/pages/introduction/sandbox-applications.md
+++ b/src/docs/pages/introduction/sandbox-applications.md
@@ -17,5 +17,6 @@ In order to help you get started with Liquid we have begun implementing small sa
 - Liquid + **SvelteKit + Typescript + Tailwind CSS** ([repository](https://github.com/emdgroup-liquid/liquid-sandbox-sveltekit-tailwind), [code sandbox](https://codesandbox.io/s/liquid-sandbox-sveltekit-tailwind-g5w7w))
 - Liquid + **React + Typescript + Tailwind CSS** ([repository](https://github.com/emdgroup-liquid/liquid-sandbox-react-tailwind), [code sandbox](https://codesandbox.io/s/liquid-sandbox-react-tailwind-5mmvd))
 - Liquid + **Next + Typescript + Tailwind CSS** ([repository](https://github.com/emdgroup-liquid/liquid-sandbox-next-tailwind), [code sandbox](https://codesandbox.io/s/liquid-sandbox-next-tailwind-q070f))
+- Liquid + **Astro + Svelte + Typescript + Tailwind CSS** ([repository](https://github.com/emdgroup-liquid/liquid-sandbox-astro-svelte-tailwind), [stackblitz](https://stackblitz.com/github/emdgroup-liquid/liquid-sandbox-astro-svelte-tailwind))
 
 <docs-page-nav prev-href="introduction/design-tokens/" next-title="FAQ" next-href="introduction/faq/"></docs-page-nav>


### PR DESCRIPTION
As code sandbox node environments do not fit to Astro Requirements I prepared the sandbox project to use StackBlitz.

# Description

This PR just adds a new sandbox to the docs.

## Type of change

Documentation

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
