### PR TITLE
fix: event target closest is this element check

### DIFF
--- a/src/liquid/components/ld-accordion/ld-accordion-section/ld-accordion-section.tsx
+++ b/src/liquid/components/ld-accordion/ld-accordion-section/ld-accordion-section.tsx
@@ -10,6 +10,7 @@ import {
   Watch,
 } from '@stencil/core'
 import { getClassNames } from '../../../utils/getClassNames'
+import { closest } from '../../../utils/closest'
 
 /**
  * @virtualProp ref - reference to component
@@ -47,7 +48,10 @@ export class LdAccordionSection {
   }
 
   private handleToggleClick(ev) {
-    if (ev.target.closest('ld-accordion-section') !== this.el) {
+    // closest utility function must be used here for the component
+    // to work in Solid.js app, where ev.target can be an element
+    // within the shadow DOM of the component.
+    if (closest('ld-accordion-section', ev.target) !== this.el) {
       return
     }
     this.expanded = !this.expanded

--- a/src/liquid/components/ld-select/ld-select.tsx
+++ b/src/liquid/components/ld-select/ld-select.tsx
@@ -829,9 +829,12 @@ export class LdSelect implements InnerFocusable {
     target: 'window',
   })
   handleClickOutside(ev) {
+    // closest utility function must be used here for the component
+    // to work in Solid.js app, where ev.target can be an element
+    // within the shadow DOM of the component.
     if (
-      ev.target.closest('ld-select') !== this.el &&
-      ev.target.closest('[role="listbox"]') !== this.listboxRef
+      closest('ld-select', ev.target) !== this.el &&
+      closest('[role="listbox"]', ev.target) !== this.listboxRef
     ) {
       this.expanded = false
       this.resetFilter()


### PR DESCRIPTION
# Description

I noticed that the `ld-select` component doesn't expand on click in a Solid.js app. Turns out that in the Solid.js app the event target is the actual element clicked within the shadow DOM of the `ld-select` component, while in other apps (React, Vue, Svelte etc.) the event target is always the component host element itself. I don't know why the event target is a different one in a Solid.js app. The fix is simple enough however: I replaced all (2) occurrences of `ev.target.closest` with our `closest` util function which penetrates shadow DOM boundaries.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] tested manually

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
