### PR TITLE
fix(ld-sidenav): update toggle in sidenav header on collapsible change

### DIFF
--- a/src/liquid/components/ld-sidenav/ld-sidenav-header/ld-sidenav-header.tsx
+++ b/src/liquid/components/ld-sidenav/ld-sidenav-header/ld-sidenav-header.tsx
@@ -6,6 +6,7 @@ import {
   h,
   Host,
   Listen,
+  Method,
   Prop,
   State,
 } from '@stencil/core'
@@ -42,6 +43,7 @@ export class LdSidenavHeader {
   @State() sidenavClosable: boolean
   @State() sidenavCollapsed: boolean
   @State() sidenavCollapsedFully: boolean
+  @State() sidenavCollapsible: boolean
   @State() sidenavOpen: boolean
 
   /** Emitted on toggle click. */
@@ -77,9 +79,21 @@ export class LdSidenavHeader {
     this.ldSidenavHeaderToggleClick.emit()
   }
 
+  /**
+   * @internal
+   * Updates collapsible state.
+   */
+  @Method()
+  async updateCollapsible() {
+    this.sidenavCollapsible = this.sidenav.collapsible
+  }
+
   componentWillLoad() {
     this.sidenav = this.el.closest('ld-sidenav')
-    if (this.sidenav) this.sidenavAlignement = this.sidenav.align
+    if (this.sidenav) {
+      this.sidenavAlignement = this.sidenav.align
+      this.sidenavCollapsible = this.sidenav.collapsible
+    }
   }
 
   render() {
@@ -98,7 +112,7 @@ export class LdSidenavHeader {
     return (
       <Host class={cl}>
         {/*Inner toggle*/}
-        {this.sidenav.collapsible && (
+        {this.sidenavCollapsible && (
           <ld-tooltip
             arrow
             size="sm"

--- a/src/liquid/components/ld-sidenav/ld-sidenav-toggle-outside/ld-sidenav-toggle-outside.tsx
+++ b/src/liquid/components/ld-sidenav/ld-sidenav-toggle-outside/ld-sidenav-toggle-outside.tsx
@@ -34,7 +34,6 @@ export class LdSidenavToggleOutside implements InnerFocusable {
   @State() sidenavClosable: boolean
   @State() sidenavCollapsed: boolean
   @State() sidenavCollapsedFully: boolean
-  @State() sidenavCollapsible: boolean
   @State() sidenavAlignement: 'left' | 'right' = 'left'
 
   /** Sets focus on the radio button. */

--- a/src/liquid/components/ld-sidenav/ld-sidenav.tsx
+++ b/src/liquid/components/ld-sidenav/ld-sidenav.tsx
@@ -167,6 +167,7 @@ export class LdSidenav {
     this.fullyCollapsible =
       this.collapsible && (!this.narrow || !this.activeSubnavContainsIcons())
     if (!this.collapsible) this.collapsed = false
+    this.el.querySelector('ld-sidenav-header')?.updateCollapsible()
   }
 
   @Listen('click', {

--- a/src/liquid/components/ld-sidenav/test/__snapshots__/ld-sidenav.spec.ts.snap
+++ b/src/liquid/components/ld-sidenav/test/__snapshots__/ld-sidenav.spec.ts.snap
@@ -134,7 +134,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
     <mock:shadow-root>
       <ld-tooltip show-delay="1000">
         <mock:shadow-root>
-          <span aria-describedby="ld-tooltip-517" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+          <span aria-describedby="ld-tooltip-519" class="ld-tooltip__trigger" part="trigger focusable" type="button">
             <ld-sr-only>
               Info
             </ld-sr-only>
@@ -145,7 +145,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
               </svg>
             </slot>
           </span>
-          <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-517" part="popper" size="sm" triggertype="hover">
+          <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-519" part="popper" size="sm" triggertype="hover">
             <slot></slot>
           </ld-tooltip-popper>
         </mock:shadow-root>
@@ -198,7 +198,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
       <mock:shadow-root>
         <ld-tooltip class="ld-sidenav-header__tooltip" show-delay="1000">
           <mock:shadow-root>
-            <span aria-describedby="ld-tooltip-518" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+            <span aria-describedby="ld-tooltip-520" class="ld-tooltip__trigger" part="trigger focusable" type="button">
               <ld-sr-only>
                 Info
               </ld-sr-only>
@@ -209,7 +209,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                 </svg>
               </slot>
             </span>
-            <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-518" part="popper" size="sm" triggertype="hover">
+            <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-520" part="popper" size="sm" triggertype="hover">
               <slot></slot>
             </ld-tooltip-popper>
           </mock:shadow-root>
@@ -275,7 +275,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
               </span>
               <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                 <mock:shadow-root>
-                  <span aria-describedby="ld-tooltip-520" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                  <span aria-describedby="ld-tooltip-522" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                     <ld-sr-only>
                       Info
                     </ld-sr-only>
@@ -286,7 +286,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                       </svg>
                     </slot>
                   </span>
-                  <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-520" part="popper" size="sm" triggertype="hover">
+                  <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-522" part="popper" size="sm" triggertype="hover">
                     <slot></slot>
                   </ld-tooltip-popper>
                 </mock:shadow-root>
@@ -354,7 +354,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
               </span>
               <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                 <mock:shadow-root>
-                  <span aria-describedby="ld-tooltip-521" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                  <span aria-describedby="ld-tooltip-523" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                     <ld-sr-only>
                       Info
                     </ld-sr-only>
@@ -365,7 +365,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                       </svg>
                     </slot>
                   </span>
-                  <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-521" part="popper" size="sm" triggertype="hover">
+                  <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-523" part="popper" size="sm" triggertype="hover">
                     <slot></slot>
                   </ld-tooltip-popper>
                 </mock:shadow-root>
@@ -404,7 +404,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
               </span>
               <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                 <mock:shadow-root>
-                  <span aria-describedby="ld-tooltip-522" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                  <span aria-describedby="ld-tooltip-524" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                     <ld-sr-only>
                       Info
                     </ld-sr-only>
@@ -415,7 +415,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                       </svg>
                     </slot>
                   </span>
-                  <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-522" part="popper" size="sm" triggertype="hover">
+                  <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-524" part="popper" size="sm" triggertype="hover">
                     <slot></slot>
                   </ld-tooltip-popper>
                 </mock:shadow-root>
@@ -454,103 +454,6 @@ exports[`ld-sidenav collapses to narrow 1`] = `
               </span>
               <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                 <mock:shadow-root>
-                  <span aria-describedby="ld-tooltip-523" class="ld-tooltip__trigger" part="trigger focusable" type="button">
-                    <ld-sr-only>
-                      Info
-                    </ld-sr-only>
-                    <slot name="trigger">
-                      <svg class="ld-tooltip__icon" fill="none" part="icon" viewBox="0 0 24 24">
-                        <path clip-rule="evenodd" d="M12 23C18.0751 23 23 18.0751 23 12C23 5.9249 18.0751 1 12 1C5.9249 1 1 5.9249 1 12C1 18.0751 5.9249 23 12 23Z" fill="currentColor" fill-rule="evenodd"></path>
-                        <path clip-rule="evenodd" d="M11.9996 8.6477C12.9254 8.6477 13.6758 7.8973 13.6758 6.9715C13.6758 6.0458 12.9254 5.2953 11.9996 5.2953C11.0739 5.2953 10.3235 6.0458 10.3235 6.9715C10.3235 7.8973 11.0739 8.6477 11.9996 8.6477ZM10.8453 17.8038C11.1932 18.1517 11.6736 18.3256 12.2865 18.3256H13.4545C13.6864 18.3256 13.8023 18.2263 13.8023 18.0275V12.2873C13.8023 11.6744 13.6284 11.1939 13.2805 10.8461C12.9326 10.4982 12.4522 10.3242 11.8393 10.3242H10.6713C10.4394 10.3242 10.3235 10.4236 10.3235 10.6224V16.3626C10.3235 16.9755 10.4974 17.456 10.8453 17.8038Z" fill="var(--ld-col-wht)" fill-rule="evenodd"></path>
-                      </svg>
-                    </slot>
-                  </span>
-                  <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-523" part="popper" size="sm" triggertype="hover">
-                    <slot></slot>
-                  </ld-tooltip-popper>
-                </mock:shadow-root>
-                <div class="ld-sidenav-navitem__tooltip-trigger" slot="trigger"></div>
-                <div style="display: grid; grid-auto-flow: column; align-items: center;">
-                  <ld-typo>
-                    Artificial intelligence
-                  </ld-typo>
-                  <ld-icon name="real-arrow" style="color: var(--ld-thm-primary); display: inline-flex; margin-left: var(--ld-sp-6);"></ld-icon>
-                </div>
-              </ld-tooltip>
-            </div>
-            <div class="ld-sidenav-navitem__slot-container" part="slot-container">
-              <slot></slot>
-            </div>
-            <div class="ld-sidenav-navitem__slot-icon-secondary-container">
-              <ld-icon class="ld-sidenav-navitem__icon-to" name="real-arrow"></ld-icon>
-            </div>
-          </button>
-        </mock:shadow-root>
-        Artificial intelligence
-      </ld-sidenav-navitem>
-      <ld-sidenav-navitem to="communication-and-security" style="--ld-slider-navitem-move-up: -NaNpx;">
-        <mock:shadow-root>
-          <button aria-haspopup="true" class="ld-sidenav-navitem ld-sidenav-navitem--collapsed" part="navitem focusable">
-            <div class="ld-sidenav-navitem__bg" part="bg">
-              <div class="ld-sidenav-navitem__bg-left"></div>
-              <div class="ld-sidenav-navitem__bg-center"></div>
-              <div class="ld-sidenav-navitem__bg-right"></div>
-            </div>
-            <div class="ld-sidenav-navitem__dot" part="dot"></div>
-            <div class="ld-sidenav-navitem__slot-container-icon" part="slot-container-icon" role="presentation">
-              <slot name="icon"></slot>
-              <span class="ld-sidenav-navitem__abbr" part="abbreviation">
-                CA
-              </span>
-              <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
-                <mock:shadow-root>
-                  <span aria-describedby="ld-tooltip-524" class="ld-tooltip__trigger" part="trigger focusable" type="button">
-                    <ld-sr-only>
-                      Info
-                    </ld-sr-only>
-                    <slot name="trigger">
-                      <svg class="ld-tooltip__icon" fill="none" part="icon" viewBox="0 0 24 24">
-                        <path clip-rule="evenodd" d="M12 23C18.0751 23 23 18.0751 23 12C23 5.9249 18.0751 1 12 1C5.9249 1 1 5.9249 1 12C1 18.0751 5.9249 23 12 23Z" fill="currentColor" fill-rule="evenodd"></path>
-                        <path clip-rule="evenodd" d="M11.9996 8.6477C12.9254 8.6477 13.6758 7.8973 13.6758 6.9715C13.6758 6.0458 12.9254 5.2953 11.9996 5.2953C11.0739 5.2953 10.3235 6.0458 10.3235 6.9715C10.3235 7.8973 11.0739 8.6477 11.9996 8.6477ZM10.8453 17.8038C11.1932 18.1517 11.6736 18.3256 12.2865 18.3256H13.4545C13.6864 18.3256 13.8023 18.2263 13.8023 18.0275V12.2873C13.8023 11.6744 13.6284 11.1939 13.2805 10.8461C12.9326 10.4982 12.4522 10.3242 11.8393 10.3242H10.6713C10.4394 10.3242 10.3235 10.4236 10.3235 10.6224V16.3626C10.3235 16.9755 10.4974 17.456 10.8453 17.8038Z" fill="var(--ld-col-wht)" fill-rule="evenodd"></path>
-                      </svg>
-                    </slot>
-                  </span>
-                  <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-524" part="popper" size="sm" triggertype="hover">
-                    <slot></slot>
-                  </ld-tooltip-popper>
-                </mock:shadow-root>
-                <div class="ld-sidenav-navitem__tooltip-trigger" slot="trigger"></div>
-                <div style="display: grid; grid-auto-flow: column; align-items: center;">
-                  <ld-typo>
-                    Communication and security
-                  </ld-typo>
-                  <ld-icon name="real-arrow" style="color: var(--ld-thm-primary); display: inline-flex; margin-left: var(--ld-sp-6);"></ld-icon>
-                </div>
-              </ld-tooltip>
-            </div>
-            <div class="ld-sidenav-navitem__slot-container" part="slot-container">
-              <slot></slot>
-            </div>
-            <div class="ld-sidenav-navitem__slot-icon-secondary-container">
-              <ld-icon class="ld-sidenav-navitem__icon-to" name="real-arrow"></ld-icon>
-            </div>
-          </button>
-        </mock:shadow-root>
-        Communication and security
-      </ld-sidenav-navitem>
-      <ld-sidenav-navitem selected="" to="artificial-intelligence" style="--ld-slider-navitem-move-up: -NaNpx;">
-        <mock:shadow-root>
-          <button aria-haspopup="true" class="ld-sidenav-navitem ld-sidenav-navitem--collapsed ld-sidenav-navitem--selected" part="navitem focusable">
-            <div class="ld-sidenav-navitem__bg" part="bg">
-              <div class="ld-sidenav-navitem__bg-left"></div>
-              <div class="ld-sidenav-navitem__bg-center"></div>
-              <div class="ld-sidenav-navitem__bg-right"></div>
-            </div>
-            <div class="ld-sidenav-navitem__dot" part="dot"></div>
-            <div class="ld-sidenav-navitem__slot-container-icon" part="slot-container-icon" role="presentation">
-              <slot name="icon"></slot>
-              <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
-                <mock:shadow-root>
                   <span aria-describedby="ld-tooltip-525" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                     <ld-sr-only>
                       Info
@@ -583,9 +486,6 @@ exports[`ld-sidenav collapses to narrow 1`] = `
             </div>
           </button>
         </mock:shadow-root>
-        <svg slot="icon" viewBox="0 0 40 40">
-          <circle cx="20" cy="20" fill="var(--ld-col-vm)" r="10"></circle>
-        </svg>
         Artificial intelligence
       </ld-sidenav-navitem>
       <ld-sidenav-navitem to="communication-and-security" style="--ld-slider-navitem-move-up: -NaNpx;">
@@ -638,6 +538,106 @@ exports[`ld-sidenav collapses to narrow 1`] = `
         </mock:shadow-root>
         Communication and security
       </ld-sidenav-navitem>
+      <ld-sidenav-navitem selected="" to="artificial-intelligence" style="--ld-slider-navitem-move-up: -NaNpx;">
+        <mock:shadow-root>
+          <button aria-haspopup="true" class="ld-sidenav-navitem ld-sidenav-navitem--collapsed ld-sidenav-navitem--selected" part="navitem focusable">
+            <div class="ld-sidenav-navitem__bg" part="bg">
+              <div class="ld-sidenav-navitem__bg-left"></div>
+              <div class="ld-sidenav-navitem__bg-center"></div>
+              <div class="ld-sidenav-navitem__bg-right"></div>
+            </div>
+            <div class="ld-sidenav-navitem__dot" part="dot"></div>
+            <div class="ld-sidenav-navitem__slot-container-icon" part="slot-container-icon" role="presentation">
+              <slot name="icon"></slot>
+              <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
+                <mock:shadow-root>
+                  <span aria-describedby="ld-tooltip-527" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                    <ld-sr-only>
+                      Info
+                    </ld-sr-only>
+                    <slot name="trigger">
+                      <svg class="ld-tooltip__icon" fill="none" part="icon" viewBox="0 0 24 24">
+                        <path clip-rule="evenodd" d="M12 23C18.0751 23 23 18.0751 23 12C23 5.9249 18.0751 1 12 1C5.9249 1 1 5.9249 1 12C1 18.0751 5.9249 23 12 23Z" fill="currentColor" fill-rule="evenodd"></path>
+                        <path clip-rule="evenodd" d="M11.9996 8.6477C12.9254 8.6477 13.6758 7.8973 13.6758 6.9715C13.6758 6.0458 12.9254 5.2953 11.9996 5.2953C11.0739 5.2953 10.3235 6.0458 10.3235 6.9715C10.3235 7.8973 11.0739 8.6477 11.9996 8.6477ZM10.8453 17.8038C11.1932 18.1517 11.6736 18.3256 12.2865 18.3256H13.4545C13.6864 18.3256 13.8023 18.2263 13.8023 18.0275V12.2873C13.8023 11.6744 13.6284 11.1939 13.2805 10.8461C12.9326 10.4982 12.4522 10.3242 11.8393 10.3242H10.6713C10.4394 10.3242 10.3235 10.4236 10.3235 10.6224V16.3626C10.3235 16.9755 10.4974 17.456 10.8453 17.8038Z" fill="var(--ld-col-wht)" fill-rule="evenodd"></path>
+                      </svg>
+                    </slot>
+                  </span>
+                  <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-527" part="popper" size="sm" triggertype="hover">
+                    <slot></slot>
+                  </ld-tooltip-popper>
+                </mock:shadow-root>
+                <div class="ld-sidenav-navitem__tooltip-trigger" slot="trigger"></div>
+                <div style="display: grid; grid-auto-flow: column; align-items: center;">
+                  <ld-typo>
+                    Artificial intelligence
+                  </ld-typo>
+                  <ld-icon name="real-arrow" style="color: var(--ld-thm-primary); display: inline-flex; margin-left: var(--ld-sp-6);"></ld-icon>
+                </div>
+              </ld-tooltip>
+            </div>
+            <div class="ld-sidenav-navitem__slot-container" part="slot-container">
+              <slot></slot>
+            </div>
+            <div class="ld-sidenav-navitem__slot-icon-secondary-container">
+              <ld-icon class="ld-sidenav-navitem__icon-to" name="real-arrow"></ld-icon>
+            </div>
+          </button>
+        </mock:shadow-root>
+        <svg slot="icon" viewBox="0 0 40 40">
+          <circle cx="20" cy="20" fill="var(--ld-col-vm)" r="10"></circle>
+        </svg>
+        Artificial intelligence
+      </ld-sidenav-navitem>
+      <ld-sidenav-navitem to="communication-and-security" style="--ld-slider-navitem-move-up: -NaNpx;">
+        <mock:shadow-root>
+          <button aria-haspopup="true" class="ld-sidenav-navitem ld-sidenav-navitem--collapsed" part="navitem focusable">
+            <div class="ld-sidenav-navitem__bg" part="bg">
+              <div class="ld-sidenav-navitem__bg-left"></div>
+              <div class="ld-sidenav-navitem__bg-center"></div>
+              <div class="ld-sidenav-navitem__bg-right"></div>
+            </div>
+            <div class="ld-sidenav-navitem__dot" part="dot"></div>
+            <div class="ld-sidenav-navitem__slot-container-icon" part="slot-container-icon" role="presentation">
+              <slot name="icon"></slot>
+              <span class="ld-sidenav-navitem__abbr" part="abbreviation">
+                CA
+              </span>
+              <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
+                <mock:shadow-root>
+                  <span aria-describedby="ld-tooltip-528" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                    <ld-sr-only>
+                      Info
+                    </ld-sr-only>
+                    <slot name="trigger">
+                      <svg class="ld-tooltip__icon" fill="none" part="icon" viewBox="0 0 24 24">
+                        <path clip-rule="evenodd" d="M12 23C18.0751 23 23 18.0751 23 12C23 5.9249 18.0751 1 12 1C5.9249 1 1 5.9249 1 12C1 18.0751 5.9249 23 12 23Z" fill="currentColor" fill-rule="evenodd"></path>
+                        <path clip-rule="evenodd" d="M11.9996 8.6477C12.9254 8.6477 13.6758 7.8973 13.6758 6.9715C13.6758 6.0458 12.9254 5.2953 11.9996 5.2953C11.0739 5.2953 10.3235 6.0458 10.3235 6.9715C10.3235 7.8973 11.0739 8.6477 11.9996 8.6477ZM10.8453 17.8038C11.1932 18.1517 11.6736 18.3256 12.2865 18.3256H13.4545C13.6864 18.3256 13.8023 18.2263 13.8023 18.0275V12.2873C13.8023 11.6744 13.6284 11.1939 13.2805 10.8461C12.9326 10.4982 12.4522 10.3242 11.8393 10.3242H10.6713C10.4394 10.3242 10.3235 10.4236 10.3235 10.6224V16.3626C10.3235 16.9755 10.4974 17.456 10.8453 17.8038Z" fill="var(--ld-col-wht)" fill-rule="evenodd"></path>
+                      </svg>
+                    </slot>
+                  </span>
+                  <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-528" part="popper" size="sm" triggertype="hover">
+                    <slot></slot>
+                  </ld-tooltip-popper>
+                </mock:shadow-root>
+                <div class="ld-sidenav-navitem__tooltip-trigger" slot="trigger"></div>
+                <div style="display: grid; grid-auto-flow: column; align-items: center;">
+                  <ld-typo>
+                    Communication and security
+                  </ld-typo>
+                  <ld-icon name="real-arrow" style="color: var(--ld-thm-primary); display: inline-flex; margin-left: var(--ld-sp-6);"></ld-icon>
+                </div>
+              </ld-tooltip>
+            </div>
+            <div class="ld-sidenav-navitem__slot-container" part="slot-container">
+              <slot></slot>
+            </div>
+            <div class="ld-sidenav-navitem__slot-icon-secondary-container">
+              <ld-icon class="ld-sidenav-navitem__icon-to" name="real-arrow"></ld-icon>
+            </div>
+          </button>
+        </mock:shadow-root>
+        Communication and security
+      </ld-sidenav-navitem>
       <ld-sidenav-navitem to="computer-architecture" style="--ld-slider-navitem-move-up: -NaNpx;">
         <mock:shadow-root>
           <button aria-haspopup="true" class="ld-sidenav-navitem ld-sidenav-navitem--collapsed" part="navitem focusable">
@@ -654,7 +654,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
               </span>
               <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                 <mock:shadow-root>
-                  <span aria-describedby="ld-tooltip-527" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                  <span aria-describedby="ld-tooltip-529" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                     <ld-sr-only>
                       Info
                     </ld-sr-only>
@@ -665,7 +665,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                       </svg>
                     </slot>
                   </span>
-                  <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-527" part="popper" size="sm" triggertype="hover">
+                  <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-529" part="popper" size="sm" triggertype="hover">
                     <slot></slot>
                   </ld-tooltip-popper>
                 </mock:shadow-root>
@@ -704,7 +704,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
               </span>
               <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                 <mock:shadow-root>
-                  <span aria-describedby="ld-tooltip-528" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                  <span aria-describedby="ld-tooltip-530" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                     <ld-sr-only>
                       Info
                     </ld-sr-only>
@@ -715,7 +715,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                       </svg>
                     </slot>
                   </span>
-                  <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-528" part="popper" size="sm" triggertype="hover">
+                  <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-530" part="popper" size="sm" triggertype="hover">
                     <slot></slot>
                   </ld-tooltip-popper>
                 </mock:shadow-root>
@@ -754,7 +754,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
               </span>
               <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                 <mock:shadow-root>
-                  <span aria-describedby="ld-tooltip-529" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                  <span aria-describedby="ld-tooltip-531" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                     <ld-sr-only>
                       Info
                     </ld-sr-only>
@@ -765,7 +765,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                       </svg>
                     </slot>
                   </span>
-                  <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-529" part="popper" size="sm" triggertype="hover">
+                  <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-531" part="popper" size="sm" triggertype="hover">
                     <slot></slot>
                   </ld-tooltip-popper>
                 </mock:shadow-root>
@@ -804,7 +804,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
               </span>
               <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                 <mock:shadow-root>
-                  <span aria-describedby="ld-tooltip-530" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                  <span aria-describedby="ld-tooltip-532" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                     <ld-sr-only>
                       Info
                     </ld-sr-only>
@@ -815,7 +815,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                       </svg>
                     </slot>
                   </span>
-                  <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-530" part="popper" size="sm" triggertype="hover">
+                  <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-532" part="popper" size="sm" triggertype="hover">
                     <slot></slot>
                   </ld-tooltip-popper>
                 </mock:shadow-root>
@@ -859,7 +859,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
               </span>
               <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                 <mock:shadow-root>
-                  <span aria-describedby="ld-tooltip-531" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                  <span aria-describedby="ld-tooltip-533" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                     <ld-sr-only>
                       Info
                     </ld-sr-only>
@@ -870,7 +870,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                       </svg>
                     </slot>
                   </span>
-                  <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-531" part="popper" size="sm" triggertype="hover">
+                  <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-533" part="popper" size="sm" triggertype="hover">
                     <slot></slot>
                   </ld-tooltip-popper>
                 </mock:shadow-root>
@@ -909,7 +909,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
               </span>
               <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                 <mock:shadow-root>
-                  <span aria-describedby="ld-tooltip-532" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                  <span aria-describedby="ld-tooltip-534" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                     <ld-sr-only>
                       Info
                     </ld-sr-only>
@@ -920,7 +920,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                       </svg>
                     </slot>
                   </span>
-                  <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-532" part="popper" size="sm" triggertype="hover">
+                  <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-534" part="popper" size="sm" triggertype="hover">
                     <slot></slot>
                   </ld-tooltip-popper>
                 </mock:shadow-root>
@@ -959,7 +959,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
               </span>
               <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                 <mock:shadow-root>
-                  <span aria-describedby="ld-tooltip-533" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                  <span aria-describedby="ld-tooltip-535" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                     <ld-sr-only>
                       Info
                     </ld-sr-only>
@@ -970,7 +970,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                       </svg>
                     </slot>
                   </span>
-                  <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-533" part="popper" size="sm" triggertype="hover">
+                  <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-535" part="popper" size="sm" triggertype="hover">
                     <slot></slot>
                   </ld-tooltip-popper>
                 </mock:shadow-root>
@@ -1009,7 +1009,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
               </span>
               <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                 <mock:shadow-root>
-                  <span aria-describedby="ld-tooltip-534" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                  <span aria-describedby="ld-tooltip-536" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                     <ld-sr-only>
                       Info
                     </ld-sr-only>
@@ -1020,7 +1020,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                       </svg>
                     </slot>
                   </span>
-                  <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-534" part="popper" size="sm" triggertype="hover">
+                  <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-536" part="popper" size="sm" triggertype="hover">
                     <slot></slot>
                   </ld-tooltip-popper>
                 </mock:shadow-root>
@@ -1086,94 +1086,6 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                 <slot name="icon"></slot>
                 <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                   <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-535" class="ld-tooltip__trigger" part="trigger focusable" type="button">
-                      <ld-sr-only>
-                        Info
-                      </ld-sr-only>
-                      <slot name="trigger">
-                        <svg class="ld-tooltip__icon" fill="none" part="icon" viewBox="0 0 24 24">
-                          <path clip-rule="evenodd" d="M12 23C18.0751 23 23 18.0751 23 12C23 5.9249 18.0751 1 12 1C5.9249 1 1 5.9249 1 12C1 18.0751 5.9249 23 12 23Z" fill="currentColor" fill-rule="evenodd"></path>
-                          <path clip-rule="evenodd" d="M11.9996 8.6477C12.9254 8.6477 13.6758 7.8973 13.6758 6.9715C13.6758 6.0458 12.9254 5.2953 11.9996 5.2953C11.0739 5.2953 10.3235 6.0458 10.3235 6.9715C10.3235 7.8973 11.0739 8.6477 11.9996 8.6477ZM10.8453 17.8038C11.1932 18.1517 11.6736 18.3256 12.2865 18.3256H13.4545C13.6864 18.3256 13.8023 18.2263 13.8023 18.0275V12.2873C13.8023 11.6744 13.6284 11.1939 13.2805 10.8461C12.9326 10.4982 12.4522 10.3242 11.8393 10.3242H10.6713C10.4394 10.3242 10.3235 10.4236 10.3235 10.6224V16.3626C10.3235 16.9755 10.4974 17.456 10.8453 17.8038Z" fill="var(--ld-col-wht)" fill-rule="evenodd"></path>
-                        </svg>
-                      </slot>
-                    </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-535" part="popper" size="sm" triggertype="hover">
-                      <slot></slot>
-                    </ld-tooltip-popper>
-                  </mock:shadow-root>
-                  <div class="ld-sidenav-navitem__tooltip-trigger" slot="trigger"></div>
-                  <div style="display: grid; grid-auto-flow: column; align-items: center;">
-                    <ld-typo></ld-typo>
-                  </div>
-                </ld-tooltip>
-              </div>
-              <div class="ld-sidenav-navitem__slot-container" part="slot-container">
-                <slot></slot>
-              </div>
-              <div class="ld-sidenav-navitem__slot-icon-secondary-container">
-                <slot name="icon-secondary"></slot>
-              </div>
-            </button>
-          </mock:shadow-root>
-          Coding theory
-        </ld-sidenav-navitem>
-        <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
-          <mock:shadow-root>
-            <button class="ld-sidenav-navitem ld-sidenav-navitem--collapsed ld-sidenav-navitem--secondary" part="navitem focusable">
-              <div class="ld-sidenav-navitem__bg" part="bg">
-                <div class="ld-sidenav-navitem__bg-left"></div>
-                <div class="ld-sidenav-navitem__bg-center"></div>
-                <div class="ld-sidenav-navitem__bg-right"></div>
-              </div>
-              <div class="ld-sidenav-navitem__dot" part="dot"></div>
-              <div class="ld-sidenav-navitem__slot-container-icon" part="slot-container-icon" role="presentation">
-                <slot name="icon"></slot>
-                <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
-                  <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-536" class="ld-tooltip__trigger" part="trigger focusable" type="button">
-                      <ld-sr-only>
-                        Info
-                      </ld-sr-only>
-                      <slot name="trigger">
-                        <svg class="ld-tooltip__icon" fill="none" part="icon" viewBox="0 0 24 24">
-                          <path clip-rule="evenodd" d="M12 23C18.0751 23 23 18.0751 23 12C23 5.9249 18.0751 1 12 1C5.9249 1 1 5.9249 1 12C1 18.0751 5.9249 23 12 23Z" fill="currentColor" fill-rule="evenodd"></path>
-                          <path clip-rule="evenodd" d="M11.9996 8.6477C12.9254 8.6477 13.6758 7.8973 13.6758 6.9715C13.6758 6.0458 12.9254 5.2953 11.9996 5.2953C11.0739 5.2953 10.3235 6.0458 10.3235 6.9715C10.3235 7.8973 11.0739 8.6477 11.9996 8.6477ZM10.8453 17.8038C11.1932 18.1517 11.6736 18.3256 12.2865 18.3256H13.4545C13.6864 18.3256 13.8023 18.2263 13.8023 18.0275V12.2873C13.8023 11.6744 13.6284 11.1939 13.2805 10.8461C12.9326 10.4982 12.4522 10.3242 11.8393 10.3242H10.6713C10.4394 10.3242 10.3235 10.4236 10.3235 10.6224V16.3626C10.3235 16.9755 10.4974 17.456 10.8453 17.8038Z" fill="var(--ld-col-wht)" fill-rule="evenodd"></path>
-                        </svg>
-                      </slot>
-                    </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-536" part="popper" size="sm" triggertype="hover">
-                      <slot></slot>
-                    </ld-tooltip-popper>
-                  </mock:shadow-root>
-                  <div class="ld-sidenav-navitem__tooltip-trigger" slot="trigger"></div>
-                  <div style="display: grid; grid-auto-flow: column; align-items: center;">
-                    <ld-typo></ld-typo>
-                  </div>
-                </ld-tooltip>
-              </div>
-              <div class="ld-sidenav-navitem__slot-container" part="slot-container">
-                <slot></slot>
-              </div>
-              <div class="ld-sidenav-navitem__slot-icon-secondary-container">
-                <slot name="icon-secondary"></slot>
-              </div>
-            </button>
-          </mock:shadow-root>
-          Game theory
-        </ld-sidenav-navitem>
-        <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
-          <mock:shadow-root>
-            <button class="ld-sidenav-navitem ld-sidenav-navitem--collapsed ld-sidenav-navitem--secondary" part="navitem focusable">
-              <div class="ld-sidenav-navitem__bg" part="bg">
-                <div class="ld-sidenav-navitem__bg-left"></div>
-                <div class="ld-sidenav-navitem__bg-center"></div>
-                <div class="ld-sidenav-navitem__bg-right"></div>
-              </div>
-              <div class="ld-sidenav-navitem__dot" part="dot"></div>
-              <div class="ld-sidenav-navitem__slot-container-icon" part="slot-container-icon" role="presentation">
-                <slot name="icon"></slot>
-                <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
-                  <mock:shadow-root>
                     <span aria-describedby="ld-tooltip-537" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                       <ld-sr-only>
                         Info
@@ -1203,7 +1115,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
               </div>
             </button>
           </mock:shadow-root>
-          Discrete Mathematics
+          Coding theory
         </ld-sidenav-navitem>
         <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
           <mock:shadow-root>
@@ -1247,7 +1159,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
               </div>
             </button>
           </mock:shadow-root>
-          Graph theory
+          Game theory
         </ld-sidenav-navitem>
         <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
           <mock:shadow-root>
@@ -1291,7 +1203,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
               </div>
             </button>
           </mock:shadow-root>
-          Mathematical logic
+          Discrete Mathematics
         </ld-sidenav-navitem>
         <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
           <mock:shadow-root>
@@ -1318,6 +1230,94 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                       </slot>
                     </span>
                     <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-540" part="popper" size="sm" triggertype="hover">
+                      <slot></slot>
+                    </ld-tooltip-popper>
+                  </mock:shadow-root>
+                  <div class="ld-sidenav-navitem__tooltip-trigger" slot="trigger"></div>
+                  <div style="display: grid; grid-auto-flow: column; align-items: center;">
+                    <ld-typo></ld-typo>
+                  </div>
+                </ld-tooltip>
+              </div>
+              <div class="ld-sidenav-navitem__slot-container" part="slot-container">
+                <slot></slot>
+              </div>
+              <div class="ld-sidenav-navitem__slot-icon-secondary-container">
+                <slot name="icon-secondary"></slot>
+              </div>
+            </button>
+          </mock:shadow-root>
+          Graph theory
+        </ld-sidenav-navitem>
+        <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
+          <mock:shadow-root>
+            <button class="ld-sidenav-navitem ld-sidenav-navitem--collapsed ld-sidenav-navitem--secondary" part="navitem focusable">
+              <div class="ld-sidenav-navitem__bg" part="bg">
+                <div class="ld-sidenav-navitem__bg-left"></div>
+                <div class="ld-sidenav-navitem__bg-center"></div>
+                <div class="ld-sidenav-navitem__bg-right"></div>
+              </div>
+              <div class="ld-sidenav-navitem__dot" part="dot"></div>
+              <div class="ld-sidenav-navitem__slot-container-icon" part="slot-container-icon" role="presentation">
+                <slot name="icon"></slot>
+                <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
+                  <mock:shadow-root>
+                    <span aria-describedby="ld-tooltip-541" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                      <ld-sr-only>
+                        Info
+                      </ld-sr-only>
+                      <slot name="trigger">
+                        <svg class="ld-tooltip__icon" fill="none" part="icon" viewBox="0 0 24 24">
+                          <path clip-rule="evenodd" d="M12 23C18.0751 23 23 18.0751 23 12C23 5.9249 18.0751 1 12 1C5.9249 1 1 5.9249 1 12C1 18.0751 5.9249 23 12 23Z" fill="currentColor" fill-rule="evenodd"></path>
+                          <path clip-rule="evenodd" d="M11.9996 8.6477C12.9254 8.6477 13.6758 7.8973 13.6758 6.9715C13.6758 6.0458 12.9254 5.2953 11.9996 5.2953C11.0739 5.2953 10.3235 6.0458 10.3235 6.9715C10.3235 7.8973 11.0739 8.6477 11.9996 8.6477ZM10.8453 17.8038C11.1932 18.1517 11.6736 18.3256 12.2865 18.3256H13.4545C13.6864 18.3256 13.8023 18.2263 13.8023 18.0275V12.2873C13.8023 11.6744 13.6284 11.1939 13.2805 10.8461C12.9326 10.4982 12.4522 10.3242 11.8393 10.3242H10.6713C10.4394 10.3242 10.3235 10.4236 10.3235 10.6224V16.3626C10.3235 16.9755 10.4974 17.456 10.8453 17.8038Z" fill="var(--ld-col-wht)" fill-rule="evenodd"></path>
+                        </svg>
+                      </slot>
+                    </span>
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-541" part="popper" size="sm" triggertype="hover">
+                      <slot></slot>
+                    </ld-tooltip-popper>
+                  </mock:shadow-root>
+                  <div class="ld-sidenav-navitem__tooltip-trigger" slot="trigger"></div>
+                  <div style="display: grid; grid-auto-flow: column; align-items: center;">
+                    <ld-typo></ld-typo>
+                  </div>
+                </ld-tooltip>
+              </div>
+              <div class="ld-sidenav-navitem__slot-container" part="slot-container">
+                <slot></slot>
+              </div>
+              <div class="ld-sidenav-navitem__slot-icon-secondary-container">
+                <slot name="icon-secondary"></slot>
+              </div>
+            </button>
+          </mock:shadow-root>
+          Mathematical logic
+        </ld-sidenav-navitem>
+        <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
+          <mock:shadow-root>
+            <button class="ld-sidenav-navitem ld-sidenav-navitem--collapsed ld-sidenav-navitem--secondary" part="navitem focusable">
+              <div class="ld-sidenav-navitem__bg" part="bg">
+                <div class="ld-sidenav-navitem__bg-left"></div>
+                <div class="ld-sidenav-navitem__bg-center"></div>
+                <div class="ld-sidenav-navitem__bg-right"></div>
+              </div>
+              <div class="ld-sidenav-navitem__dot" part="dot"></div>
+              <div class="ld-sidenav-navitem__slot-container-icon" part="slot-container-icon" role="presentation">
+                <slot name="icon"></slot>
+                <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
+                  <mock:shadow-root>
+                    <span aria-describedby="ld-tooltip-542" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                      <ld-sr-only>
+                        Info
+                      </ld-sr-only>
+                      <slot name="trigger">
+                        <svg class="ld-tooltip__icon" fill="none" part="icon" viewBox="0 0 24 24">
+                          <path clip-rule="evenodd" d="M12 23C18.0751 23 23 18.0751 23 12C23 5.9249 18.0751 1 12 1C5.9249 1 1 5.9249 1 12C1 18.0751 5.9249 23 12 23Z" fill="currentColor" fill-rule="evenodd"></path>
+                          <path clip-rule="evenodd" d="M11.9996 8.6477C12.9254 8.6477 13.6758 7.8973 13.6758 6.9715C13.6758 6.0458 12.9254 5.2953 11.9996 5.2953C11.0739 5.2953 10.3235 6.0458 10.3235 6.9715C10.3235 7.8973 11.0739 8.6477 11.9996 8.6477ZM10.8453 17.8038C11.1932 18.1517 11.6736 18.3256 12.2865 18.3256H13.4545C13.6864 18.3256 13.8023 18.2263 13.8023 18.0275V12.2873C13.8023 11.6744 13.6284 11.1939 13.2805 10.8461C12.9326 10.4982 12.4522 10.3242 11.8393 10.3242H10.6713C10.4394 10.3242 10.3235 10.4236 10.3235 10.6224V16.3626C10.3235 16.9755 10.4974 17.456 10.8453 17.8038Z" fill="var(--ld-col-wht)" fill-rule="evenodd"></path>
+                        </svg>
+                      </slot>
+                    </span>
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-542" part="popper" size="sm" triggertype="hover">
                       <slot></slot>
                     </ld-tooltip-popper>
                   </mock:shadow-root>
@@ -1381,7 +1381,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                 <slot name="icon"></slot>
                 <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                   <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-541" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                    <span aria-describedby="ld-tooltip-543" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                       <ld-sr-only>
                         Info
                       </ld-sr-only>
@@ -1392,7 +1392,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                         </svg>
                       </slot>
                     </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-541" part="popper" size="sm" triggertype="hover">
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-543" part="popper" size="sm" triggertype="hover">
                       <slot></slot>
                     </ld-tooltip-popper>
                   </mock:shadow-root>
@@ -1425,7 +1425,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                 <slot name="icon"></slot>
                 <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                   <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-542" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                    <span aria-describedby="ld-tooltip-544" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                       <ld-sr-only>
                         Info
                       </ld-sr-only>
@@ -1436,7 +1436,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                         </svg>
                       </slot>
                     </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-542" part="popper" size="sm" triggertype="hover">
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-544" part="popper" size="sm" triggertype="hover">
                       <slot></slot>
                     </ld-tooltip-popper>
                   </mock:shadow-root>
@@ -1472,7 +1472,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                 </span>
                 <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                   <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-543" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                    <span aria-describedby="ld-tooltip-545" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                       <ld-sr-only>
                         Info
                       </ld-sr-only>
@@ -1483,7 +1483,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                         </svg>
                       </slot>
                     </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-543" part="popper" size="sm" triggertype="hover">
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-545" part="popper" size="sm" triggertype="hover">
                       <slot></slot>
                     </ld-tooltip-popper>
                   </mock:shadow-root>
@@ -1550,7 +1550,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                 <slot name="icon"></slot>
                 <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                   <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-544" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                    <span aria-describedby="ld-tooltip-546" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                       <ld-sr-only>
                         Info
                       </ld-sr-only>
@@ -1561,7 +1561,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                         </svg>
                       </slot>
                     </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-544" part="popper" size="sm" triggertype="hover">
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-546" part="popper" size="sm" triggertype="hover">
                       <slot></slot>
                     </ld-tooltip-popper>
                   </mock:shadow-root>
@@ -1594,7 +1594,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                 <slot name="icon"></slot>
                 <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                   <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-545" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                    <span aria-describedby="ld-tooltip-547" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                       <ld-sr-only>
                         Info
                       </ld-sr-only>
@@ -1605,7 +1605,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                         </svg>
                       </slot>
                     </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-545" part="popper" size="sm" triggertype="hover">
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-547" part="popper" size="sm" triggertype="hover">
                       <slot></slot>
                     </ld-tooltip-popper>
                   </mock:shadow-root>
@@ -1643,7 +1643,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                 <slot name="icon"></slot>
                 <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                   <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-546" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                    <span aria-describedby="ld-tooltip-548" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                       <ld-sr-only>
                         Info
                       </ld-sr-only>
@@ -1654,7 +1654,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                         </svg>
                       </slot>
                     </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-546" part="popper" size="sm" triggertype="hover">
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-548" part="popper" size="sm" triggertype="hover">
                       <slot></slot>
                     </ld-tooltip-popper>
                   </mock:shadow-root>
@@ -1690,7 +1690,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                 </span>
                 <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                   <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-547" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                    <span aria-describedby="ld-tooltip-549" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                       <ld-sr-only>
                         Info
                       </ld-sr-only>
@@ -1701,7 +1701,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                         </svg>
                       </slot>
                     </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-547" part="popper" size="sm" triggertype="hover">
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-549" part="popper" size="sm" triggertype="hover">
                       <slot></slot>
                     </ld-tooltip-popper>
                   </mock:shadow-root>
@@ -1742,7 +1742,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                 <slot name="icon"></slot>
                 <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                   <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-548" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                    <span aria-describedby="ld-tooltip-550" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                       <ld-sr-only>
                         Info
                       </ld-sr-only>
@@ -1753,7 +1753,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                         </svg>
                       </slot>
                     </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-548" part="popper" size="sm" triggertype="hover">
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-550" part="popper" size="sm" triggertype="hover">
                       <slot></slot>
                     </ld-tooltip-popper>
                   </mock:shadow-root>
@@ -1786,7 +1786,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                 <slot name="icon"></slot>
                 <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                   <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-549" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                    <span aria-describedby="ld-tooltip-551" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                       <ld-sr-only>
                         Info
                       </ld-sr-only>
@@ -1797,7 +1797,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                         </svg>
                       </slot>
                     </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-549" part="popper" size="sm" triggertype="hover">
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-551" part="popper" size="sm" triggertype="hover">
                       <slot></slot>
                     </ld-tooltip-popper>
                   </mock:shadow-root>
@@ -1860,7 +1860,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                   <slot name="icon"></slot>
                   <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                     <mock:shadow-root>
-                      <span aria-describedby="ld-tooltip-587" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                      <span aria-describedby="ld-tooltip-589" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                         <ld-sr-only>
                           Info
                         </ld-sr-only>
@@ -1871,7 +1871,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                           </svg>
                         </slot>
                       </span>
-                      <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-587" part="popper" size="sm" triggertype="hover">
+                      <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-589" part="popper" size="sm" triggertype="hover">
                         <slot></slot>
                       </ld-tooltip-popper>
                     </mock:shadow-root>
@@ -1904,7 +1904,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                   <slot name="icon"></slot>
                   <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                     <mock:shadow-root>
-                      <span aria-describedby="ld-tooltip-588" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                      <span aria-describedby="ld-tooltip-590" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                         <ld-sr-only>
                           Info
                         </ld-sr-only>
@@ -1915,7 +1915,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                           </svg>
                         </slot>
                       </span>
-                      <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-588" part="popper" size="sm" triggertype="hover">
+                      <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-590" part="popper" size="sm" triggertype="hover">
                         <slot></slot>
                       </ld-tooltip-popper>
                     </mock:shadow-root>
@@ -1980,7 +1980,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                 <slot name="icon"></slot>
                 <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                   <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-550" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                    <span aria-describedby="ld-tooltip-552" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                       <ld-sr-only>
                         Info
                       </ld-sr-only>
@@ -1991,7 +1991,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                         </svg>
                       </slot>
                     </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-550" part="popper" size="sm" triggertype="hover">
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-552" part="popper" size="sm" triggertype="hover">
                       <slot></slot>
                     </ld-tooltip-popper>
                   </mock:shadow-root>
@@ -2024,7 +2024,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                 <slot name="icon"></slot>
                 <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                   <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-551" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                    <span aria-describedby="ld-tooltip-553" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                       <ld-sr-only>
                         Info
                       </ld-sr-only>
@@ -2035,7 +2035,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                         </svg>
                       </slot>
                     </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-551" part="popper" size="sm" triggertype="hover">
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-553" part="popper" size="sm" triggertype="hover">
                       <slot></slot>
                     </ld-tooltip-popper>
                   </mock:shadow-root>
@@ -2068,7 +2068,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                 <slot name="icon"></slot>
                 <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                   <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-552" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                    <span aria-describedby="ld-tooltip-554" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                       <ld-sr-only>
                         Info
                       </ld-sr-only>
@@ -2079,7 +2079,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                         </svg>
                       </slot>
                     </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-552" part="popper" size="sm" triggertype="hover">
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-554" part="popper" size="sm" triggertype="hover">
                       <slot></slot>
                     </ld-tooltip-popper>
                   </mock:shadow-root>
@@ -2143,7 +2143,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                 <slot name="icon"></slot>
                 <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                   <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-553" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                    <span aria-describedby="ld-tooltip-555" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                       <ld-sr-only>
                         Info
                       </ld-sr-only>
@@ -2154,7 +2154,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                         </svg>
                       </slot>
                     </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-553" part="popper" size="sm" triggertype="hover">
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-555" part="popper" size="sm" triggertype="hover">
                       <slot></slot>
                     </ld-tooltip-popper>
                   </mock:shadow-root>
@@ -2187,7 +2187,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                 <slot name="icon"></slot>
                 <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                   <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-554" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                    <span aria-describedby="ld-tooltip-556" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                       <ld-sr-only>
                         Info
                       </ld-sr-only>
@@ -2198,7 +2198,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                         </svg>
                       </slot>
                     </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-554" part="popper" size="sm" triggertype="hover">
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-556" part="popper" size="sm" triggertype="hover">
                       <slot></slot>
                     </ld-tooltip-popper>
                   </mock:shadow-root>
@@ -2262,7 +2262,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                 <slot name="icon"></slot>
                 <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                   <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-555" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                    <span aria-describedby="ld-tooltip-557" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                       <ld-sr-only>
                         Info
                       </ld-sr-only>
@@ -2273,7 +2273,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                         </svg>
                       </slot>
                     </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-555" part="popper" size="sm" triggertype="hover">
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-557" part="popper" size="sm" triggertype="hover">
                       <slot></slot>
                     </ld-tooltip-popper>
                   </mock:shadow-root>
@@ -2306,7 +2306,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                 <slot name="icon"></slot>
                 <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                   <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-556" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                    <span aria-describedby="ld-tooltip-558" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                       <ld-sr-only>
                         Info
                       </ld-sr-only>
@@ -2317,7 +2317,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                         </svg>
                       </slot>
                     </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-556" part="popper" size="sm" triggertype="hover">
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-558" part="popper" size="sm" triggertype="hover">
                       <slot></slot>
                     </ld-tooltip-popper>
                   </mock:shadow-root>
@@ -2350,7 +2350,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                 <slot name="icon"></slot>
                 <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                   <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-557" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                    <span aria-describedby="ld-tooltip-559" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                       <ld-sr-only>
                         Info
                       </ld-sr-only>
@@ -2361,7 +2361,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                         </svg>
                       </slot>
                     </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-557" part="popper" size="sm" triggertype="hover">
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-559" part="popper" size="sm" triggertype="hover">
                       <slot></slot>
                     </ld-tooltip-popper>
                   </mock:shadow-root>
@@ -2425,7 +2425,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                 <slot name="icon"></slot>
                 <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                   <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-558" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                    <span aria-describedby="ld-tooltip-560" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                       <ld-sr-only>
                         Info
                       </ld-sr-only>
@@ -2436,7 +2436,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                         </svg>
                       </slot>
                     </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-558" part="popper" size="sm" triggertype="hover">
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-560" part="popper" size="sm" triggertype="hover">
                       <slot></slot>
                     </ld-tooltip-popper>
                   </mock:shadow-root>
@@ -2469,7 +2469,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                 <slot name="icon"></slot>
                 <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                   <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-559" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                    <span aria-describedby="ld-tooltip-561" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                       <ld-sr-only>
                         Info
                       </ld-sr-only>
@@ -2480,7 +2480,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                         </svg>
                       </slot>
                     </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-559" part="popper" size="sm" triggertype="hover">
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-561" part="popper" size="sm" triggertype="hover">
                       <slot></slot>
                     </ld-tooltip-popper>
                   </mock:shadow-root>
@@ -2513,7 +2513,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                 <slot name="icon"></slot>
                 <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                   <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-560" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                    <span aria-describedby="ld-tooltip-562" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                       <ld-sr-only>
                         Info
                       </ld-sr-only>
@@ -2524,7 +2524,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                         </svg>
                       </slot>
                     </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-560" part="popper" size="sm" triggertype="hover">
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-562" part="popper" size="sm" triggertype="hover">
                       <slot></slot>
                     </ld-tooltip-popper>
                   </mock:shadow-root>
@@ -2588,7 +2588,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                 <slot name="icon"></slot>
                 <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                   <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-561" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                    <span aria-describedby="ld-tooltip-563" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                       <ld-sr-only>
                         Info
                       </ld-sr-only>
@@ -2599,7 +2599,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                         </svg>
                       </slot>
                     </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-561" part="popper" size="sm" triggertype="hover">
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-563" part="popper" size="sm" triggertype="hover">
                       <slot></slot>
                     </ld-tooltip-popper>
                   </mock:shadow-root>
@@ -2632,7 +2632,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                 <slot name="icon"></slot>
                 <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                   <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-562" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                    <span aria-describedby="ld-tooltip-564" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                       <ld-sr-only>
                         Info
                       </ld-sr-only>
@@ -2643,7 +2643,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                         </svg>
                       </slot>
                     </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-562" part="popper" size="sm" triggertype="hover">
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-564" part="popper" size="sm" triggertype="hover">
                       <slot></slot>
                     </ld-tooltip-popper>
                   </mock:shadow-root>
@@ -2676,7 +2676,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                 <slot name="icon"></slot>
                 <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                   <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-563" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                    <span aria-describedby="ld-tooltip-565" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                       <ld-sr-only>
                         Info
                       </ld-sr-only>
@@ -2687,7 +2687,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                         </svg>
                       </slot>
                     </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-563" part="popper" size="sm" triggertype="hover">
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-565" part="popper" size="sm" triggertype="hover">
                       <slot></slot>
                     </ld-tooltip-popper>
                   </mock:shadow-root>
@@ -2751,94 +2751,6 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                 <slot name="icon"></slot>
                 <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                   <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-564" class="ld-tooltip__trigger" part="trigger focusable" type="button">
-                      <ld-sr-only>
-                        Info
-                      </ld-sr-only>
-                      <slot name="trigger">
-                        <svg class="ld-tooltip__icon" fill="none" part="icon" viewBox="0 0 24 24">
-                          <path clip-rule="evenodd" d="M12 23C18.0751 23 23 18.0751 23 12C23 5.9249 18.0751 1 12 1C5.9249 1 1 5.9249 1 12C1 18.0751 5.9249 23 12 23Z" fill="currentColor" fill-rule="evenodd"></path>
-                          <path clip-rule="evenodd" d="M11.9996 8.6477C12.9254 8.6477 13.6758 7.8973 13.6758 6.9715C13.6758 6.0458 12.9254 5.2953 11.9996 5.2953C11.0739 5.2953 10.3235 6.0458 10.3235 6.9715C10.3235 7.8973 11.0739 8.6477 11.9996 8.6477ZM10.8453 17.8038C11.1932 18.1517 11.6736 18.3256 12.2865 18.3256H13.4545C13.6864 18.3256 13.8023 18.2263 13.8023 18.0275V12.2873C13.8023 11.6744 13.6284 11.1939 13.2805 10.8461C12.9326 10.4982 12.4522 10.3242 11.8393 10.3242H10.6713C10.4394 10.3242 10.3235 10.4236 10.3235 10.6224V16.3626C10.3235 16.9755 10.4974 17.456 10.8453 17.8038Z" fill="var(--ld-col-wht)" fill-rule="evenodd"></path>
-                        </svg>
-                      </slot>
-                    </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-564" part="popper" size="sm" triggertype="hover">
-                      <slot></slot>
-                    </ld-tooltip-popper>
-                  </mock:shadow-root>
-                  <div class="ld-sidenav-navitem__tooltip-trigger" slot="trigger"></div>
-                  <div style="display: grid; grid-auto-flow: column; align-items: center;">
-                    <ld-typo></ld-typo>
-                  </div>
-                </ld-tooltip>
-              </div>
-              <div class="ld-sidenav-navitem__slot-container" part="slot-container">
-                <slot></slot>
-              </div>
-              <div class="ld-sidenav-navitem__slot-icon-secondary-container">
-                <slot name="icon-secondary"></slot>
-              </div>
-            </button>
-          </mock:shadow-root>
-          Compiler theory
-        </ld-sidenav-navitem>
-        <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
-          <mock:shadow-root>
-            <button class="ld-sidenav-navitem ld-sidenav-navitem--collapsed ld-sidenav-navitem--secondary" part="navitem focusable">
-              <div class="ld-sidenav-navitem__bg" part="bg">
-                <div class="ld-sidenav-navitem__bg-left"></div>
-                <div class="ld-sidenav-navitem__bg-center"></div>
-                <div class="ld-sidenav-navitem__bg-right"></div>
-              </div>
-              <div class="ld-sidenav-navitem__dot" part="dot"></div>
-              <div class="ld-sidenav-navitem__slot-container-icon" part="slot-container-icon" role="presentation">
-                <slot name="icon"></slot>
-                <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
-                  <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-565" class="ld-tooltip__trigger" part="trigger focusable" type="button">
-                      <ld-sr-only>
-                        Info
-                      </ld-sr-only>
-                      <slot name="trigger">
-                        <svg class="ld-tooltip__icon" fill="none" part="icon" viewBox="0 0 24 24">
-                          <path clip-rule="evenodd" d="M12 23C18.0751 23 23 18.0751 23 12C23 5.9249 18.0751 1 12 1C5.9249 1 1 5.9249 1 12C1 18.0751 5.9249 23 12 23Z" fill="currentColor" fill-rule="evenodd"></path>
-                          <path clip-rule="evenodd" d="M11.9996 8.6477C12.9254 8.6477 13.6758 7.8973 13.6758 6.9715C13.6758 6.0458 12.9254 5.2953 11.9996 5.2953C11.0739 5.2953 10.3235 6.0458 10.3235 6.9715C10.3235 7.8973 11.0739 8.6477 11.9996 8.6477ZM10.8453 17.8038C11.1932 18.1517 11.6736 18.3256 12.2865 18.3256H13.4545C13.6864 18.3256 13.8023 18.2263 13.8023 18.0275V12.2873C13.8023 11.6744 13.6284 11.1939 13.2805 10.8461C12.9326 10.4982 12.4522 10.3242 11.8393 10.3242H10.6713C10.4394 10.3242 10.3235 10.4236 10.3235 10.6224V16.3626C10.3235 16.9755 10.4974 17.456 10.8453 17.8038Z" fill="var(--ld-col-wht)" fill-rule="evenodd"></path>
-                        </svg>
-                      </slot>
-                    </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-565" part="popper" size="sm" triggertype="hover">
-                      <slot></slot>
-                    </ld-tooltip-popper>
-                  </mock:shadow-root>
-                  <div class="ld-sidenav-navitem__tooltip-trigger" slot="trigger"></div>
-                  <div style="display: grid; grid-auto-flow: column; align-items: center;">
-                    <ld-typo></ld-typo>
-                  </div>
-                </ld-tooltip>
-              </div>
-              <div class="ld-sidenav-navitem__slot-container" part="slot-container">
-                <slot></slot>
-              </div>
-              <div class="ld-sidenav-navitem__slot-icon-secondary-container">
-                <slot name="icon-secondary"></slot>
-              </div>
-            </button>
-          </mock:shadow-root>
-          Programming language pragmatics
-        </ld-sidenav-navitem>
-        <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
-          <mock:shadow-root>
-            <button class="ld-sidenav-navitem ld-sidenav-navitem--collapsed ld-sidenav-navitem--secondary" part="navitem focusable">
-              <div class="ld-sidenav-navitem__bg" part="bg">
-                <div class="ld-sidenav-navitem__bg-left"></div>
-                <div class="ld-sidenav-navitem__bg-center"></div>
-                <div class="ld-sidenav-navitem__bg-right"></div>
-              </div>
-              <div class="ld-sidenav-navitem__dot" part="dot"></div>
-              <div class="ld-sidenav-navitem__slot-container-icon" part="slot-container-icon" role="presentation">
-                <slot name="icon"></slot>
-                <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
-                  <mock:shadow-root>
                     <span aria-describedby="ld-tooltip-566" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                       <ld-sr-only>
                         Info
@@ -2868,7 +2780,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
               </div>
             </button>
           </mock:shadow-root>
-          Programming language theory
+          Compiler theory
         </ld-sidenav-navitem>
         <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
           <mock:shadow-root>
@@ -2912,7 +2824,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
               </div>
             </button>
           </mock:shadow-root>
-          Formal semantics
+          Programming language pragmatics
         </ld-sidenav-navitem>
         <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
           <mock:shadow-root>
@@ -2939,6 +2851,94 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                       </slot>
                     </span>
                     <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-568" part="popper" size="sm" triggertype="hover">
+                      <slot></slot>
+                    </ld-tooltip-popper>
+                  </mock:shadow-root>
+                  <div class="ld-sidenav-navitem__tooltip-trigger" slot="trigger"></div>
+                  <div style="display: grid; grid-auto-flow: column; align-items: center;">
+                    <ld-typo></ld-typo>
+                  </div>
+                </ld-tooltip>
+              </div>
+              <div class="ld-sidenav-navitem__slot-container" part="slot-container">
+                <slot></slot>
+              </div>
+              <div class="ld-sidenav-navitem__slot-icon-secondary-container">
+                <slot name="icon-secondary"></slot>
+              </div>
+            </button>
+          </mock:shadow-root>
+          Programming language theory
+        </ld-sidenav-navitem>
+        <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
+          <mock:shadow-root>
+            <button class="ld-sidenav-navitem ld-sidenav-navitem--collapsed ld-sidenav-navitem--secondary" part="navitem focusable">
+              <div class="ld-sidenav-navitem__bg" part="bg">
+                <div class="ld-sidenav-navitem__bg-left"></div>
+                <div class="ld-sidenav-navitem__bg-center"></div>
+                <div class="ld-sidenav-navitem__bg-right"></div>
+              </div>
+              <div class="ld-sidenav-navitem__dot" part="dot"></div>
+              <div class="ld-sidenav-navitem__slot-container-icon" part="slot-container-icon" role="presentation">
+                <slot name="icon"></slot>
+                <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
+                  <mock:shadow-root>
+                    <span aria-describedby="ld-tooltip-569" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                      <ld-sr-only>
+                        Info
+                      </ld-sr-only>
+                      <slot name="trigger">
+                        <svg class="ld-tooltip__icon" fill="none" part="icon" viewBox="0 0 24 24">
+                          <path clip-rule="evenodd" d="M12 23C18.0751 23 23 18.0751 23 12C23 5.9249 18.0751 1 12 1C5.9249 1 1 5.9249 1 12C1 18.0751 5.9249 23 12 23Z" fill="currentColor" fill-rule="evenodd"></path>
+                          <path clip-rule="evenodd" d="M11.9996 8.6477C12.9254 8.6477 13.6758 7.8973 13.6758 6.9715C13.6758 6.0458 12.9254 5.2953 11.9996 5.2953C11.0739 5.2953 10.3235 6.0458 10.3235 6.9715C10.3235 7.8973 11.0739 8.6477 11.9996 8.6477ZM10.8453 17.8038C11.1932 18.1517 11.6736 18.3256 12.2865 18.3256H13.4545C13.6864 18.3256 13.8023 18.2263 13.8023 18.0275V12.2873C13.8023 11.6744 13.6284 11.1939 13.2805 10.8461C12.9326 10.4982 12.4522 10.3242 11.8393 10.3242H10.6713C10.4394 10.3242 10.3235 10.4236 10.3235 10.6224V16.3626C10.3235 16.9755 10.4974 17.456 10.8453 17.8038Z" fill="var(--ld-col-wht)" fill-rule="evenodd"></path>
+                        </svg>
+                      </slot>
+                    </span>
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-569" part="popper" size="sm" triggertype="hover">
+                      <slot></slot>
+                    </ld-tooltip-popper>
+                  </mock:shadow-root>
+                  <div class="ld-sidenav-navitem__tooltip-trigger" slot="trigger"></div>
+                  <div style="display: grid; grid-auto-flow: column; align-items: center;">
+                    <ld-typo></ld-typo>
+                  </div>
+                </ld-tooltip>
+              </div>
+              <div class="ld-sidenav-navitem__slot-container" part="slot-container">
+                <slot></slot>
+              </div>
+              <div class="ld-sidenav-navitem__slot-icon-secondary-container">
+                <slot name="icon-secondary"></slot>
+              </div>
+            </button>
+          </mock:shadow-root>
+          Formal semantics
+        </ld-sidenav-navitem>
+        <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
+          <mock:shadow-root>
+            <button class="ld-sidenav-navitem ld-sidenav-navitem--collapsed ld-sidenav-navitem--secondary" part="navitem focusable">
+              <div class="ld-sidenav-navitem__bg" part="bg">
+                <div class="ld-sidenav-navitem__bg-left"></div>
+                <div class="ld-sidenav-navitem__bg-center"></div>
+                <div class="ld-sidenav-navitem__bg-right"></div>
+              </div>
+              <div class="ld-sidenav-navitem__dot" part="dot"></div>
+              <div class="ld-sidenav-navitem__slot-container-icon" part="slot-container-icon" role="presentation">
+                <slot name="icon"></slot>
+                <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
+                  <mock:shadow-root>
+                    <span aria-describedby="ld-tooltip-570" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                      <ld-sr-only>
+                        Info
+                      </ld-sr-only>
+                      <slot name="trigger">
+                        <svg class="ld-tooltip__icon" fill="none" part="icon" viewBox="0 0 24 24">
+                          <path clip-rule="evenodd" d="M12 23C18.0751 23 23 18.0751 23 12C23 5.9249 18.0751 1 12 1C5.9249 1 1 5.9249 1 12C1 18.0751 5.9249 23 12 23Z" fill="currentColor" fill-rule="evenodd"></path>
+                          <path clip-rule="evenodd" d="M11.9996 8.6477C12.9254 8.6477 13.6758 7.8973 13.6758 6.9715C13.6758 6.0458 12.9254 5.2953 11.9996 5.2953C11.0739 5.2953 10.3235 6.0458 10.3235 6.9715C10.3235 7.8973 11.0739 8.6477 11.9996 8.6477ZM10.8453 17.8038C11.1932 18.1517 11.6736 18.3256 12.2865 18.3256H13.4545C13.6864 18.3256 13.8023 18.2263 13.8023 18.0275V12.2873C13.8023 11.6744 13.6284 11.1939 13.2805 10.8461C12.9326 10.4982 12.4522 10.3242 11.8393 10.3242H10.6713C10.4394 10.3242 10.3235 10.4236 10.3235 10.6224V16.3626C10.3235 16.9755 10.4974 17.456 10.8453 17.8038Z" fill="var(--ld-col-wht)" fill-rule="evenodd"></path>
+                        </svg>
+                      </slot>
+                    </span>
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-570" part="popper" size="sm" triggertype="hover">
                       <slot></slot>
                     </ld-tooltip-popper>
                   </mock:shadow-root>
@@ -3002,94 +3002,6 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                 <slot name="icon"></slot>
                 <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                   <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-569" class="ld-tooltip__trigger" part="trigger focusable" type="button">
-                      <ld-sr-only>
-                        Info
-                      </ld-sr-only>
-                      <slot name="trigger">
-                        <svg class="ld-tooltip__icon" fill="none" part="icon" viewBox="0 0 24 24">
-                          <path clip-rule="evenodd" d="M12 23C18.0751 23 23 18.0751 23 12C23 5.9249 18.0751 1 12 1C5.9249 1 1 5.9249 1 12C1 18.0751 5.9249 23 12 23Z" fill="currentColor" fill-rule="evenodd"></path>
-                          <path clip-rule="evenodd" d="M11.9996 8.6477C12.9254 8.6477 13.6758 7.8973 13.6758 6.9715C13.6758 6.0458 12.9254 5.2953 11.9996 5.2953C11.0739 5.2953 10.3235 6.0458 10.3235 6.9715C10.3235 7.8973 11.0739 8.6477 11.9996 8.6477ZM10.8453 17.8038C11.1932 18.1517 11.6736 18.3256 12.2865 18.3256H13.4545C13.6864 18.3256 13.8023 18.2263 13.8023 18.0275V12.2873C13.8023 11.6744 13.6284 11.1939 13.2805 10.8461C12.9326 10.4982 12.4522 10.3242 11.8393 10.3242H10.6713C10.4394 10.3242 10.3235 10.4236 10.3235 10.6224V16.3626C10.3235 16.9755 10.4974 17.456 10.8453 17.8038Z" fill="var(--ld-col-wht)" fill-rule="evenodd"></path>
-                        </svg>
-                      </slot>
-                    </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-569" part="popper" size="sm" triggertype="hover">
-                      <slot></slot>
-                    </ld-tooltip-popper>
-                  </mock:shadow-root>
-                  <div class="ld-sidenav-navitem__tooltip-trigger" slot="trigger"></div>
-                  <div style="display: grid; grid-auto-flow: column; align-items: center;">
-                    <ld-typo></ld-typo>
-                  </div>
-                </ld-tooltip>
-              </div>
-              <div class="ld-sidenav-navitem__slot-container" part="slot-container">
-                <slot></slot>
-              </div>
-              <div class="ld-sidenav-navitem__slot-icon-secondary-container">
-                <slot name="icon-secondary"></slot>
-              </div>
-            </button>
-          </mock:shadow-root>
-          Computational science
-        </ld-sidenav-navitem>
-        <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
-          <mock:shadow-root>
-            <button class="ld-sidenav-navitem ld-sidenav-navitem--collapsed ld-sidenav-navitem--secondary" part="navitem focusable">
-              <div class="ld-sidenav-navitem__bg" part="bg">
-                <div class="ld-sidenav-navitem__bg-left"></div>
-                <div class="ld-sidenav-navitem__bg-center"></div>
-                <div class="ld-sidenav-navitem__bg-right"></div>
-              </div>
-              <div class="ld-sidenav-navitem__dot" part="dot"></div>
-              <div class="ld-sidenav-navitem__slot-container-icon" part="slot-container-icon" role="presentation">
-                <slot name="icon"></slot>
-                <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
-                  <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-570" class="ld-tooltip__trigger" part="trigger focusable" type="button">
-                      <ld-sr-only>
-                        Info
-                      </ld-sr-only>
-                      <slot name="trigger">
-                        <svg class="ld-tooltip__icon" fill="none" part="icon" viewBox="0 0 24 24">
-                          <path clip-rule="evenodd" d="M12 23C18.0751 23 23 18.0751 23 12C23 5.9249 18.0751 1 12 1C5.9249 1 1 5.9249 1 12C1 18.0751 5.9249 23 12 23Z" fill="currentColor" fill-rule="evenodd"></path>
-                          <path clip-rule="evenodd" d="M11.9996 8.6477C12.9254 8.6477 13.6758 7.8973 13.6758 6.9715C13.6758 6.0458 12.9254 5.2953 11.9996 5.2953C11.0739 5.2953 10.3235 6.0458 10.3235 6.9715C10.3235 7.8973 11.0739 8.6477 11.9996 8.6477ZM10.8453 17.8038C11.1932 18.1517 11.6736 18.3256 12.2865 18.3256H13.4545C13.6864 18.3256 13.8023 18.2263 13.8023 18.0275V12.2873C13.8023 11.6744 13.6284 11.1939 13.2805 10.8461C12.9326 10.4982 12.4522 10.3242 11.8393 10.3242H10.6713C10.4394 10.3242 10.3235 10.4236 10.3235 10.6224V16.3626C10.3235 16.9755 10.4974 17.456 10.8453 17.8038Z" fill="var(--ld-col-wht)" fill-rule="evenodd"></path>
-                        </svg>
-                      </slot>
-                    </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-570" part="popper" size="sm" triggertype="hover">
-                      <slot></slot>
-                    </ld-tooltip-popper>
-                  </mock:shadow-root>
-                  <div class="ld-sidenav-navitem__tooltip-trigger" slot="trigger"></div>
-                  <div style="display: grid; grid-auto-flow: column; align-items: center;">
-                    <ld-typo></ld-typo>
-                  </div>
-                </ld-tooltip>
-              </div>
-              <div class="ld-sidenav-navitem__slot-container" part="slot-container">
-                <slot></slot>
-              </div>
-              <div class="ld-sidenav-navitem__slot-icon-secondary-container">
-                <slot name="icon-secondary"></slot>
-              </div>
-            </button>
-          </mock:shadow-root>
-          Numerical analysis
-        </ld-sidenav-navitem>
-        <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
-          <mock:shadow-root>
-            <button class="ld-sidenav-navitem ld-sidenav-navitem--collapsed ld-sidenav-navitem--secondary" part="navitem focusable">
-              <div class="ld-sidenav-navitem__bg" part="bg">
-                <div class="ld-sidenav-navitem__bg-left"></div>
-                <div class="ld-sidenav-navitem__bg-center"></div>
-                <div class="ld-sidenav-navitem__bg-right"></div>
-              </div>
-              <div class="ld-sidenav-navitem__dot" part="dot"></div>
-              <div class="ld-sidenav-navitem__slot-container-icon" part="slot-container-icon" role="presentation">
-                <slot name="icon"></slot>
-                <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
-                  <mock:shadow-root>
                     <span aria-describedby="ld-tooltip-571" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                       <ld-sr-only>
                         Info
@@ -3119,7 +3031,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
               </div>
             </button>
           </mock:shadow-root>
-          Symbolic computation
+          Computational science
         </ld-sidenav-navitem>
         <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
           <mock:shadow-root>
@@ -3163,7 +3075,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
               </div>
             </button>
           </mock:shadow-root>
-          Computational physics
+          Numerical analysis
         </ld-sidenav-navitem>
         <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
           <mock:shadow-root>
@@ -3207,7 +3119,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
               </div>
             </button>
           </mock:shadow-root>
-          Computational chemistry
+          Symbolic computation
         </ld-sidenav-navitem>
         <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
           <mock:shadow-root>
@@ -3251,7 +3163,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
               </div>
             </button>
           </mock:shadow-root>
-          Bioinformatics and Computational biology
+          Computational physics
         </ld-sidenav-navitem>
         <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
           <mock:shadow-root>
@@ -3278,6 +3190,94 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                       </slot>
                     </span>
                     <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-575" part="popper" size="sm" triggertype="hover">
+                      <slot></slot>
+                    </ld-tooltip-popper>
+                  </mock:shadow-root>
+                  <div class="ld-sidenav-navitem__tooltip-trigger" slot="trigger"></div>
+                  <div style="display: grid; grid-auto-flow: column; align-items: center;">
+                    <ld-typo></ld-typo>
+                  </div>
+                </ld-tooltip>
+              </div>
+              <div class="ld-sidenav-navitem__slot-container" part="slot-container">
+                <slot></slot>
+              </div>
+              <div class="ld-sidenav-navitem__slot-icon-secondary-container">
+                <slot name="icon-secondary"></slot>
+              </div>
+            </button>
+          </mock:shadow-root>
+          Computational chemistry
+        </ld-sidenav-navitem>
+        <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
+          <mock:shadow-root>
+            <button class="ld-sidenav-navitem ld-sidenav-navitem--collapsed ld-sidenav-navitem--secondary" part="navitem focusable">
+              <div class="ld-sidenav-navitem__bg" part="bg">
+                <div class="ld-sidenav-navitem__bg-left"></div>
+                <div class="ld-sidenav-navitem__bg-center"></div>
+                <div class="ld-sidenav-navitem__bg-right"></div>
+              </div>
+              <div class="ld-sidenav-navitem__dot" part="dot"></div>
+              <div class="ld-sidenav-navitem__slot-container-icon" part="slot-container-icon" role="presentation">
+                <slot name="icon"></slot>
+                <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
+                  <mock:shadow-root>
+                    <span aria-describedby="ld-tooltip-576" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                      <ld-sr-only>
+                        Info
+                      </ld-sr-only>
+                      <slot name="trigger">
+                        <svg class="ld-tooltip__icon" fill="none" part="icon" viewBox="0 0 24 24">
+                          <path clip-rule="evenodd" d="M12 23C18.0751 23 23 18.0751 23 12C23 5.9249 18.0751 1 12 1C5.9249 1 1 5.9249 1 12C1 18.0751 5.9249 23 12 23Z" fill="currentColor" fill-rule="evenodd"></path>
+                          <path clip-rule="evenodd" d="M11.9996 8.6477C12.9254 8.6477 13.6758 7.8973 13.6758 6.9715C13.6758 6.0458 12.9254 5.2953 11.9996 5.2953C11.0739 5.2953 10.3235 6.0458 10.3235 6.9715C10.3235 7.8973 11.0739 8.6477 11.9996 8.6477ZM10.8453 17.8038C11.1932 18.1517 11.6736 18.3256 12.2865 18.3256H13.4545C13.6864 18.3256 13.8023 18.2263 13.8023 18.0275V12.2873C13.8023 11.6744 13.6284 11.1939 13.2805 10.8461C12.9326 10.4982 12.4522 10.3242 11.8393 10.3242H10.6713C10.4394 10.3242 10.3235 10.4236 10.3235 10.6224V16.3626C10.3235 16.9755 10.4974 17.456 10.8453 17.8038Z" fill="var(--ld-col-wht)" fill-rule="evenodd"></path>
+                        </svg>
+                      </slot>
+                    </span>
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-576" part="popper" size="sm" triggertype="hover">
+                      <slot></slot>
+                    </ld-tooltip-popper>
+                  </mock:shadow-root>
+                  <div class="ld-sidenav-navitem__tooltip-trigger" slot="trigger"></div>
+                  <div style="display: grid; grid-auto-flow: column; align-items: center;">
+                    <ld-typo></ld-typo>
+                  </div>
+                </ld-tooltip>
+              </div>
+              <div class="ld-sidenav-navitem__slot-container" part="slot-container">
+                <slot></slot>
+              </div>
+              <div class="ld-sidenav-navitem__slot-icon-secondary-container">
+                <slot name="icon-secondary"></slot>
+              </div>
+            </button>
+          </mock:shadow-root>
+          Bioinformatics and Computational biology
+        </ld-sidenav-navitem>
+        <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
+          <mock:shadow-root>
+            <button class="ld-sidenav-navitem ld-sidenav-navitem--collapsed ld-sidenav-navitem--secondary" part="navitem focusable">
+              <div class="ld-sidenav-navitem__bg" part="bg">
+                <div class="ld-sidenav-navitem__bg-left"></div>
+                <div class="ld-sidenav-navitem__bg-center"></div>
+                <div class="ld-sidenav-navitem__bg-right"></div>
+              </div>
+              <div class="ld-sidenav-navitem__dot" part="dot"></div>
+              <div class="ld-sidenav-navitem__slot-container-icon" part="slot-container-icon" role="presentation">
+                <slot name="icon"></slot>
+                <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
+                  <mock:shadow-root>
+                    <span aria-describedby="ld-tooltip-577" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                      <ld-sr-only>
+                        Info
+                      </ld-sr-only>
+                      <slot name="trigger">
+                        <svg class="ld-tooltip__icon" fill="none" part="icon" viewBox="0 0 24 24">
+                          <path clip-rule="evenodd" d="M12 23C18.0751 23 23 18.0751 23 12C23 5.9249 18.0751 1 12 1C5.9249 1 1 5.9249 1 12C1 18.0751 5.9249 23 12 23Z" fill="currentColor" fill-rule="evenodd"></path>
+                          <path clip-rule="evenodd" d="M11.9996 8.6477C12.9254 8.6477 13.6758 7.8973 13.6758 6.9715C13.6758 6.0458 12.9254 5.2953 11.9996 5.2953C11.0739 5.2953 10.3235 6.0458 10.3235 6.9715C10.3235 7.8973 11.0739 8.6477 11.9996 8.6477ZM10.8453 17.8038C11.1932 18.1517 11.6736 18.3256 12.2865 18.3256H13.4545C13.6864 18.3256 13.8023 18.2263 13.8023 18.0275V12.2873C13.8023 11.6744 13.6284 11.1939 13.2805 10.8461C12.9326 10.4982 12.4522 10.3242 11.8393 10.3242H10.6713C10.4394 10.3242 10.3235 10.4236 10.3235 10.6224V16.3626C10.3235 16.9755 10.4974 17.456 10.8453 17.8038Z" fill="var(--ld-col-wht)" fill-rule="evenodd"></path>
+                        </svg>
+                      </slot>
+                    </span>
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-577" part="popper" size="sm" triggertype="hover">
                       <slot></slot>
                     </ld-tooltip-popper>
                   </mock:shadow-root>
@@ -3341,94 +3341,6 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                 <slot name="icon"></slot>
                 <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                   <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-576" class="ld-tooltip__trigger" part="trigger focusable" type="button">
-                      <ld-sr-only>
-                        Info
-                      </ld-sr-only>
-                      <slot name="trigger">
-                        <svg class="ld-tooltip__icon" fill="none" part="icon" viewBox="0 0 24 24">
-                          <path clip-rule="evenodd" d="M12 23C18.0751 23 23 18.0751 23 12C23 5.9249 18.0751 1 12 1C5.9249 1 1 5.9249 1 12C1 18.0751 5.9249 23 12 23Z" fill="currentColor" fill-rule="evenodd"></path>
-                          <path clip-rule="evenodd" d="M11.9996 8.6477C12.9254 8.6477 13.6758 7.8973 13.6758 6.9715C13.6758 6.0458 12.9254 5.2953 11.9996 5.2953C11.0739 5.2953 10.3235 6.0458 10.3235 6.9715C10.3235 7.8973 11.0739 8.6477 11.9996 8.6477ZM10.8453 17.8038C11.1932 18.1517 11.6736 18.3256 12.2865 18.3256H13.4545C13.6864 18.3256 13.8023 18.2263 13.8023 18.0275V12.2873C13.8023 11.6744 13.6284 11.1939 13.2805 10.8461C12.9326 10.4982 12.4522 10.3242 11.8393 10.3242H10.6713C10.4394 10.3242 10.3235 10.4236 10.3235 10.6224V16.3626C10.3235 16.9755 10.4974 17.456 10.8453 17.8038Z" fill="var(--ld-col-wht)" fill-rule="evenodd"></path>
-                        </svg>
-                      </slot>
-                    </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-576" part="popper" size="sm" triggertype="hover">
-                      <slot></slot>
-                    </ld-tooltip-popper>
-                  </mock:shadow-root>
-                  <div class="ld-sidenav-navitem__tooltip-trigger" slot="trigger"></div>
-                  <div style="display: grid; grid-auto-flow: column; align-items: center;">
-                    <ld-typo></ld-typo>
-                  </div>
-                </ld-tooltip>
-              </div>
-              <div class="ld-sidenav-navitem__slot-container" part="slot-container">
-                <slot></slot>
-              </div>
-              <div class="ld-sidenav-navitem__slot-icon-secondary-container">
-                <slot name="icon-secondary"></slot>
-              </div>
-            </button>
-          </mock:shadow-root>
-          Computational science
-        </ld-sidenav-navitem>
-        <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
-          <mock:shadow-root>
-            <button class="ld-sidenav-navitem ld-sidenav-navitem--collapsed ld-sidenav-navitem--secondary" part="navitem focusable">
-              <div class="ld-sidenav-navitem__bg" part="bg">
-                <div class="ld-sidenav-navitem__bg-left"></div>
-                <div class="ld-sidenav-navitem__bg-center"></div>
-                <div class="ld-sidenav-navitem__bg-right"></div>
-              </div>
-              <div class="ld-sidenav-navitem__dot" part="dot"></div>
-              <div class="ld-sidenav-navitem__slot-container-icon" part="slot-container-icon" role="presentation">
-                <slot name="icon"></slot>
-                <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
-                  <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-577" class="ld-tooltip__trigger" part="trigger focusable" type="button">
-                      <ld-sr-only>
-                        Info
-                      </ld-sr-only>
-                      <slot name="trigger">
-                        <svg class="ld-tooltip__icon" fill="none" part="icon" viewBox="0 0 24 24">
-                          <path clip-rule="evenodd" d="M12 23C18.0751 23 23 18.0751 23 12C23 5.9249 18.0751 1 12 1C5.9249 1 1 5.9249 1 12C1 18.0751 5.9249 23 12 23Z" fill="currentColor" fill-rule="evenodd"></path>
-                          <path clip-rule="evenodd" d="M11.9996 8.6477C12.9254 8.6477 13.6758 7.8973 13.6758 6.9715C13.6758 6.0458 12.9254 5.2953 11.9996 5.2953C11.0739 5.2953 10.3235 6.0458 10.3235 6.9715C10.3235 7.8973 11.0739 8.6477 11.9996 8.6477ZM10.8453 17.8038C11.1932 18.1517 11.6736 18.3256 12.2865 18.3256H13.4545C13.6864 18.3256 13.8023 18.2263 13.8023 18.0275V12.2873C13.8023 11.6744 13.6284 11.1939 13.2805 10.8461C12.9326 10.4982 12.4522 10.3242 11.8393 10.3242H10.6713C10.4394 10.3242 10.3235 10.4236 10.3235 10.6224V16.3626C10.3235 16.9755 10.4974 17.456 10.8453 17.8038Z" fill="var(--ld-col-wht)" fill-rule="evenodd"></path>
-                        </svg>
-                      </slot>
-                    </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-577" part="popper" size="sm" triggertype="hover">
-                      <slot></slot>
-                    </ld-tooltip-popper>
-                  </mock:shadow-root>
-                  <div class="ld-sidenav-navitem__tooltip-trigger" slot="trigger"></div>
-                  <div style="display: grid; grid-auto-flow: column; align-items: center;">
-                    <ld-typo></ld-typo>
-                  </div>
-                </ld-tooltip>
-              </div>
-              <div class="ld-sidenav-navitem__slot-container" part="slot-container">
-                <slot></slot>
-              </div>
-              <div class="ld-sidenav-navitem__slot-icon-secondary-container">
-                <slot name="icon-secondary"></slot>
-              </div>
-            </button>
-          </mock:shadow-root>
-          Formal methods
-        </ld-sidenav-navitem>
-        <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
-          <mock:shadow-root>
-            <button class="ld-sidenav-navitem ld-sidenav-navitem--collapsed ld-sidenav-navitem--secondary" part="navitem focusable">
-              <div class="ld-sidenav-navitem__bg" part="bg">
-                <div class="ld-sidenav-navitem__bg-left"></div>
-                <div class="ld-sidenav-navitem__bg-center"></div>
-                <div class="ld-sidenav-navitem__bg-right"></div>
-              </div>
-              <div class="ld-sidenav-navitem__dot" part="dot"></div>
-              <div class="ld-sidenav-navitem__slot-container-icon" part="slot-container-icon" role="presentation">
-                <slot name="icon"></slot>
-                <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
-                  <mock:shadow-root>
                     <span aria-describedby="ld-tooltip-578" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                       <ld-sr-only>
                         Info
@@ -3458,7 +3370,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
               </div>
             </button>
           </mock:shadow-root>
-          Software engineering
+          Computational science
         </ld-sidenav-navitem>
         <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
           <mock:shadow-root>
@@ -3502,7 +3414,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
               </div>
             </button>
           </mock:shadow-root>
-          Algorithm design
+          Formal methods
         </ld-sidenav-navitem>
         <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
           <mock:shadow-root>
@@ -3546,7 +3458,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
               </div>
             </button>
           </mock:shadow-root>
-          Computer programming
+          Software engineering
         </ld-sidenav-navitem>
         <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
           <mock:shadow-root>
@@ -3590,7 +3502,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
               </div>
             </button>
           </mock:shadow-root>
-          Human–computer interaction
+          Algorithm design
         </ld-sidenav-navitem>
         <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
           <mock:shadow-root>
@@ -3617,6 +3529,94 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                       </slot>
                     </span>
                     <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-582" part="popper" size="sm" triggertype="hover">
+                      <slot></slot>
+                    </ld-tooltip-popper>
+                  </mock:shadow-root>
+                  <div class="ld-sidenav-navitem__tooltip-trigger" slot="trigger"></div>
+                  <div style="display: grid; grid-auto-flow: column; align-items: center;">
+                    <ld-typo></ld-typo>
+                  </div>
+                </ld-tooltip>
+              </div>
+              <div class="ld-sidenav-navitem__slot-container" part="slot-container">
+                <slot></slot>
+              </div>
+              <div class="ld-sidenav-navitem__slot-icon-secondary-container">
+                <slot name="icon-secondary"></slot>
+              </div>
+            </button>
+          </mock:shadow-root>
+          Computer programming
+        </ld-sidenav-navitem>
+        <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
+          <mock:shadow-root>
+            <button class="ld-sidenav-navitem ld-sidenav-navitem--collapsed ld-sidenav-navitem--secondary" part="navitem focusable">
+              <div class="ld-sidenav-navitem__bg" part="bg">
+                <div class="ld-sidenav-navitem__bg-left"></div>
+                <div class="ld-sidenav-navitem__bg-center"></div>
+                <div class="ld-sidenav-navitem__bg-right"></div>
+              </div>
+              <div class="ld-sidenav-navitem__dot" part="dot"></div>
+              <div class="ld-sidenav-navitem__slot-container-icon" part="slot-container-icon" role="presentation">
+                <slot name="icon"></slot>
+                <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
+                  <mock:shadow-root>
+                    <span aria-describedby="ld-tooltip-583" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                      <ld-sr-only>
+                        Info
+                      </ld-sr-only>
+                      <slot name="trigger">
+                        <svg class="ld-tooltip__icon" fill="none" part="icon" viewBox="0 0 24 24">
+                          <path clip-rule="evenodd" d="M12 23C18.0751 23 23 18.0751 23 12C23 5.9249 18.0751 1 12 1C5.9249 1 1 5.9249 1 12C1 18.0751 5.9249 23 12 23Z" fill="currentColor" fill-rule="evenodd"></path>
+                          <path clip-rule="evenodd" d="M11.9996 8.6477C12.9254 8.6477 13.6758 7.8973 13.6758 6.9715C13.6758 6.0458 12.9254 5.2953 11.9996 5.2953C11.0739 5.2953 10.3235 6.0458 10.3235 6.9715C10.3235 7.8973 11.0739 8.6477 11.9996 8.6477ZM10.8453 17.8038C11.1932 18.1517 11.6736 18.3256 12.2865 18.3256H13.4545C13.6864 18.3256 13.8023 18.2263 13.8023 18.0275V12.2873C13.8023 11.6744 13.6284 11.1939 13.2805 10.8461C12.9326 10.4982 12.4522 10.3242 11.8393 10.3242H10.6713C10.4394 10.3242 10.3235 10.4236 10.3235 10.6224V16.3626C10.3235 16.9755 10.4974 17.456 10.8453 17.8038Z" fill="var(--ld-col-wht)" fill-rule="evenodd"></path>
+                        </svg>
+                      </slot>
+                    </span>
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-583" part="popper" size="sm" triggertype="hover">
+                      <slot></slot>
+                    </ld-tooltip-popper>
+                  </mock:shadow-root>
+                  <div class="ld-sidenav-navitem__tooltip-trigger" slot="trigger"></div>
+                  <div style="display: grid; grid-auto-flow: column; align-items: center;">
+                    <ld-typo></ld-typo>
+                  </div>
+                </ld-tooltip>
+              </div>
+              <div class="ld-sidenav-navitem__slot-container" part="slot-container">
+                <slot></slot>
+              </div>
+              <div class="ld-sidenav-navitem__slot-icon-secondary-container">
+                <slot name="icon-secondary"></slot>
+              </div>
+            </button>
+          </mock:shadow-root>
+          Human–computer interaction
+        </ld-sidenav-navitem>
+        <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
+          <mock:shadow-root>
+            <button class="ld-sidenav-navitem ld-sidenav-navitem--collapsed ld-sidenav-navitem--secondary" part="navitem focusable">
+              <div class="ld-sidenav-navitem__bg" part="bg">
+                <div class="ld-sidenav-navitem__bg-left"></div>
+                <div class="ld-sidenav-navitem__bg-center"></div>
+                <div class="ld-sidenav-navitem__bg-right"></div>
+              </div>
+              <div class="ld-sidenav-navitem__dot" part="dot"></div>
+              <div class="ld-sidenav-navitem__slot-container-icon" part="slot-container-icon" role="presentation">
+                <slot name="icon"></slot>
+                <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
+                  <mock:shadow-root>
+                    <span aria-describedby="ld-tooltip-584" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                      <ld-sr-only>
+                        Info
+                      </ld-sr-only>
+                      <slot name="trigger">
+                        <svg class="ld-tooltip__icon" fill="none" part="icon" viewBox="0 0 24 24">
+                          <path clip-rule="evenodd" d="M12 23C18.0751 23 23 18.0751 23 12C23 5.9249 18.0751 1 12 1C5.9249 1 1 5.9249 1 12C1 18.0751 5.9249 23 12 23Z" fill="currentColor" fill-rule="evenodd"></path>
+                          <path clip-rule="evenodd" d="M11.9996 8.6477C12.9254 8.6477 13.6758 7.8973 13.6758 6.9715C13.6758 6.0458 12.9254 5.2953 11.9996 5.2953C11.0739 5.2953 10.3235 6.0458 10.3235 6.9715C10.3235 7.8973 11.0739 8.6477 11.9996 8.6477ZM10.8453 17.8038C11.1932 18.1517 11.6736 18.3256 12.2865 18.3256H13.4545C13.6864 18.3256 13.8023 18.2263 13.8023 18.0275V12.2873C13.8023 11.6744 13.6284 11.1939 13.2805 10.8461C12.9326 10.4982 12.4522 10.3242 11.8393 10.3242H10.6713C10.4394 10.3242 10.3235 10.4236 10.3235 10.6224V16.3626C10.3235 16.9755 10.4974 17.456 10.8453 17.8038Z" fill="var(--ld-col-wht)" fill-rule="evenodd"></path>
+                        </svg>
+                      </slot>
+                    </span>
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-584" part="popper" size="sm" triggertype="hover">
                       <slot></slot>
                     </ld-tooltip-popper>
                   </mock:shadow-root>
@@ -3680,94 +3680,6 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                 <slot name="icon"></slot>
                 <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                   <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-583" class="ld-tooltip__trigger" part="trigger focusable" type="button">
-                      <ld-sr-only>
-                        Info
-                      </ld-sr-only>
-                      <slot name="trigger">
-                        <svg class="ld-tooltip__icon" fill="none" part="icon" viewBox="0 0 24 24">
-                          <path clip-rule="evenodd" d="M12 23C18.0751 23 23 18.0751 23 12C23 5.9249 18.0751 1 12 1C5.9249 1 1 5.9249 1 12C1 18.0751 5.9249 23 12 23Z" fill="currentColor" fill-rule="evenodd"></path>
-                          <path clip-rule="evenodd" d="M11.9996 8.6477C12.9254 8.6477 13.6758 7.8973 13.6758 6.9715C13.6758 6.0458 12.9254 5.2953 11.9996 5.2953C11.0739 5.2953 10.3235 6.0458 10.3235 6.9715C10.3235 7.8973 11.0739 8.6477 11.9996 8.6477ZM10.8453 17.8038C11.1932 18.1517 11.6736 18.3256 12.2865 18.3256H13.4545C13.6864 18.3256 13.8023 18.2263 13.8023 18.0275V12.2873C13.8023 11.6744 13.6284 11.1939 13.2805 10.8461C12.9326 10.4982 12.4522 10.3242 11.8393 10.3242H10.6713C10.4394 10.3242 10.3235 10.4236 10.3235 10.6224V16.3626C10.3235 16.9755 10.4974 17.456 10.8453 17.8038Z" fill="var(--ld-col-wht)" fill-rule="evenodd"></path>
-                        </svg>
-                      </slot>
-                    </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-583" part="popper" size="sm" triggertype="hover">
-                      <slot></slot>
-                    </ld-tooltip-popper>
-                  </mock:shadow-root>
-                  <div class="ld-sidenav-navitem__tooltip-trigger" slot="trigger"></div>
-                  <div style="display: grid; grid-auto-flow: column; align-items: center;">
-                    <ld-typo></ld-typo>
-                  </div>
-                </ld-tooltip>
-              </div>
-              <div class="ld-sidenav-navitem__slot-container" part="slot-container">
-                <slot></slot>
-              </div>
-              <div class="ld-sidenav-navitem__slot-icon-secondary-container">
-                <slot name="icon-secondary"></slot>
-              </div>
-            </button>
-          </mock:shadow-root>
-          Automata theory
-        </ld-sidenav-navitem>
-        <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
-          <mock:shadow-root>
-            <button class="ld-sidenav-navitem ld-sidenav-navitem--collapsed ld-sidenav-navitem--secondary" part="navitem focusable">
-              <div class="ld-sidenav-navitem__bg" part="bg">
-                <div class="ld-sidenav-navitem__bg-left"></div>
-                <div class="ld-sidenav-navitem__bg-center"></div>
-                <div class="ld-sidenav-navitem__bg-right"></div>
-              </div>
-              <div class="ld-sidenav-navitem__dot" part="dot"></div>
-              <div class="ld-sidenav-navitem__slot-container-icon" part="slot-container-icon" role="presentation">
-                <slot name="icon"></slot>
-                <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
-                  <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-584" class="ld-tooltip__trigger" part="trigger focusable" type="button">
-                      <ld-sr-only>
-                        Info
-                      </ld-sr-only>
-                      <slot name="trigger">
-                        <svg class="ld-tooltip__icon" fill="none" part="icon" viewBox="0 0 24 24">
-                          <path clip-rule="evenodd" d="M12 23C18.0751 23 23 18.0751 23 12C23 5.9249 18.0751 1 12 1C5.9249 1 1 5.9249 1 12C1 18.0751 5.9249 23 12 23Z" fill="currentColor" fill-rule="evenodd"></path>
-                          <path clip-rule="evenodd" d="M11.9996 8.6477C12.9254 8.6477 13.6758 7.8973 13.6758 6.9715C13.6758 6.0458 12.9254 5.2953 11.9996 5.2953C11.0739 5.2953 10.3235 6.0458 10.3235 6.9715C10.3235 7.8973 11.0739 8.6477 11.9996 8.6477ZM10.8453 17.8038C11.1932 18.1517 11.6736 18.3256 12.2865 18.3256H13.4545C13.6864 18.3256 13.8023 18.2263 13.8023 18.0275V12.2873C13.8023 11.6744 13.6284 11.1939 13.2805 10.8461C12.9326 10.4982 12.4522 10.3242 11.8393 10.3242H10.6713C10.4394 10.3242 10.3235 10.4236 10.3235 10.6224V16.3626C10.3235 16.9755 10.4974 17.456 10.8453 17.8038Z" fill="var(--ld-col-wht)" fill-rule="evenodd"></path>
-                        </svg>
-                      </slot>
-                    </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-584" part="popper" size="sm" triggertype="hover">
-                      <slot></slot>
-                    </ld-tooltip-popper>
-                  </mock:shadow-root>
-                  <div class="ld-sidenav-navitem__tooltip-trigger" slot="trigger"></div>
-                  <div style="display: grid; grid-auto-flow: column; align-items: center;">
-                    <ld-typo></ld-typo>
-                  </div>
-                </ld-tooltip>
-              </div>
-              <div class="ld-sidenav-navitem__slot-container" part="slot-container">
-                <slot></slot>
-              </div>
-              <div class="ld-sidenav-navitem__slot-icon-secondary-container">
-                <slot name="icon-secondary"></slot>
-              </div>
-            </button>
-          </mock:shadow-root>
-          Computability theory
-        </ld-sidenav-navitem>
-        <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
-          <mock:shadow-root>
-            <button class="ld-sidenav-navitem ld-sidenav-navitem--collapsed ld-sidenav-navitem--secondary" part="navitem focusable">
-              <div class="ld-sidenav-navitem__bg" part="bg">
-                <div class="ld-sidenav-navitem__bg-left"></div>
-                <div class="ld-sidenav-navitem__bg-center"></div>
-                <div class="ld-sidenav-navitem__bg-right"></div>
-              </div>
-              <div class="ld-sidenav-navitem__dot" part="dot"></div>
-              <div class="ld-sidenav-navitem__slot-container-icon" part="slot-container-icon" role="presentation">
-                <slot name="icon"></slot>
-                <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
-                  <mock:shadow-root>
                     <span aria-describedby="ld-tooltip-585" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                       <ld-sr-only>
                         Info
@@ -3797,7 +3709,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
               </div>
             </button>
           </mock:shadow-root>
-          Computational complexity theory
+          Automata theory
         </ld-sidenav-navitem>
         <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
           <mock:shadow-root>
@@ -3841,6 +3753,94 @@ exports[`ld-sidenav collapses to narrow 1`] = `
               </div>
             </button>
           </mock:shadow-root>
+          Computability theory
+        </ld-sidenav-navitem>
+        <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
+          <mock:shadow-root>
+            <button class="ld-sidenav-navitem ld-sidenav-navitem--collapsed ld-sidenav-navitem--secondary" part="navitem focusable">
+              <div class="ld-sidenav-navitem__bg" part="bg">
+                <div class="ld-sidenav-navitem__bg-left"></div>
+                <div class="ld-sidenav-navitem__bg-center"></div>
+                <div class="ld-sidenav-navitem__bg-right"></div>
+              </div>
+              <div class="ld-sidenav-navitem__dot" part="dot"></div>
+              <div class="ld-sidenav-navitem__slot-container-icon" part="slot-container-icon" role="presentation">
+                <slot name="icon"></slot>
+                <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
+                  <mock:shadow-root>
+                    <span aria-describedby="ld-tooltip-587" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                      <ld-sr-only>
+                        Info
+                      </ld-sr-only>
+                      <slot name="trigger">
+                        <svg class="ld-tooltip__icon" fill="none" part="icon" viewBox="0 0 24 24">
+                          <path clip-rule="evenodd" d="M12 23C18.0751 23 23 18.0751 23 12C23 5.9249 18.0751 1 12 1C5.9249 1 1 5.9249 1 12C1 18.0751 5.9249 23 12 23Z" fill="currentColor" fill-rule="evenodd"></path>
+                          <path clip-rule="evenodd" d="M11.9996 8.6477C12.9254 8.6477 13.6758 7.8973 13.6758 6.9715C13.6758 6.0458 12.9254 5.2953 11.9996 5.2953C11.0739 5.2953 10.3235 6.0458 10.3235 6.9715C10.3235 7.8973 11.0739 8.6477 11.9996 8.6477ZM10.8453 17.8038C11.1932 18.1517 11.6736 18.3256 12.2865 18.3256H13.4545C13.6864 18.3256 13.8023 18.2263 13.8023 18.0275V12.2873C13.8023 11.6744 13.6284 11.1939 13.2805 10.8461C12.9326 10.4982 12.4522 10.3242 11.8393 10.3242H10.6713C10.4394 10.3242 10.3235 10.4236 10.3235 10.6224V16.3626C10.3235 16.9755 10.4974 17.456 10.8453 17.8038Z" fill="var(--ld-col-wht)" fill-rule="evenodd"></path>
+                        </svg>
+                      </slot>
+                    </span>
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-587" part="popper" size="sm" triggertype="hover">
+                      <slot></slot>
+                    </ld-tooltip-popper>
+                  </mock:shadow-root>
+                  <div class="ld-sidenav-navitem__tooltip-trigger" slot="trigger"></div>
+                  <div style="display: grid; grid-auto-flow: column; align-items: center;">
+                    <ld-typo></ld-typo>
+                  </div>
+                </ld-tooltip>
+              </div>
+              <div class="ld-sidenav-navitem__slot-container" part="slot-container">
+                <slot></slot>
+              </div>
+              <div class="ld-sidenav-navitem__slot-icon-secondary-container">
+                <slot name="icon-secondary"></slot>
+              </div>
+            </button>
+          </mock:shadow-root>
+          Computational complexity theory
+        </ld-sidenav-navitem>
+        <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
+          <mock:shadow-root>
+            <button class="ld-sidenav-navitem ld-sidenav-navitem--collapsed ld-sidenav-navitem--secondary" part="navitem focusable">
+              <div class="ld-sidenav-navitem__bg" part="bg">
+                <div class="ld-sidenav-navitem__bg-left"></div>
+                <div class="ld-sidenav-navitem__bg-center"></div>
+                <div class="ld-sidenav-navitem__bg-right"></div>
+              </div>
+              <div class="ld-sidenav-navitem__dot" part="dot"></div>
+              <div class="ld-sidenav-navitem__slot-container-icon" part="slot-container-icon" role="presentation">
+                <slot name="icon"></slot>
+                <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
+                  <mock:shadow-root>
+                    <span aria-describedby="ld-tooltip-588" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                      <ld-sr-only>
+                        Info
+                      </ld-sr-only>
+                      <slot name="trigger">
+                        <svg class="ld-tooltip__icon" fill="none" part="icon" viewBox="0 0 24 24">
+                          <path clip-rule="evenodd" d="M12 23C18.0751 23 23 18.0751 23 12C23 5.9249 18.0751 1 12 1C5.9249 1 1 5.9249 1 12C1 18.0751 5.9249 23 12 23Z" fill="currentColor" fill-rule="evenodd"></path>
+                          <path clip-rule="evenodd" d="M11.9996 8.6477C12.9254 8.6477 13.6758 7.8973 13.6758 6.9715C13.6758 6.0458 12.9254 5.2953 11.9996 5.2953C11.0739 5.2953 10.3235 6.0458 10.3235 6.9715C10.3235 7.8973 11.0739 8.6477 11.9996 8.6477ZM10.8453 17.8038C11.1932 18.1517 11.6736 18.3256 12.2865 18.3256H13.4545C13.6864 18.3256 13.8023 18.2263 13.8023 18.0275V12.2873C13.8023 11.6744 13.6284 11.1939 13.2805 10.8461C12.9326 10.4982 12.4522 10.3242 11.8393 10.3242H10.6713C10.4394 10.3242 10.3235 10.4236 10.3235 10.6224V16.3626C10.3235 16.9755 10.4974 17.456 10.8453 17.8038Z" fill="var(--ld-col-wht)" fill-rule="evenodd"></path>
+                        </svg>
+                      </slot>
+                    </span>
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-588" part="popper" size="sm" triggertype="hover">
+                      <slot></slot>
+                    </ld-tooltip-popper>
+                  </mock:shadow-root>
+                  <div class="ld-sidenav-navitem__tooltip-trigger" slot="trigger"></div>
+                  <div style="display: grid; grid-auto-flow: column; align-items: center;">
+                    <ld-typo></ld-typo>
+                  </div>
+                </ld-tooltip>
+              </div>
+              <div class="ld-sidenav-navitem__slot-container" part="slot-container">
+                <slot></slot>
+              </div>
+              <div class="ld-sidenav-navitem__slot-icon-secondary-container">
+                <slot name="icon-secondary"></slot>
+              </div>
+            </button>
+          </mock:shadow-root>
           Quantum computing theory
         </ld-sidenav-navitem>
       </ld-sidenav-subnav>
@@ -3861,7 +3861,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
             </span>
             <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
               <mock:shadow-root>
-                <span aria-describedby="ld-tooltip-519" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                <span aria-describedby="ld-tooltip-521" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                   <ld-sr-only>
                     Info
                   </ld-sr-only>
@@ -3872,7 +3872,7 @@ exports[`ld-sidenav collapses to narrow 1`] = `
                     </svg>
                   </slot>
                 </span>
-                <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-519" part="popper" size="sm" triggertype="hover">
+                <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-521" part="popper" size="sm" triggertype="hover">
                   <slot></slot>
                 </ld-tooltip-popper>
               </mock:shadow-root>
@@ -3976,7 +3976,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
     <mock:shadow-root>
       <ld-tooltip show-delay="1000">
         <mock:shadow-root>
-          <span aria-describedby="ld-tooltip-1163" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+          <span aria-describedby="ld-tooltip-1165" class="ld-tooltip__trigger" part="trigger focusable" type="button">
             <ld-sr-only>
               Info
             </ld-sr-only>
@@ -3987,7 +3987,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
               </svg>
             </slot>
           </span>
-          <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1163" part="popper" size="sm" triggertype="hover">
+          <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1165" part="popper" size="sm" triggertype="hover">
             <slot></slot>
           </ld-tooltip-popper>
         </mock:shadow-root>
@@ -4040,7 +4040,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
       <mock:shadow-root>
         <ld-tooltip class="ld-sidenav-header__tooltip" show-delay="1000">
           <mock:shadow-root>
-            <span aria-describedby="ld-tooltip-1164" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+            <span aria-describedby="ld-tooltip-1166" class="ld-tooltip__trigger" part="trigger focusable" type="button">
               <ld-sr-only>
                 Info
               </ld-sr-only>
@@ -4051,7 +4051,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
                 </svg>
               </slot>
             </span>
-            <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1164" part="popper" size="sm" triggertype="hover">
+            <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1166" part="popper" size="sm" triggertype="hover">
               <slot></slot>
             </ld-tooltip-popper>
           </mock:shadow-root>
@@ -4117,7 +4117,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
               </span>
               <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                 <mock:shadow-root>
-                  <span aria-describedby="ld-tooltip-1166" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                  <span aria-describedby="ld-tooltip-1168" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                     <ld-sr-only>
                       Info
                     </ld-sr-only>
@@ -4128,7 +4128,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
                       </svg>
                     </slot>
                   </span>
-                  <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1166" part="popper" size="sm" triggertype="hover">
+                  <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1168" part="popper" size="sm" triggertype="hover">
                     <slot></slot>
                   </ld-tooltip-popper>
                 </mock:shadow-root>
@@ -4237,7 +4237,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
                 </span>
                 <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                   <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-1168" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                    <span aria-describedby="ld-tooltip-1170" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                       <ld-sr-only>
                         Info
                       </ld-sr-only>
@@ -4248,7 +4248,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
                         </svg>
                       </slot>
                     </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1168" part="popper" size="sm" triggertype="hover">
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1170" part="popper" size="sm" triggertype="hover">
                       <slot></slot>
                     </ld-tooltip-popper>
                   </mock:shadow-root>
@@ -4271,94 +4271,6 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
           Mathematical foundations
         </ld-sidenav-navitem>
         <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -0px;">
-          <mock:shadow-root>
-            <button class="ld-sidenav-navitem ld-sidenav-navitem--collapsed ld-sidenav-navitem--in-accordion ld-sidenav-navitem--secondary" part="navitem focusable">
-              <div class="ld-sidenav-navitem__bg" part="bg">
-                <div class="ld-sidenav-navitem__bg-left"></div>
-                <div class="ld-sidenav-navitem__bg-center"></div>
-                <div class="ld-sidenav-navitem__bg-right"></div>
-              </div>
-              <div class="ld-sidenav-navitem__dot" part="dot"></div>
-              <div class="ld-sidenav-navitem__slot-container-icon" part="slot-container-icon" role="presentation">
-                <slot name="icon"></slot>
-                <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
-                  <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-1169" class="ld-tooltip__trigger" part="trigger focusable" type="button">
-                      <ld-sr-only>
-                        Info
-                      </ld-sr-only>
-                      <slot name="trigger">
-                        <svg class="ld-tooltip__icon" fill="none" part="icon" viewBox="0 0 24 24">
-                          <path clip-rule="evenodd" d="M12 23C18.0751 23 23 18.0751 23 12C23 5.9249 18.0751 1 12 1C5.9249 1 1 5.9249 1 12C1 18.0751 5.9249 23 12 23Z" fill="currentColor" fill-rule="evenodd"></path>
-                          <path clip-rule="evenodd" d="M11.9996 8.6477C12.9254 8.6477 13.6758 7.8973 13.6758 6.9715C13.6758 6.0458 12.9254 5.2953 11.9996 5.2953C11.0739 5.2953 10.3235 6.0458 10.3235 6.9715C10.3235 7.8973 11.0739 8.6477 11.9996 8.6477ZM10.8453 17.8038C11.1932 18.1517 11.6736 18.3256 12.2865 18.3256H13.4545C13.6864 18.3256 13.8023 18.2263 13.8023 18.0275V12.2873C13.8023 11.6744 13.6284 11.1939 13.2805 10.8461C12.9326 10.4982 12.4522 10.3242 11.8393 10.3242H10.6713C10.4394 10.3242 10.3235 10.4236 10.3235 10.6224V16.3626C10.3235 16.9755 10.4974 17.456 10.8453 17.8038Z" fill="var(--ld-col-wht)" fill-rule="evenodd"></path>
-                        </svg>
-                      </slot>
-                    </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1169" part="popper" size="sm" triggertype="hover">
-                      <slot></slot>
-                    </ld-tooltip-popper>
-                  </mock:shadow-root>
-                  <div class="ld-sidenav-navitem__tooltip-trigger" slot="trigger"></div>
-                  <div style="display: grid; grid-auto-flow: column; align-items: center;">
-                    <ld-typo></ld-typo>
-                  </div>
-                </ld-tooltip>
-              </div>
-              <div class="ld-sidenav-navitem__slot-container" part="slot-container">
-                <slot></slot>
-              </div>
-              <div class="ld-sidenav-navitem__slot-icon-secondary-container">
-                <slot name="icon-secondary"></slot>
-              </div>
-            </button>
-          </mock:shadow-root>
-          Coding theory
-        </ld-sidenav-navitem>
-        <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
-          <mock:shadow-root>
-            <button class="ld-sidenav-navitem ld-sidenav-navitem--collapsed ld-sidenav-navitem--in-accordion ld-sidenav-navitem--secondary" part="navitem focusable">
-              <div class="ld-sidenav-navitem__bg" part="bg">
-                <div class="ld-sidenav-navitem__bg-left"></div>
-                <div class="ld-sidenav-navitem__bg-center"></div>
-                <div class="ld-sidenav-navitem__bg-right"></div>
-              </div>
-              <div class="ld-sidenav-navitem__dot" part="dot"></div>
-              <div class="ld-sidenav-navitem__slot-container-icon" part="slot-container-icon" role="presentation">
-                <slot name="icon"></slot>
-                <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
-                  <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-1170" class="ld-tooltip__trigger" part="trigger focusable" type="button">
-                      <ld-sr-only>
-                        Info
-                      </ld-sr-only>
-                      <slot name="trigger">
-                        <svg class="ld-tooltip__icon" fill="none" part="icon" viewBox="0 0 24 24">
-                          <path clip-rule="evenodd" d="M12 23C18.0751 23 23 18.0751 23 12C23 5.9249 18.0751 1 12 1C5.9249 1 1 5.9249 1 12C1 18.0751 5.9249 23 12 23Z" fill="currentColor" fill-rule="evenodd"></path>
-                          <path clip-rule="evenodd" d="M11.9996 8.6477C12.9254 8.6477 13.6758 7.8973 13.6758 6.9715C13.6758 6.0458 12.9254 5.2953 11.9996 5.2953C11.0739 5.2953 10.3235 6.0458 10.3235 6.9715C10.3235 7.8973 11.0739 8.6477 11.9996 8.6477ZM10.8453 17.8038C11.1932 18.1517 11.6736 18.3256 12.2865 18.3256H13.4545C13.6864 18.3256 13.8023 18.2263 13.8023 18.0275V12.2873C13.8023 11.6744 13.6284 11.1939 13.2805 10.8461C12.9326 10.4982 12.4522 10.3242 11.8393 10.3242H10.6713C10.4394 10.3242 10.3235 10.4236 10.3235 10.6224V16.3626C10.3235 16.9755 10.4974 17.456 10.8453 17.8038Z" fill="var(--ld-col-wht)" fill-rule="evenodd"></path>
-                        </svg>
-                      </slot>
-                    </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1170" part="popper" size="sm" triggertype="hover">
-                      <slot></slot>
-                    </ld-tooltip-popper>
-                  </mock:shadow-root>
-                  <div class="ld-sidenav-navitem__tooltip-trigger" slot="trigger"></div>
-                  <div style="display: grid; grid-auto-flow: column; align-items: center;">
-                    <ld-typo></ld-typo>
-                  </div>
-                </ld-tooltip>
-              </div>
-              <div class="ld-sidenav-navitem__slot-container" part="slot-container">
-                <slot></slot>
-              </div>
-              <div class="ld-sidenav-navitem__slot-icon-secondary-container">
-                <slot name="icon-secondary"></slot>
-              </div>
-            </button>
-          </mock:shadow-root>
-          Game theory
-        </ld-sidenav-navitem>
-        <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
           <mock:shadow-root>
             <button class="ld-sidenav-navitem ld-sidenav-navitem--collapsed ld-sidenav-navitem--in-accordion ld-sidenav-navitem--secondary" part="navitem focusable">
               <div class="ld-sidenav-navitem__bg" part="bg">
@@ -4400,7 +4312,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
               </div>
             </button>
           </mock:shadow-root>
-          Discrete Mathematics
+          Coding theory
         </ld-sidenav-navitem>
         <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
           <mock:shadow-root>
@@ -4444,7 +4356,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
               </div>
             </button>
           </mock:shadow-root>
-          Graph theory
+          Game theory
         </ld-sidenav-navitem>
         <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
           <mock:shadow-root>
@@ -4488,7 +4400,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
               </div>
             </button>
           </mock:shadow-root>
-          Mathematical logic
+          Discrete Mathematics
         </ld-sidenav-navitem>
         <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
           <mock:shadow-root>
@@ -4515,6 +4427,94 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
                       </slot>
                     </span>
                     <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1174" part="popper" size="sm" triggertype="hover">
+                      <slot></slot>
+                    </ld-tooltip-popper>
+                  </mock:shadow-root>
+                  <div class="ld-sidenav-navitem__tooltip-trigger" slot="trigger"></div>
+                  <div style="display: grid; grid-auto-flow: column; align-items: center;">
+                    <ld-typo></ld-typo>
+                  </div>
+                </ld-tooltip>
+              </div>
+              <div class="ld-sidenav-navitem__slot-container" part="slot-container">
+                <slot></slot>
+              </div>
+              <div class="ld-sidenav-navitem__slot-icon-secondary-container">
+                <slot name="icon-secondary"></slot>
+              </div>
+            </button>
+          </mock:shadow-root>
+          Graph theory
+        </ld-sidenav-navitem>
+        <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
+          <mock:shadow-root>
+            <button class="ld-sidenav-navitem ld-sidenav-navitem--collapsed ld-sidenav-navitem--in-accordion ld-sidenav-navitem--secondary" part="navitem focusable">
+              <div class="ld-sidenav-navitem__bg" part="bg">
+                <div class="ld-sidenav-navitem__bg-left"></div>
+                <div class="ld-sidenav-navitem__bg-center"></div>
+                <div class="ld-sidenav-navitem__bg-right"></div>
+              </div>
+              <div class="ld-sidenav-navitem__dot" part="dot"></div>
+              <div class="ld-sidenav-navitem__slot-container-icon" part="slot-container-icon" role="presentation">
+                <slot name="icon"></slot>
+                <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
+                  <mock:shadow-root>
+                    <span aria-describedby="ld-tooltip-1175" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                      <ld-sr-only>
+                        Info
+                      </ld-sr-only>
+                      <slot name="trigger">
+                        <svg class="ld-tooltip__icon" fill="none" part="icon" viewBox="0 0 24 24">
+                          <path clip-rule="evenodd" d="M12 23C18.0751 23 23 18.0751 23 12C23 5.9249 18.0751 1 12 1C5.9249 1 1 5.9249 1 12C1 18.0751 5.9249 23 12 23Z" fill="currentColor" fill-rule="evenodd"></path>
+                          <path clip-rule="evenodd" d="M11.9996 8.6477C12.9254 8.6477 13.6758 7.8973 13.6758 6.9715C13.6758 6.0458 12.9254 5.2953 11.9996 5.2953C11.0739 5.2953 10.3235 6.0458 10.3235 6.9715C10.3235 7.8973 11.0739 8.6477 11.9996 8.6477ZM10.8453 17.8038C11.1932 18.1517 11.6736 18.3256 12.2865 18.3256H13.4545C13.6864 18.3256 13.8023 18.2263 13.8023 18.0275V12.2873C13.8023 11.6744 13.6284 11.1939 13.2805 10.8461C12.9326 10.4982 12.4522 10.3242 11.8393 10.3242H10.6713C10.4394 10.3242 10.3235 10.4236 10.3235 10.6224V16.3626C10.3235 16.9755 10.4974 17.456 10.8453 17.8038Z" fill="var(--ld-col-wht)" fill-rule="evenodd"></path>
+                        </svg>
+                      </slot>
+                    </span>
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1175" part="popper" size="sm" triggertype="hover">
+                      <slot></slot>
+                    </ld-tooltip-popper>
+                  </mock:shadow-root>
+                  <div class="ld-sidenav-navitem__tooltip-trigger" slot="trigger"></div>
+                  <div style="display: grid; grid-auto-flow: column; align-items: center;">
+                    <ld-typo></ld-typo>
+                  </div>
+                </ld-tooltip>
+              </div>
+              <div class="ld-sidenav-navitem__slot-container" part="slot-container">
+                <slot></slot>
+              </div>
+              <div class="ld-sidenav-navitem__slot-icon-secondary-container">
+                <slot name="icon-secondary"></slot>
+              </div>
+            </button>
+          </mock:shadow-root>
+          Mathematical logic
+        </ld-sidenav-navitem>
+        <ld-sidenav-navitem mode="secondary" style="--ld-slider-navitem-move-up: -NaNpx;">
+          <mock:shadow-root>
+            <button class="ld-sidenav-navitem ld-sidenav-navitem--collapsed ld-sidenav-navitem--in-accordion ld-sidenav-navitem--secondary" part="navitem focusable">
+              <div class="ld-sidenav-navitem__bg" part="bg">
+                <div class="ld-sidenav-navitem__bg-left"></div>
+                <div class="ld-sidenav-navitem__bg-center"></div>
+                <div class="ld-sidenav-navitem__bg-right"></div>
+              </div>
+              <div class="ld-sidenav-navitem__dot" part="dot"></div>
+              <div class="ld-sidenav-navitem__slot-container-icon" part="slot-container-icon" role="presentation">
+                <slot name="icon"></slot>
+                <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
+                  <mock:shadow-root>
+                    <span aria-describedby="ld-tooltip-1176" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                      <ld-sr-only>
+                        Info
+                      </ld-sr-only>
+                      <slot name="trigger">
+                        <svg class="ld-tooltip__icon" fill="none" part="icon" viewBox="0 0 24 24">
+                          <path clip-rule="evenodd" d="M12 23C18.0751 23 23 18.0751 23 12C23 5.9249 18.0751 1 12 1C5.9249 1 1 5.9249 1 12C1 18.0751 5.9249 23 12 23Z" fill="currentColor" fill-rule="evenodd"></path>
+                          <path clip-rule="evenodd" d="M11.9996 8.6477C12.9254 8.6477 13.6758 7.8973 13.6758 6.9715C13.6758 6.0458 12.9254 5.2953 11.9996 5.2953C11.0739 5.2953 10.3235 6.0458 10.3235 6.9715C10.3235 7.8973 11.0739 8.6477 11.9996 8.6477ZM10.8453 17.8038C11.1932 18.1517 11.6736 18.3256 12.2865 18.3256H13.4545C13.6864 18.3256 13.8023 18.2263 13.8023 18.0275V12.2873C13.8023 11.6744 13.6284 11.1939 13.2805 10.8461C12.9326 10.4982 12.4522 10.3242 11.8393 10.3242H10.6713C10.4394 10.3242 10.3235 10.4236 10.3235 10.6224V16.3626C10.3235 16.9755 10.4974 17.456 10.8453 17.8038Z" fill="var(--ld-col-wht)" fill-rule="evenodd"></path>
+                        </svg>
+                      </slot>
+                    </span>
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1176" part="popper" size="sm" triggertype="hover">
                       <slot></slot>
                     </ld-tooltip-popper>
                   </mock:shadow-root>
@@ -4592,7 +4592,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
                 </span>
                 <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                   <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-1175" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                    <span aria-describedby="ld-tooltip-1177" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                       <ld-sr-only>
                         Info
                       </ld-sr-only>
@@ -4603,7 +4603,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
                         </svg>
                       </slot>
                     </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1175" part="popper" size="sm" triggertype="hover">
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1177" part="popper" size="sm" triggertype="hover">
                       <slot></slot>
                     </ld-tooltip-popper>
                   </mock:shadow-root>
@@ -4638,7 +4638,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
                 <slot name="icon"></slot>
                 <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                   <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-1176" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                    <span aria-describedby="ld-tooltip-1178" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                       <ld-sr-only>
                         Info
                       </ld-sr-only>
@@ -4649,7 +4649,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
                         </svg>
                       </slot>
                     </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1176" part="popper" size="sm" triggertype="hover">
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1178" part="popper" size="sm" triggertype="hover">
                       <slot></slot>
                     </ld-tooltip-popper>
                   </mock:shadow-root>
@@ -4682,7 +4682,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
                 <slot name="icon"></slot>
                 <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                   <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-1177" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                    <span aria-describedby="ld-tooltip-1179" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                       <ld-sr-only>
                         Info
                       </ld-sr-only>
@@ -4693,7 +4693,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
                         </svg>
                       </slot>
                     </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1177" part="popper" size="sm" triggertype="hover">
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1179" part="popper" size="sm" triggertype="hover">
                       <slot></slot>
                     </ld-tooltip-popper>
                   </mock:shadow-root>
@@ -4730,7 +4730,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
               </span>
               <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                 <mock:shadow-root>
-                  <span aria-describedby="ld-tooltip-1167" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                  <span aria-describedby="ld-tooltip-1169" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                     <ld-sr-only>
                       Info
                     </ld-sr-only>
@@ -4741,7 +4741,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
                       </svg>
                     </slot>
                   </span>
-                  <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1167" part="popper" size="sm" triggertype="hover">
+                  <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1169" part="popper" size="sm" triggertype="hover">
                     <slot></slot>
                   </ld-tooltip-popper>
                 </mock:shadow-root>
@@ -4822,7 +4822,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
                 </span>
                 <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                   <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-1178" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                    <span aria-describedby="ld-tooltip-1180" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                       <ld-sr-only>
                         Info
                       </ld-sr-only>
@@ -4833,7 +4833,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
                         </svg>
                       </slot>
                     </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1178" part="popper" size="sm" triggertype="hover">
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1180" part="popper" size="sm" triggertype="hover">
                       <slot></slot>
                     </ld-tooltip-popper>
                   </mock:shadow-root>
@@ -4868,7 +4868,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
                 <slot name="icon"></slot>
                 <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                   <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-1179" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                    <span aria-describedby="ld-tooltip-1181" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                       <ld-sr-only>
                         Info
                       </ld-sr-only>
@@ -4879,7 +4879,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
                         </svg>
                       </slot>
                     </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1179" part="popper" size="sm" triggertype="hover">
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1181" part="popper" size="sm" triggertype="hover">
                       <slot></slot>
                     </ld-tooltip-popper>
                   </mock:shadow-root>
@@ -4912,7 +4912,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
                 <slot name="icon"></slot>
                 <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                   <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-1180" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                    <span aria-describedby="ld-tooltip-1182" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                       <ld-sr-only>
                         Info
                       </ld-sr-only>
@@ -4923,7 +4923,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
                         </svg>
                       </slot>
                     </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1180" part="popper" size="sm" triggertype="hover">
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1182" part="popper" size="sm" triggertype="hover">
                       <slot></slot>
                     </ld-tooltip-popper>
                   </mock:shadow-root>
@@ -4956,7 +4956,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
                 <slot name="icon"></slot>
                 <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                   <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-1181" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                    <span aria-describedby="ld-tooltip-1183" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                       <ld-sr-only>
                         Info
                       </ld-sr-only>
@@ -4967,7 +4967,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
                         </svg>
                       </slot>
                     </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1181" part="popper" size="sm" triggertype="hover">
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1183" part="popper" size="sm" triggertype="hover">
                       <slot></slot>
                     </ld-tooltip-popper>
                   </mock:shadow-root>
@@ -5031,7 +5031,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
                 <slot name="icon"></slot>
                 <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                   <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-1182" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                    <span aria-describedby="ld-tooltip-1184" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                       <ld-sr-only>
                         Info
                       </ld-sr-only>
@@ -5042,7 +5042,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
                         </svg>
                       </slot>
                     </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1182" part="popper" size="sm" triggertype="hover">
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1184" part="popper" size="sm" triggertype="hover">
                       <slot></slot>
                     </ld-tooltip-popper>
                   </mock:shadow-root>
@@ -5075,7 +5075,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
                 <slot name="icon"></slot>
                 <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                   <mock:shadow-root>
-                    <span aria-describedby="ld-tooltip-1183" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                    <span aria-describedby="ld-tooltip-1185" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                       <ld-sr-only>
                         Info
                       </ld-sr-only>
@@ -5086,7 +5086,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
                         </svg>
                       </slot>
                     </span>
-                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1183" part="popper" size="sm" triggertype="hover">
+                    <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1185" part="popper" size="sm" triggertype="hover">
                       <slot></slot>
                     </ld-tooltip-popper>
                   </mock:shadow-root>
@@ -5163,7 +5163,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
                   </span>
                   <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                     <mock:shadow-root>
-                      <span aria-describedby="ld-tooltip-1184" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                      <span aria-describedby="ld-tooltip-1186" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                         <ld-sr-only>
                           Info
                         </ld-sr-only>
@@ -5174,7 +5174,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
                           </svg>
                         </slot>
                       </span>
-                      <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1184" part="popper" size="sm" triggertype="hover">
+                      <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1186" part="popper" size="sm" triggertype="hover">
                         <slot></slot>
                       </ld-tooltip-popper>
                     </mock:shadow-root>
@@ -5250,94 +5250,6 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
                     <slot name="icon"></slot>
                     <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                       <mock:shadow-root>
-                        <span aria-describedby="ld-tooltip-1186" class="ld-tooltip__trigger" part="trigger focusable" type="button">
-                          <ld-sr-only>
-                            Info
-                          </ld-sr-only>
-                          <slot name="trigger">
-                            <svg class="ld-tooltip__icon" fill="none" part="icon" viewBox="0 0 24 24">
-                              <path clip-rule="evenodd" d="M12 23C18.0751 23 23 18.0751 23 12C23 5.9249 18.0751 1 12 1C5.9249 1 1 5.9249 1 12C1 18.0751 5.9249 23 12 23Z" fill="currentColor" fill-rule="evenodd"></path>
-                              <path clip-rule="evenodd" d="M11.9996 8.6477C12.9254 8.6477 13.6758 7.8973 13.6758 6.9715C13.6758 6.0458 12.9254 5.2953 11.9996 5.2953C11.0739 5.2953 10.3235 6.0458 10.3235 6.9715C10.3235 7.8973 11.0739 8.6477 11.9996 8.6477ZM10.8453 17.8038C11.1932 18.1517 11.6736 18.3256 12.2865 18.3256H13.4545C13.6864 18.3256 13.8023 18.2263 13.8023 18.0275V12.2873C13.8023 11.6744 13.6284 11.1939 13.2805 10.8461C12.9326 10.4982 12.4522 10.3242 11.8393 10.3242H10.6713C10.4394 10.3242 10.3235 10.4236 10.3235 10.6224V16.3626C10.3235 16.9755 10.4974 17.456 10.8453 17.8038Z" fill="var(--ld-col-wht)" fill-rule="evenodd"></path>
-                            </svg>
-                          </slot>
-                        </span>
-                        <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1186" part="popper" size="sm" triggertype="hover">
-                          <slot></slot>
-                        </ld-tooltip-popper>
-                      </mock:shadow-root>
-                      <div class="ld-sidenav-navitem__tooltip-trigger" slot="trigger"></div>
-                      <div style="display: grid; grid-auto-flow: column; align-items: center;">
-                        <ld-typo></ld-typo>
-                      </div>
-                    </ld-tooltip>
-                  </div>
-                  <div class="ld-sidenav-navitem__slot-container" part="slot-container">
-                    <slot></slot>
-                  </div>
-                  <div class="ld-sidenav-navitem__slot-icon-secondary-container">
-                    <slot name="icon-secondary"></slot>
-                  </div>
-                </button>
-              </mock:shadow-root>
-              Machine learning
-            </ld-sidenav-navitem>
-            <ld-sidenav-navitem mode="tertiary" style="--ld-slider-navitem-move-up: -NaNpx;">
-              <mock:shadow-root>
-                <button class="ld-sidenav-navitem ld-sidenav-navitem--collapsed ld-sidenav-navitem--in-accordion ld-sidenav-navitem--tertiary" part="navitem focusable">
-                  <div class="ld-sidenav-navitem__bg" part="bg">
-                    <div class="ld-sidenav-navitem__bg-left"></div>
-                    <div class="ld-sidenav-navitem__bg-center"></div>
-                    <div class="ld-sidenav-navitem__bg-right"></div>
-                  </div>
-                  <div class="ld-sidenav-navitem__dot" part="dot"></div>
-                  <div class="ld-sidenav-navitem__slot-container-icon" part="slot-container-icon" role="presentation">
-                    <slot name="icon"></slot>
-                    <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
-                      <mock:shadow-root>
-                        <span aria-describedby="ld-tooltip-1187" class="ld-tooltip__trigger" part="trigger focusable" type="button">
-                          <ld-sr-only>
-                            Info
-                          </ld-sr-only>
-                          <slot name="trigger">
-                            <svg class="ld-tooltip__icon" fill="none" part="icon" viewBox="0 0 24 24">
-                              <path clip-rule="evenodd" d="M12 23C18.0751 23 23 18.0751 23 12C23 5.9249 18.0751 1 12 1C5.9249 1 1 5.9249 1 12C1 18.0751 5.9249 23 12 23Z" fill="currentColor" fill-rule="evenodd"></path>
-                              <path clip-rule="evenodd" d="M11.9996 8.6477C12.9254 8.6477 13.6758 7.8973 13.6758 6.9715C13.6758 6.0458 12.9254 5.2953 11.9996 5.2953C11.0739 5.2953 10.3235 6.0458 10.3235 6.9715C10.3235 7.8973 11.0739 8.6477 11.9996 8.6477ZM10.8453 17.8038C11.1932 18.1517 11.6736 18.3256 12.2865 18.3256H13.4545C13.6864 18.3256 13.8023 18.2263 13.8023 18.0275V12.2873C13.8023 11.6744 13.6284 11.1939 13.2805 10.8461C12.9326 10.4982 12.4522 10.3242 11.8393 10.3242H10.6713C10.4394 10.3242 10.3235 10.4236 10.3235 10.6224V16.3626C10.3235 16.9755 10.4974 17.456 10.8453 17.8038Z" fill="var(--ld-col-wht)" fill-rule="evenodd"></path>
-                            </svg>
-                          </slot>
-                        </span>
-                        <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1187" part="popper" size="sm" triggertype="hover">
-                          <slot></slot>
-                        </ld-tooltip-popper>
-                      </mock:shadow-root>
-                      <div class="ld-sidenav-navitem__tooltip-trigger" slot="trigger"></div>
-                      <div style="display: grid; grid-auto-flow: column; align-items: center;">
-                        <ld-typo></ld-typo>
-                      </div>
-                    </ld-tooltip>
-                  </div>
-                  <div class="ld-sidenav-navitem__slot-container" part="slot-container">
-                    <slot></slot>
-                  </div>
-                  <div class="ld-sidenav-navitem__slot-icon-secondary-container">
-                    <slot name="icon-secondary"></slot>
-                  </div>
-                </button>
-              </mock:shadow-root>
-              Supervised learning
-            </ld-sidenav-navitem>
-            <ld-sidenav-navitem mode="tertiary" style="--ld-slider-navitem-move-up: -NaNpx;">
-              <mock:shadow-root>
-                <button class="ld-sidenav-navitem ld-sidenav-navitem--collapsed ld-sidenav-navitem--in-accordion ld-sidenav-navitem--tertiary" part="navitem focusable">
-                  <div class="ld-sidenav-navitem__bg" part="bg">
-                    <div class="ld-sidenav-navitem__bg-left"></div>
-                    <div class="ld-sidenav-navitem__bg-center"></div>
-                    <div class="ld-sidenav-navitem__bg-right"></div>
-                  </div>
-                  <div class="ld-sidenav-navitem__dot" part="dot"></div>
-                  <div class="ld-sidenav-navitem__slot-container-icon" part="slot-container-icon" role="presentation">
-                    <slot name="icon"></slot>
-                    <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
-                      <mock:shadow-root>
                         <span aria-describedby="ld-tooltip-1188" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                           <ld-sr-only>
                             Info
@@ -5367,7 +5279,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
                   </div>
                 </button>
               </mock:shadow-root>
-              Unsupervised learning
+              Machine learning
             </ld-sidenav-navitem>
             <ld-sidenav-navitem mode="tertiary" style="--ld-slider-navitem-move-up: -NaNpx;">
               <mock:shadow-root>
@@ -5411,6 +5323,94 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
                   </div>
                 </button>
               </mock:shadow-root>
+              Supervised learning
+            </ld-sidenav-navitem>
+            <ld-sidenav-navitem mode="tertiary" style="--ld-slider-navitem-move-up: -NaNpx;">
+              <mock:shadow-root>
+                <button class="ld-sidenav-navitem ld-sidenav-navitem--collapsed ld-sidenav-navitem--in-accordion ld-sidenav-navitem--tertiary" part="navitem focusable">
+                  <div class="ld-sidenav-navitem__bg" part="bg">
+                    <div class="ld-sidenav-navitem__bg-left"></div>
+                    <div class="ld-sidenav-navitem__bg-center"></div>
+                    <div class="ld-sidenav-navitem__bg-right"></div>
+                  </div>
+                  <div class="ld-sidenav-navitem__dot" part="dot"></div>
+                  <div class="ld-sidenav-navitem__slot-container-icon" part="slot-container-icon" role="presentation">
+                    <slot name="icon"></slot>
+                    <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
+                      <mock:shadow-root>
+                        <span aria-describedby="ld-tooltip-1190" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                          <ld-sr-only>
+                            Info
+                          </ld-sr-only>
+                          <slot name="trigger">
+                            <svg class="ld-tooltip__icon" fill="none" part="icon" viewBox="0 0 24 24">
+                              <path clip-rule="evenodd" d="M12 23C18.0751 23 23 18.0751 23 12C23 5.9249 18.0751 1 12 1C5.9249 1 1 5.9249 1 12C1 18.0751 5.9249 23 12 23Z" fill="currentColor" fill-rule="evenodd"></path>
+                              <path clip-rule="evenodd" d="M11.9996 8.6477C12.9254 8.6477 13.6758 7.8973 13.6758 6.9715C13.6758 6.0458 12.9254 5.2953 11.9996 5.2953C11.0739 5.2953 10.3235 6.0458 10.3235 6.9715C10.3235 7.8973 11.0739 8.6477 11.9996 8.6477ZM10.8453 17.8038C11.1932 18.1517 11.6736 18.3256 12.2865 18.3256H13.4545C13.6864 18.3256 13.8023 18.2263 13.8023 18.0275V12.2873C13.8023 11.6744 13.6284 11.1939 13.2805 10.8461C12.9326 10.4982 12.4522 10.3242 11.8393 10.3242H10.6713C10.4394 10.3242 10.3235 10.4236 10.3235 10.6224V16.3626C10.3235 16.9755 10.4974 17.456 10.8453 17.8038Z" fill="var(--ld-col-wht)" fill-rule="evenodd"></path>
+                            </svg>
+                          </slot>
+                        </span>
+                        <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1190" part="popper" size="sm" triggertype="hover">
+                          <slot></slot>
+                        </ld-tooltip-popper>
+                      </mock:shadow-root>
+                      <div class="ld-sidenav-navitem__tooltip-trigger" slot="trigger"></div>
+                      <div style="display: grid; grid-auto-flow: column; align-items: center;">
+                        <ld-typo></ld-typo>
+                      </div>
+                    </ld-tooltip>
+                  </div>
+                  <div class="ld-sidenav-navitem__slot-container" part="slot-container">
+                    <slot></slot>
+                  </div>
+                  <div class="ld-sidenav-navitem__slot-icon-secondary-container">
+                    <slot name="icon-secondary"></slot>
+                  </div>
+                </button>
+              </mock:shadow-root>
+              Unsupervised learning
+            </ld-sidenav-navitem>
+            <ld-sidenav-navitem mode="tertiary" style="--ld-slider-navitem-move-up: -NaNpx;">
+              <mock:shadow-root>
+                <button class="ld-sidenav-navitem ld-sidenav-navitem--collapsed ld-sidenav-navitem--in-accordion ld-sidenav-navitem--tertiary" part="navitem focusable">
+                  <div class="ld-sidenav-navitem__bg" part="bg">
+                    <div class="ld-sidenav-navitem__bg-left"></div>
+                    <div class="ld-sidenav-navitem__bg-center"></div>
+                    <div class="ld-sidenav-navitem__bg-right"></div>
+                  </div>
+                  <div class="ld-sidenav-navitem__dot" part="dot"></div>
+                  <div class="ld-sidenav-navitem__slot-container-icon" part="slot-container-icon" role="presentation">
+                    <slot name="icon"></slot>
+                    <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
+                      <mock:shadow-root>
+                        <span aria-describedby="ld-tooltip-1191" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                          <ld-sr-only>
+                            Info
+                          </ld-sr-only>
+                          <slot name="trigger">
+                            <svg class="ld-tooltip__icon" fill="none" part="icon" viewBox="0 0 24 24">
+                              <path clip-rule="evenodd" d="M12 23C18.0751 23 23 18.0751 23 12C23 5.9249 18.0751 1 12 1C5.9249 1 1 5.9249 1 12C1 18.0751 5.9249 23 12 23Z" fill="currentColor" fill-rule="evenodd"></path>
+                              <path clip-rule="evenodd" d="M11.9996 8.6477C12.9254 8.6477 13.6758 7.8973 13.6758 6.9715C13.6758 6.0458 12.9254 5.2953 11.9996 5.2953C11.0739 5.2953 10.3235 6.0458 10.3235 6.9715C10.3235 7.8973 11.0739 8.6477 11.9996 8.6477ZM10.8453 17.8038C11.1932 18.1517 11.6736 18.3256 12.2865 18.3256H13.4545C13.6864 18.3256 13.8023 18.2263 13.8023 18.0275V12.2873C13.8023 11.6744 13.6284 11.1939 13.2805 10.8461C12.9326 10.4982 12.4522 10.3242 11.8393 10.3242H10.6713C10.4394 10.3242 10.3235 10.4236 10.3235 10.6224V16.3626C10.3235 16.9755 10.4974 17.456 10.8453 17.8038Z" fill="var(--ld-col-wht)" fill-rule="evenodd"></path>
+                            </svg>
+                          </slot>
+                        </span>
+                        <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1191" part="popper" size="sm" triggertype="hover">
+                          <slot></slot>
+                        </ld-tooltip-popper>
+                      </mock:shadow-root>
+                      <div class="ld-sidenav-navitem__tooltip-trigger" slot="trigger"></div>
+                      <div style="display: grid; grid-auto-flow: column; align-items: center;">
+                        <ld-typo></ld-typo>
+                      </div>
+                    </ld-tooltip>
+                  </div>
+                  <div class="ld-sidenav-navitem__slot-container" part="slot-container">
+                    <slot></slot>
+                  </div>
+                  <div class="ld-sidenav-navitem__slot-icon-secondary-container">
+                    <slot name="icon-secondary"></slot>
+                  </div>
+                </button>
+              </mock:shadow-root>
               Reinforcement learning
             </ld-sidenav-navitem>
           </ld-sidenav-accordion>
@@ -5427,7 +5427,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
                   <slot name="icon"></slot>
                   <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
                     <mock:shadow-root>
-                      <span aria-describedby="ld-tooltip-1185" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                      <span aria-describedby="ld-tooltip-1187" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                         <ld-sr-only>
                           Info
                         </ld-sr-only>
@@ -5438,7 +5438,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
                           </svg>
                         </slot>
                       </span>
-                      <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1185" part="popper" size="sm" triggertype="hover">
+                      <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1187" part="popper" size="sm" triggertype="hover">
                         <slot></slot>
                       </ld-tooltip-popper>
                     </mock:shadow-root>
@@ -5477,7 +5477,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
             </span>
             <ld-tooltip class="ld-sidenav-navitem__tooltip" show-delay="250">
               <mock:shadow-root>
-                <span aria-describedby="ld-tooltip-1165" class="ld-tooltip__trigger" part="trigger focusable" type="button">
+                <span aria-describedby="ld-tooltip-1167" class="ld-tooltip__trigger" part="trigger focusable" type="button">
                   <ld-sr-only>
                     Info
                   </ld-sr-only>
@@ -5488,7 +5488,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
                     </svg>
                   </slot>
                 </span>
-                <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1165" part="popper" size="sm" triggertype="hover">
+                <ld-tooltip-popper aria-hidden="true" arrow="" id="ld-tooltip-1167" part="popper" size="sm" triggertype="hover">
                   <slot></slot>
                 </ld-tooltip-popper>
               </mock:shadow-root>

--- a/src/liquid/components/ld-sidenav/test/ld-sidenav.spec.ts
+++ b/src/liquid/components/ld-sidenav/test/ld-sidenav.spec.ts
@@ -265,7 +265,7 @@ describe('ld-sidenav', () => {
 
     it('expands on mouse enter when narrow with explicit expand-trigger', async () => {
       const page = await newSpecPage({
-        components: [LdSidenav],
+        components: sidenavComponents,
         html: `
           <ld-sidenav collapsible collapsed narrow expand-trigger="mouseenter">
             <ld-sidenav-header href="#" slot="header">Computer Science</ld-sidenav-header>
@@ -1927,5 +1927,27 @@ describe('ld-sidenav', () => {
 
     expect(ldSidenav).not.toHaveClass('ld-sidenav--collapsible')
     expect(handler).toHaveBeenCalled()
+  })
+
+  it('updates collapsible state on sidenav header', async () => {
+    const page = await newSpecPage({
+      components: sidenavComponents,
+      html: `<ld-sidenav>
+        <ld-sidenav-header href="#" slot="header">Computer Science</ld-sidenav-header>
+      </ld-sidenav>`,
+    })
+    const ldSidenav = page.body.querySelector('ld-sidenav')
+    const ldSidenavHeader = ldSidenav.querySelector('ld-sidenav-header')
+
+    expect(
+      ldSidenavHeader.shadowRoot.querySelector('.ld-sidenav-header__toggle')
+    ).toBeNull()
+
+    ldSidenav.setAttribute('collapsible', 'true')
+    await page.waitForChanges()
+
+    expect(
+      ldSidenavHeader.shadowRoot.querySelector('.ld-sidenav-header__toggle')
+    ).not.toBeNull()
   })
 })


### PR DESCRIPTION
# Description

This PR fixes an issue where the sidenav header toggle is not updated if the sidenav collapsible prop is changed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
