### PR TITLE
fix(ld-select): filter by option text content instead of option value

### DIFF
--- a/src/liquid/components/ld-select/ld-select.tsx
+++ b/src/liquid/components/ld-select/ld-select.tsx
@@ -633,7 +633,7 @@ export class LdSelect implements InnerFocusable {
     const query = this.getFilterInput().value.trim().toLowerCase()
     options.forEach((ldOption) => {
       ldOption.hidden =
-        Boolean(query) && !ldOption.value.toLowerCase().includes(query)
+        Boolean(query) && !ldOption.textContent.toLowerCase().includes(query)
     })
 
     // Re-position popper after new height has been applied.

--- a/src/liquid/components/ld-select/test/__snapshots__/ld-select.spec.ts.snap
+++ b/src/liquid/components/ld-select/test/__snapshots__/ld-select.spec.ts.snap
@@ -1167,7 +1167,7 @@ exports[`ld-select places the popper inside a given element 1`] = `
       </ld-option>
       <input name="fruit" slot="hidden" type="hidden">
     </ld-select>
-    <div data-tether-id="48" style="top: 0; left: 0; position: absolute;"></div>
+    <div data-tether-id="49" style="top: 0; left: 0; position: absolute;"></div>
     <ld-select-popper class="ld-select__popper--initialized ld-tether-element ld-tether-element-attached-left ld-tether-element-attached-top ld-tether-enabled ld-tether-target-attached-bottom ld-tether-target-attached-left" role="listbox" style="z-index: 2147483646; display: block; top: 0; left: 0; position: absolute; transform: translateX(NaNpx) translateY(NaNpx) translateZ(0); width: 0px;">
       <mock:shadow-root>
         <div class="ld-select-popper ld-select-popper--expanded" part="popper">


### PR DESCRIPTION
# Description

This PR fixes the filtering feature of the ld-select component making sure that it filters using the options' text content instead of the options' value. This allows using misc. values on options without effecting the filtering capability of the component.

Fixes #393

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
