### PR TITLE
fix: react output target as mjs with import injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "build:eleventy": "dotenv -e .env -- yarn eleventy",
     "build:stencil:components": "stencil build && shx mv tmp/web-components.html-data.json dist/web-components.html-data.json && shx rm -r tmp",
     "build:stencil:docs": "stencil build --config=stencil.config.docs.ts",
-    "build:stencil:react": "tsc -p tsconfig.react.json && (shx rm src/react.ts & shx rm -r src/react-component-lib)",
+    "build:stencil:react": "tsc -p tsconfig.react.json && (shx rm src/react.mts & shx rm -r src/react-component-lib)",
     "build:styles": "run-p build:styles:liquid:components build:styles:liquid:globals",
     "build:styles:liquid:components": "postcss 'src/liquid/components/**/*.css' --no-map -d dist/css/ && trash dist/css/liquid.css 'dist/css/*.shadow.css' ; cat dist/css/*.css > dist/css/liquid.css",
     "build:styles:liquid:globals": "postcss src/liquid/global/styles/global.css --no-map -o dist/css/liquid.global.css",

--- a/src/docs/pages/guides/react-bindings.md
+++ b/src/docs/pages/guides/react-bindings.md
@@ -16,12 +16,10 @@ Setting event listeners via `on<EventName>`-prop on Liquid Oxygen Web Components
 All you need to do is to import and use the React binding of a Liquid Oxygen component instead of using the web component directly.
 
 ```js
-import { LdButton } from '@emdgroup-liquid/liquid/dist/react'
+import { LdButton } from '@emdgroup-liquid/liquid/dist/react.mjs'
 
-export default ({ buttonProps }) => (
-  {/* ... */}
-  <LdButton {...buttonProps} />
-  {/* ... */}
+export default () => (
+  <LdButton>Click me</LdButton>
 )
 ```
 

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -10,7 +10,7 @@ export const config: Config = {
   outputTargets: [
     reactOutputTarget({
       componentCorePackage: '..',
-      proxiesFile: './src/react.ts',
+      proxiesFile: './src/react.mts',
       includeDefineCustomElements: true,
     }),
     {

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -46,6 +46,7 @@ export const config: Config = {
   extras: {
     cssVarsShim: false,
     dynamicImportShim: false,
+    experimentalImportInjection: true,
     shadowDomShim: false,
     safari10: false,
     scriptDataOpts: false,

--- a/tsconfig.react.json
+++ b/tsconfig.react.json
@@ -3,9 +3,8 @@
   "compilerOptions": {
     "declaration": true,
     "jsxFactory": "React.createElement",
-    "module": "commonjs",
     "outDir": "dist"
   },
-  "include": ["./src/react.ts"],
-  "exclude": ["node_modules", "./src/liquid/**/*.a11y.ts"]
+  "include": ["./src/react.mts"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
# Description

This PR resolves an issue where liquid react components are dynamically imported within a vite application.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] tested manually

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
