### PR TITLE
fix(ld-modal): hide displaced focus outlines

### DIFF
--- a/src/liquid/components/ld-modal/ld-modal.css
+++ b/src/liquid/components/ld-modal/ld-modal.css
@@ -145,6 +145,7 @@ dialog.ld-modal--blurry-backdrop,
   margin: var(--ld-sp-8) calc(var(--ld-sp-8) * -1) var(--ld-sp-8) auto;
   position: relative;
   width: var(--ld-sp-32);
+  overflow: hidden;
 
   &::before,
   &::after {

--- a/src/liquid/components/ld-modal/readme.md
+++ b/src/liquid/components/ld-modal/readme.md
@@ -27,7 +27,7 @@ The [`<dialog>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialo
 
 Here is a minimalistic example of a modal dialog:
 
-{% example %}
+{% example '{ "styles": { "overflow": "visible", "will-change": "initial" } }' %}
 <ld-modal>
   <ld-typo style="text-align: center">
     I'm a modal dialog.
@@ -60,7 +60,7 @@ Here is a minimalistic example of a modal dialog:
 
 You have two additional slots to your disposal for altering the modal header and footer which are both positioned fixed at top and bottom of the dialog element.
 
-{% example %}
+{% example '{ "styles": { "overflow": "visible", "will-change": "initial" } }' %}
 <ld-modal>
   <ld-typo slot="header">Hello</ld-typo>
   <ld-typo style="text-align: center">
@@ -99,7 +99,7 @@ You have two additional slots to your disposal for altering the modal header and
 
 ### Non-cancelable
 
-{% example %}
+{% example '{ "styles": { "overflow": "visible", "will-change": "initial" } }' %}
 <ld-modal cancelable="false">
   <ld-typo slot="header">Hello</ld-typo>
   <ld-typo style="text-align: center">
@@ -131,7 +131,7 @@ You have two additional slots to your disposal for altering the modal header and
 
 ### With blurry backdrop
 
-{% example %}
+{% example '{ "styles": { "overflow": "visible", "will-change": "initial" } }' %}
 <ld-modal blurry-backdrop>
   <ld-typo style="text-align: center">
     I'm a modal dialog.


### PR DESCRIPTION
# Description

This PR makes sure that focus outlines are displayed correctly when the close button of the modal dialog is focused.
It also includes some fixes to the examples in the documentation accounting for weird issues related to combining will-change on the examples container with fixed position of the dialog element.

![MicrosoftTeams-image](https://user-images.githubusercontent.com/527049/179863647-937de418-3887-4d8c-8293-4c7ba983e167.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] tested manually

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
