### PR TITLE
fix(ld-sidenav): dispatch collapsed change event on collapsible change

### DIFF
--- a/src/liquid/components/ld-sidenav/ld-sidenav.tsx
+++ b/src/liquid/components/ld-sidenav/ld-sidenav.tsx
@@ -166,6 +166,7 @@ export class LdSidenav {
   updateFullyCollapsible() {
     this.fullyCollapsible =
       this.collapsible && (!this.narrow || !this.activeSubnavContainsIcons())
+    if (!this.collapsible) this.collapsed = false
   }
 
   @Listen('click', {

--- a/src/liquid/components/ld-sidenav/test/ld-sidenav.spec.ts
+++ b/src/liquid/components/ld-sidenav/test/ld-sidenav.spec.ts
@@ -1908,4 +1908,24 @@ describe('ld-sidenav', () => {
       )
     }
   })
+
+  it('dispatches collapsed change event on collapsible change', async () => {
+    const page = await newSpecPage({
+      components: sidenavComponents,
+      html: '<ld-sidenav collapsible collapsed />',
+    })
+    const handler = jest.fn()
+    window.addEventListener('ldSidenavCollapsedChange', handler)
+
+    const ldSidenav = page.body.querySelector('ld-sidenav')
+
+    expect(ldSidenav).toHaveClass('ld-sidenav--collapsible')
+    expect(handler).not.toHaveBeenCalled()
+
+    ldSidenav.removeAttribute('collapsible')
+    await page.waitForChanges()
+
+    expect(ldSidenav).not.toHaveClass('ld-sidenav--collapsible')
+    expect(handler).toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
# Description

This PR fixes an issues where sub-components are not aware of dynamic changes to the `ld-sidenav`'s `collapsible` prop / state by changing the collapsed prop to false as soon as the component is not callapsible anymore, which in turn is picked up by a watcher which dispatches the `ldSidenavCollapsedChange` event.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
