### PR TITLE
fix(ld-tabs): safari layout bug due to different offset calculation

### DIFF
--- a/src/liquid/components/ld-tabs/ld-tablist/ld-tablist.tsx
+++ b/src/liquid/components/ld-tabs/ld-tablist/ld-tablist.tsx
@@ -194,10 +194,11 @@ export class LdTablist {
       return
     }
 
-    const bcr = this.selectedTab.getBoundingClientRect()
-    const offsetLeft = this.selectedTab.offsetLeft
+    const selectedTabBcr = this.selectedTab.getBoundingClientRect()
+    const parentBcr = this.selectedTab.parentElement.getBoundingClientRect()
+    const offsetLeft = selectedTabBcr.left - parentBcr.left
     indicatorStyle.transform = `translateX(${offsetLeft - 8}px)`
-    indicatorStyle.width = `${bcr.width}px`
+    indicatorStyle.width = `${selectedTabBcr.width}px`
     indicatorStyle.opacity = '1'
   }
 


### PR DESCRIPTION
# Description

Safari seems to be calculating offset differently than "normal browsers". This PR includes a change which makes sure the offset is calculated correctly in all browsers based on the bounding client rect left property of the selected tab and its parent element.

Fixes #424

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] tested manually

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
