### PR TITLE
docs: improve troubleshooting docs related to popping components

### DIFF
--- a/src/docs/pages/guides/troubleshooting.md
+++ b/src/docs/pages/guides/troubleshooting.md
@@ -14,17 +14,22 @@ Below we collect tips which may help you troubleshoot known issues.
 
 ---
 
-## Popped-out element is rendered outside application root
+## Popped-out element is rendered in wrong container
 
 **Problem**
 
 Some components have a popper element that needs to stay above every other element when popped out. The [ld-select](components/ld-select/) component and the [ld-tooltip](components/ld-tooltip/) component are two examples of such components. By default, this is achieved by rendering the popped-out element as a direct child of the `body` element.
 
-However, especially when using a UI library, such as React or Vue, this default behavior can be problematic, because your application may have been mounted on an element within the `body` element. __This may result in event handlers not being called__, because the event listeners may be attached to the root element of the application and not the `body` element.
+However, in some cases this default behavior can be problematic. For instance:
+- When using the component within the [ld-modal](components/ld-modal/) component, the browser may render the dialog element above the popped-out element.
+- When using a UI library, such as React or Vue, your application may have been mounted on an element within the `body` element. __This may result in event handlers not being called__, because the event listeners may be attached to the root element of the application and not the `body` element.
+- When you want the popped-out element to be rendered within a container with specific dimensions and overflow settings.
 
 **Solution**
 
-All components, which have a popper element, can be configured to pop out within a specific element. Here is an example on how you can do this in a React application:
+All components, which have a popper element, can be configured to pop out within a specific element using the `tetherOptions` property, which expects an object of options, including the `bodyElement` option. Use this option to specify the container, which shall become the parent element for the popped-out element. 
+
+Here is an example on how you can specify the application root element as the `bodyElement` in a React application:
 
 ```jsx
 export default function App() {
@@ -41,7 +46,44 @@ export default function App() {
     </>
   )
 }
+```
 
+This example demonstrates how you can specify the `bodyElement` when using the [ld-modal](components/ld-modal/) component:
+
+```jsx
+export default function App() {
+  const modalRef = useRef(null);
+  const tetherOptions = {
+    bodyElement: modalRef.current
+  };
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <LdModal
+        onLdmodalclosed={() => setOpen(false)}
+        open={open}
+        ref={modalRef}
+      >
+        <LdTypo slot="header">We make a fruit salat!</LdTypo>
+        <LdSelect
+          name="fruit"
+          placeholder="Pick a fruit"
+          tetherOptions={tetherOptions}
+        >
+          <LdOption value="apple">Apple</LdOption>
+          <LdOption value="banana">Banana</LdOption>
+        </LdSelect>
+      </LdModal>
+      <LdButton
+        onClick={() => {
+          setOpen(true);
+        }}
+      >
+        Open Modal
+      </LdButton>
+    </>
+  );
+}
 ```
 
 <docs-page-nav prev-href="guides/sandbox-applications/" next-title="FAQ" next-href="guides/faq/"></docs-page-nav>

--- a/src/liquid/components/ld-select/readme.md
+++ b/src/liquid/components/ld-select/readme.md
@@ -22,7 +22,7 @@ The `ld-select` component represents a control that provides a menu of options. 
 The feature set of the `ld-select` Web Component differs from its CSS Component counterpart. While the first offers more display and input modes, the latter is a lightweight alternative, which only styles the native HTML select element.
 
 <ld-notice headline="Note" mode="warning">
-  If your application is mounted to a different element than the <code>body</code> element, you may need to configure this component to pop out <strong>within your application root element</strong>. For more details check out the <a href="guides/troubleshooting/#popped-out-element-is-rendered-outside-application-root">related troubleshooting section</a>.
+  If your application is mounted to a different element than the <code>body</code> element, or you have <em>z-order</em> related issues, you may need to configure the <code>bodyElement</code> option using the <code>tetherOptions</code> property. For more details check out the <a href="guides/troubleshooting/#popped-out-element-is-rendered-in-wrong-container">related troubleshooting section</a>.
 </ld-notice>
 
 ## Examples

--- a/src/liquid/components/ld-tooltip/readme.md
+++ b/src/liquid/components/ld-tooltip/readme.md
@@ -14,7 +14,7 @@ permalink: components/ld-tooltip/
 Tooltips provide additional information, mostly short paragraphs, and can be placed beside all sorts of interface elements.
 
 <ld-notice headline="Note" mode="warning">
-  If your application is mounted to a different element than the <code>body</code> element, you may need to configure this component to pop out <strong>within your application root element</strong>. For more details check out the <a href="guides/troubleshooting/#popped-out-element-is-rendered-outside-application-root">related troubleshooting section</a>.
+  If your application is mounted to a different element than the <code>body</code> element, or you have <em>z-order</em> related issues, you may need to configure the <code>bodyElement</code> option using the <code>tetherOptions</code> property. For more details check out the <a href="guides/troubleshooting/#popped-out-element-is-rendered-in-wrong-container">related troubleshooting section</a>.
 </ld-notice>
 
 ## Default


### PR DESCRIPTION
# Description

This PR adds more detailed instructions on how to handle *z-order* related issues when dealing with popping components such as the ld-select and the ld-tooltip components.

Resolves #411

## Type of change

- [x] This change is a documentation update

# How Has This Been Tested?

The new example code has been tested manually on codesandbox.io in order to make sure that it works.

- [x] tested manually

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
