### PR TITLE
fix(ld-accordion): indicate expandable state when collapsed

### DIFF
--- a/src/liquid/components/ld-accordion/ld-accordion-toggle/ld-accordion-toggle.tsx
+++ b/src/liquid/components/ld-accordion/ld-accordion-toggle/ld-accordion-toggle.tsx
@@ -119,7 +119,7 @@ export class LdAccordionToggle implements InnerFocusable {
         part="trigger focusable"
         class="ld-accordion-toggle__trigger"
         aria-disabled={this.disabled ? 'true' : undefined}
-        aria-expanded={this.expanded ? 'true' : undefined}
+        aria-expanded={this.expanded ? 'true' : 'false'}
         aria-label={this.toggleLabel}
         onClick={this.handleToggleClick}
         ref={(el) => (this.btnRef = el as HTMLButtonElement)}
@@ -166,7 +166,7 @@ export class LdAccordionToggle implements InnerFocusable {
     ) : (
       <button
         aria-disabled={this.disabled ? 'true' : undefined}
-        aria-expanded={this.expanded ? 'true' : undefined}
+        aria-expanded={this.expanded ? 'true' : 'false'}
         class="ld-accordion-toggle__button"
         onClick={this.handleToggleClick}
         part="toggle focusable"

--- a/src/liquid/components/ld-accordion/test/__snapshots__/ld-accordion.spec.tsx.snap
+++ b/src/liquid/components/ld-accordion/test/__snapshots__/ld-accordion.spec.tsx.snap
@@ -44,7 +44,7 @@ exports[`ld-accordion renders 1`] = `
     </mock:shadow-root>
     <ld-accordion-toggle class="ld-accordion-toggle">
       <mock:shadow-root>
-        <button class="ld-accordion-toggle__button" part="toggle focusable">
+        <button aria-expanded="false" class="ld-accordion-toggle__button" part="toggle focusable">
           <div class="ld-accordion-toggle__content" part="content">
             <div class="ld-accordion-toggle__label" part="label">
               <div class="ld-accordion-toggle__label-content" part="label-content">
@@ -77,7 +77,7 @@ exports[`ld-accordion renders 1`] = `
     </mock:shadow-root>
     <ld-accordion-toggle class="ld-accordion-toggle">
       <mock:shadow-root>
-        <button aria-disabled="true" class="ld-accordion-toggle__button" part="toggle focusable">
+        <button aria-disabled="true" aria-expanded="false" class="ld-accordion-toggle__button" part="toggle focusable">
           <div class="ld-accordion-toggle__content" part="content">
             <div class="ld-accordion-toggle__label" part="label">
               <div class="ld-accordion-toggle__label-content" part="label-content">

--- a/src/liquid/components/ld-accordion/test/ld-accordion.spec.tsx
+++ b/src/liquid/components/ld-accordion/test/ld-accordion.spec.tsx
@@ -139,11 +139,8 @@ describe('ld-accordion', () => {
       const triggerBtn1 =
         ldAccordionToggles[1].shadowRoot.querySelector('button')
 
-      expect(triggerBtn0).toHaveAttribute('aria-expanded')
-      expect(triggerBtn1).not.toHaveAttribute('aria-expanded')
-
-      expect(triggerBtn0).toHaveAttribute('aria-expanded')
-      expect(triggerBtn1).not.toHaveAttribute('aria-expanded')
+      expect(triggerBtn0.getAttribute('aria-expanded')).toEqual('true')
+      expect(triggerBtn1.getAttribute('aria-expanded')).toEqual('false')
 
       triggerBtn1.dispatchEvent(new Event('click'))
       await page.waitForChanges()
@@ -185,8 +182,8 @@ describe('ld-accordion', () => {
       const triggerBtnInner =
         ldAccordionToggleInner.shadowRoot.querySelector('button')
 
-      expect(triggerBtnOuter).toHaveAttribute('aria-expanded')
-      expect(triggerBtnInner).not.toHaveAttribute('aria-expanded')
+      expect(triggerBtnOuter.getAttribute('aria-expanded')).toEqual('true')
+      expect(triggerBtnInner.getAttribute('aria-expanded')).toEqual('false')
 
       triggerBtnInner.dispatchEvent(new Event('click'))
       await page.waitForChanges()
@@ -235,16 +232,13 @@ describe('ld-accordion', () => {
         ldAccordionToggles[1].shadowRoot.querySelector('button')
 
       expect(triggerBtn0.getAttribute('aria-expanded')).toEqual('true')
-      expect(triggerBtn1.getAttribute('aria-expanded')).toEqual(null)
-
-      expect(triggerBtn0).toHaveAttribute('aria-expanded')
-      expect(triggerBtn1).not.toHaveAttribute('aria-expanded')
+      expect(triggerBtn1.getAttribute('aria-expanded')).toEqual('false')
 
       triggerBtn1.dispatchEvent(new Event('click'))
       await page.waitForChanges()
 
-      expect(triggerBtn0).not.toHaveAttribute('aria-expanded')
-      expect(triggerBtn1).toHaveAttribute('aria-expanded')
+      expect(triggerBtn0.getAttribute('aria-expanded')).toEqual('false')
+      expect(triggerBtn1.getAttribute('aria-expanded')).toEqual('true')
     })
   })
 

--- a/src/liquid/components/ld-sidenav/test/__snapshots__/ld-sidenav.spec.ts.snap
+++ b/src/liquid/components/ld-sidenav/test/__snapshots__/ld-sidenav.spec.ts.snap
@@ -4192,7 +4192,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
               </mock:shadow-root>
               <ld-accordion-toggle class="ld-accordion-toggle ld-sidenav-accordion__accordion-toggle" ld-tabindex="-1">
                 <mock:shadow-root>
-                  <button class="ld-accordion-toggle__button" part="toggle focusable" tabindex="-1">
+                  <button aria-expanded="false" class="ld-accordion-toggle__button" part="toggle focusable" tabindex="-1">
                     <div class="ld-accordion-toggle__content" part="content">
                       <div class="ld-accordion-toggle__label" part="label">
                         <div class="ld-accordion-toggle__label-content" part="label-content">
@@ -4554,7 +4554,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
                           <slot></slot>
                         </div>
                       </div>
-                      <button aria-label="Toggle" class="ld-accordion-toggle__trigger" part="trigger focusable">
+                      <button aria-expanded="false" aria-label="Toggle" class="ld-accordion-toggle__trigger" part="trigger focusable">
                         <div class="ld-accordion-toggle__trigger-content" part="trigger-content">
                           <slot name="icon"></slot>
                           <ld-icon aria-hidden="true" class="ld-accordion-toggle__trigger-icon" name="arrow-down" part="trigger-icon" size="sm"></ld-icon>
@@ -4777,7 +4777,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
               </mock:shadow-root>
               <ld-accordion-toggle class="ld-accordion-toggle ld-sidenav-accordion__accordion-toggle" ld-tabindex="-1">
                 <mock:shadow-root>
-                  <button class="ld-accordion-toggle__button" part="toggle focusable" tabindex="-1">
+                  <button aria-expanded="false" class="ld-accordion-toggle__button" part="toggle focusable" tabindex="-1">
                     <div class="ld-accordion-toggle__content" part="content">
                       <div class="ld-accordion-toggle__label" part="label">
                         <div class="ld-accordion-toggle__label-content" part="label-content">
@@ -5118,7 +5118,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
                 </mock:shadow-root>
                 <ld-accordion-toggle class="ld-accordion-toggle ld-sidenav-accordion__accordion-toggle" ld-tabindex="-1">
                   <mock:shadow-root>
-                    <button class="ld-accordion-toggle__button" part="toggle focusable" tabindex="-1">
+                    <button aria-expanded="false" class="ld-accordion-toggle__button" part="toggle focusable" tabindex="-1">
                       <div class="ld-accordion-toggle__content" part="content">
                         <div class="ld-accordion-toggle__label" part="label">
                           <div class="ld-accordion-toggle__label-content" part="label-content">
@@ -5208,7 +5208,7 @@ exports[`ld-sidenav sidenav accordion accordion collapses to narrow 1`] = `
                   </mock:shadow-root>
                   <ld-accordion-toggle class="ld-accordion-toggle ld-sidenav-accordion__accordion-toggle" ld-tabindex="-1">
                     <mock:shadow-root>
-                      <button class="ld-accordion-toggle__button" part="toggle focusable" tabindex="-1">
+                      <button aria-expanded="false" class="ld-accordion-toggle__button" part="toggle focusable" tabindex="-1">
                         <div class="ld-accordion-toggle__content" part="content">
                           <div class="ld-accordion-toggle__label" part="label">
                             <div class="ld-accordion-toggle__label-content" part="label-content">


### PR DESCRIPTION
# Description

Instead of setting the `aria-expanded` attribute to `undefined` we now set it to `false` when an element is collapsed. That way a screen reader will tell the user that the element is expandable.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
