### PR TITLE
chore(dx): keep markdown footer the same on build and during development

### DIFF
--- a/src/liquid/components/ld-accordion/ld-accordion-panel/readme.md
+++ b/src/liquid/components/ld-accordion/ld-accordion-panel/readme.md
@@ -55,4 +55,4 @@ graph TD;
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-accordion/ld-accordion-section/readme.md
+++ b/src/liquid/components/ld-accordion/ld-accordion-section/readme.md
@@ -50,4 +50,4 @@ graph TD;
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-accordion/ld-accordion-toggle/readme.md
+++ b/src/liquid/components/ld-accordion/ld-accordion-toggle/readme.md
@@ -86,4 +86,4 @@ graph TD;
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-accordion/readme.md
+++ b/src/liquid/components/ld-accordion/readme.md
@@ -367,4 +367,4 @@ graph TD;
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-badge/readme.md
+++ b/src/liquid/components/ld-badge/readme.md
@@ -172,4 +172,4 @@ graph TD;
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-bg-cells/readme.md
+++ b/src/liquid/components/ld-bg-cells/readme.md
@@ -209,4 +209,4 @@ A background pattern with the Merck cells as additional visual element.
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-breadcrumbs/ld-crumb/readme.md
+++ b/src/liquid/components/ld-breadcrumbs/ld-crumb/readme.md
@@ -47,4 +47,4 @@ graph TD;
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-breadcrumbs/readme.md
+++ b/src/liquid/components/ld-breadcrumbs/readme.md
@@ -106,4 +106,4 @@ This component is meant to be used in conjunction with the [`ld-crumb`](./ld-cru
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-button/readme.md
+++ b/src/liquid/components/ld-button/readme.md
@@ -574,4 +574,4 @@ graph TD;
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-card/readme.md
+++ b/src/liquid/components/ld-card/readme.md
@@ -136,4 +136,4 @@ Use the `shadow-interactive` prop for a transition to a different shadow on hove
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-checkbox/readme.md
+++ b/src/liquid/components/ld-checkbox/readme.md
@@ -637,4 +637,4 @@ graph TD;
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-circular-progress/readme.md
+++ b/src/liquid/components/ld-circular-progress/readme.md
@@ -426,4 +426,4 @@ Use this mode on backgrounds with brand color.
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-header/readme.md
+++ b/src/liquid/components/ld-header/readme.md
@@ -295,4 +295,4 @@ graph TD;
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-icon/readme.md
+++ b/src/liquid/components/ld-icon/readme.md
@@ -363,4 +363,4 @@ graph TD;
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-input-message/readme.md
+++ b/src/liquid/components/ld-input-message/readme.md
@@ -112,4 +112,4 @@ graph TD;
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-input/readme.md
+++ b/src/liquid/components/ld-input/readme.md
@@ -1019,4 +1019,4 @@ Type: `Promise<void>`
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-label/readme.md
+++ b/src/liquid/components/ld-label/readme.md
@@ -399,4 +399,4 @@ HTML content describing the labeled element should be wrapped in a single HTML e
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-link/readme.md
+++ b/src/liquid/components/ld-link/readme.md
@@ -158,4 +158,4 @@ graph TD;
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-loading/readme.md
+++ b/src/liquid/components/ld-loading/readme.md
@@ -92,4 +92,4 @@ Use the `ld-loading` component to indicate that the user should wait for a proce
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-modal/readme.md
+++ b/src/liquid/components/ld-modal/readme.md
@@ -219,4 +219,4 @@ Type: `Promise<void>`
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-notice/readme.md
+++ b/src/liquid/components/ld-notice/readme.md
@@ -149,4 +149,4 @@ graph TD;
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-notification/readme.md
+++ b/src/liquid/components/ld-notification/readme.md
@@ -288,4 +288,4 @@ formClear.addEventListener('submit', ev => {
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-pagination/readme.md
+++ b/src/liquid/components/ld-pagination/readme.md
@@ -202,4 +202,4 @@ graph TD;
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-progress/readme.md
+++ b/src/liquid/components/ld-progress/readme.md
@@ -178,4 +178,4 @@ Use this mode on backgrounds with brand color.
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-radio/readme.md
+++ b/src/liquid/components/ld-radio/readme.md
@@ -345,4 +345,4 @@ Type: `Promise<void>`
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-select/ld-option/readme.md
+++ b/src/liquid/components/ld-select/ld-option/readme.md
@@ -33,4 +33,4 @@ Please refer to the [`ld-select` documentation](components/ld-select) for usage 
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-select/readme.md
+++ b/src/liquid/components/ld-select/readme.md
@@ -1274,4 +1274,4 @@ graph TD;
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-sidenav/ld-sidenav-accordion/readme.md
+++ b/src/liquid/components/ld-sidenav/ld-sidenav-accordion/readme.md
@@ -58,4 +58,4 @@ graph TD;
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-sidenav/ld-sidenav-back/readme.md
+++ b/src/liquid/components/ld-sidenav/ld-sidenav-back/readme.md
@@ -57,4 +57,4 @@ Please refer to the [`ld-sidenav` documentation](components/ld-sidenav/#ld-siden
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-sidenav/ld-sidenav-header/readme.md
+++ b/src/liquid/components/ld-sidenav/ld-sidenav-header/readme.md
@@ -120,4 +120,4 @@ graph TD;
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-sidenav/ld-sidenav-heading/readme.md
+++ b/src/liquid/components/ld-sidenav/ld-sidenav-heading/readme.md
@@ -48,4 +48,4 @@ graph TD;
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-sidenav/ld-sidenav-navitem/readme.md
+++ b/src/liquid/components/ld-sidenav/ld-sidenav-navitem/readme.md
@@ -275,4 +275,4 @@ graph TD;
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-sidenav/ld-sidenav-separator/readme.md
+++ b/src/liquid/components/ld-sidenav/ld-sidenav-separator/readme.md
@@ -48,4 +48,4 @@ graph TD;
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-sidenav/ld-sidenav-slider/readme.md
+++ b/src/liquid/components/ld-sidenav/ld-sidenav-slider/readme.md
@@ -71,4 +71,4 @@ graph TD;
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-sidenav/ld-sidenav-subnav/readme.md
+++ b/src/liquid/components/ld-sidenav/ld-sidenav-subnav/readme.md
@@ -63,4 +63,4 @@ graph TD;
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-sidenav/ld-sidenav-toggle-outside/readme.md
+++ b/src/liquid/components/ld-sidenav/ld-sidenav-toggle-outside/readme.md
@@ -74,4 +74,4 @@ graph TD;
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-sidenav/readme.md
+++ b/src/liquid/components/ld-sidenav/readme.md
@@ -949,4 +949,4 @@ graph TD;
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-slider/readme.md
+++ b/src/liquid/components/ld-slider/readme.md
@@ -315,4 +315,4 @@ graph TD;
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-sr-live/readme.md
+++ b/src/liquid/components/ld-sr-live/readme.md
@@ -107,4 +107,4 @@ graph TD;
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-sr-only/readme.md
+++ b/src/liquid/components/ld-sr-only/readme.md
@@ -66,4 +66,4 @@ graph TD;
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-stepper/ld-step/readme.md
+++ b/src/liquid/components/ld-stepper/ld-step/readme.md
@@ -94,4 +94,4 @@ graph TD;
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-stepper/readme.md
+++ b/src/liquid/components/ld-stepper/readme.md
@@ -782,4 +782,4 @@ graph TD;
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-switch/ld-switch-item/readme.md
+++ b/src/liquid/components/ld-switch/ld-switch-item/readme.md
@@ -54,4 +54,4 @@ Type: `Promise<void>`
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-switch/readme.md
+++ b/src/liquid/components/ld-switch/readme.md
@@ -567,4 +567,4 @@ Type: `Promise<void>`
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-tabs/ld-tab/readme.md
+++ b/src/liquid/components/ld-tabs/ld-tab/readme.md
@@ -74,4 +74,4 @@ Type: `Promise<void>`
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-tabs/ld-tablist/readme.md
+++ b/src/liquid/components/ld-tabs/ld-tablist/readme.md
@@ -47,4 +47,4 @@ Please refer to the [`ld-tabs` documentation](components/ld-tabs) for usage exam
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-tabs/ld-tabpanel/readme.md
+++ b/src/liquid/components/ld-tabs/ld-tabpanel/readme.md
@@ -29,4 +29,4 @@ Please refer to the [`ld-tabs` documentation](components/ld-tabs) for usage exam
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-tabs/ld-tabpanellist/readme.md
+++ b/src/liquid/components/ld-tabs/ld-tabpanellist/readme.md
@@ -29,4 +29,4 @@ Please refer to the [`ld-tabs` documentation](components/ld-tabs) for usage exam
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-tabs/readme.md
+++ b/src/liquid/components/ld-tabs/readme.md
@@ -386,4 +386,4 @@ Type: `Promise<void>`
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-toggle/readme.md
+++ b/src/liquid/components/ld-toggle/readme.md
@@ -500,4 +500,4 @@ Type: `Promise<void>`
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-tooltip/readme.md
+++ b/src/liquid/components/ld-tooltip/readme.md
@@ -310,4 +310,4 @@ graph TD;
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/liquid/components/ld-typo/readme.md
+++ b/src/liquid/components/ld-typo/readme.md
@@ -441,4 +441,4 @@ graph TD;
 
 ----------------------------------------------
 
- 
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -22,7 +22,6 @@ export const config: Config = {
     },
     {
       type: 'docs-readme',
-      footer: ' ',
     },
     {
       type: 'docs-vscode',


### PR DESCRIPTION
# Description

This PR removes the stencil footer configuration from the stencil.config.ts which results in the default footer being generated in all markdown files. This is necessary as in development mode the footer configuration is ignored by stencil, hence all markdown files are changed as soon as the dev script is executed. With the default footer being used nothing changes.

Resolves #416

## Type of change

- [x] Build configuration change

# How Has This Been Tested?

- [x] tested manually

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
