### PR TITLE
feat(vue): add vue output target

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   ],
   "scripts": {
     "apply_design_tokens": "dotenv -e .env -- ts-node scripts/applyDesignTokens.ts",
-    "build": "run-s build:stencil:components build:stencil:react build:patch_loader build:styles build:copy_design_tokens build:tailwind_preset build:bin",
+    "build": "run-s build:stencil:components build:stencil:react build:stencil:vue build:patch_loader build:styles build:copy_design_tokens build:tailwind_preset build:bin",
     "build:bin": "run-p build:bin:cli build:bin:apply_design_tokens",
     "build:bin:cli": "tsc scripts/cli.ts --moduleResolution node --target esnext --outfile bin/cli.cjs",
     "build:bin:apply_design_tokens": "tsc scripts/applyDesignTokens.ts --moduleResolution node --target esnext --outfile bin/applyDesignTokens.cjs",
@@ -41,6 +41,7 @@
     "build:stencil:components": "stencil build && shx mv tmp/web-components.html-data.json dist/web-components.html-data.json && shx rm -r tmp",
     "build:stencil:docs": "stencil build --config=stencil.config.docs.ts",
     "build:stencil:react": "tsc -p tsconfig.react.json && (shx rm src/react.ts & shx rm -r src/react-component-lib)",
+    "build:stencil:vue": "tsc -p tsconfig.vue.json && (shx rm src/vue.ts & shx rm -r src/vue-component-lib)",
     "build:styles": "run-s build:styles:liquid:globals build:styles:liquid:components",
     "build:styles:liquid:components": "postcss 'src/liquid/components/**/*.css' --no-map -d dist/css/ && trash dist/css/liquid.css 'dist/css/*.shadow.css' && bash scripts/concatStyles.sh",
     "build:styles:liquid:globals": "postcss src/liquid/global/styles/global.css --no-map -o dist/css/liquid.global.css",
@@ -95,6 +96,7 @@
     "@stencil/eslint-plugin": "^0.4.0",
     "@stencil/postcss": "^2.1.0",
     "@stencil/react-output-target": "^0.3.1",
+    "@stencil/vue-output-target": "^0.6.2",
     "@types/jest": "^27.5.2",
     "@types/js-cookie": "^3.0.2",
     "@types/react": "^18.0.3",
@@ -152,6 +154,7 @@
     "ts-node": "^10.9.1",
     "typescript": "^4.9.3",
     "validate-branch-name": "^1.3.0",
+    "vue": "^3.2.45",
     "wicg-inert": "^3.1.2",
     "yargs": "^17.6.2"
   },
@@ -176,13 +179,17 @@
   ],
   "peerDependencies": {
     "react": ">=17.0.0",
-    "react-dom": ">=17.0.0"
+    "react-dom": ">=17.0.0",
+    "vue": ">=3.0.0"
   },
   "peerDependenciesMeta": {
     "react": {
       "optional": true
     },
     "react-dom": {
+      "optional": true
+    },
+    "vue": {
       "optional": true
     }
   },

--- a/src/docs/components/docs-main/docs-main.css
+++ b/src/docs/components/docs-main/docs-main.css
@@ -184,6 +184,7 @@
     'Ubuntu Mono', monospace;
   --docs-main-padding-x: var(--ld-sp-40);
   padding: var(--ld-sp-24) var(--docs-main-padding-x) var(--ld-sp-40);
+  max-width: 54rem;
   min-width: 20rem;
 
   @media (max-width: 75rem) {

--- a/src/docs/pages/guides/framework-integrations/index.md
+++ b/src/docs/pages/guides/framework-integrations/index.md
@@ -1,0 +1,18 @@
+---
+eleventyNavigation:
+  key: Framework integrations
+  parent: Guides
+  order: 7
+layout: layout.njk
+title: Framework integrations
+permalink: guides/framework-integrations/
+---
+
+# Framework integrations
+
+Liquid ships with several framework specific bindings. These improve the developer experiencefix by fixing framework related quirks and enabling type checking and intellisense.
+
+- [React bindings](guides/framework-integrations/react-bindings)
+- [Vue bindings](guides/framework-integrations/vue-bindings)
+
+<docs-page-nav prev-href="guides/form-validation/" next-title="Tailwind CSS integration" next-href="guides/tailwindcss-integration/"></docs-page-nav>

--- a/src/docs/pages/guides/framework-integrations/react-bindings.md
+++ b/src/docs/pages/guides/framework-integrations/react-bindings.md
@@ -1,13 +1,12 @@
 ---
 eleventyNavigation:
   key: React bindings
-  parent: Guides
-  order: 7
+  parent: Framework integrations
+  order: 1
 layout: layout.njk
 title: React bindings
-permalink: guides/react-bindings/
+permalink: guides/framework-integrations/react-bindings/
 ---
-
 
 # React bindings
 
@@ -23,6 +22,4 @@ export default () => (
 )
 ```
 
-For more details on React integration read the [Stencil documentation](https://stenciljs.com/docs/react).
-
-<docs-page-nav prev-href="guides/form-validation/" next-title="Tailwind CSS integration" next-href="guides/tailwindcss-integration/"></docs-page-nav>
+For more details on React integration check out our [sandbox apps](guides/sandbox-applications/) or read the [Stencil documentation](https://stenciljs.com/docs/react).

--- a/src/docs/pages/guides/framework-integrations/vue-bindings.md
+++ b/src/docs/pages/guides/framework-integrations/vue-bindings.md
@@ -1,0 +1,30 @@
+---
+eleventyNavigation:
+  key: Vue bindings
+  parent: Framework integrations
+  order: 2
+layout: layout.njk
+title: React bindings
+permalink: guides/framework-integrations/vue-bindings/
+---
+
+# Vue bindings
+
+In order to enable type checking and intellisense for Liquid components in your Vue project, simply import the Vue binding and use it as you would use any other Vue component.
+
+<ld-notice mode="warning">
+  While type checking and intellisense work well when using Visual Studio Code in combination with the <a href="https://github.com/johnsoncodehk/volar" rel="noreferrer noopener" target="_blank">Volar plugin</a>, we found that JetBrains' bundled <a href="https://plugins.jetbrains.com/plugin/9442-vue-js" rel="noreferrer noopener" target="_blank">Vue plugin</a> is not yet capable of providing equivalent features.
+</ld-notice>
+
+```js
+import { LdButton } from '@emdgroup-liquid/liquid/dist/vue'
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  components: {
+    LdButton,
+  },
+})
+```
+
+For more details on Vue integration check out our [sandbox apps](guides/sandbox-applications/) or read the [Stencil documentation](https://stenciljs.com/docs/vue).

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -1,6 +1,7 @@
 import { Config } from '@stencil/core'
 import { postcss } from '@stencil/postcss'
 import { reactOutputTarget } from '@stencil/react-output-target'
+import { vueOutputTarget } from '@stencil/vue-output-target'
 import postcssConfig from './postcss.config.cjs'
 
 export const config: Config = {
@@ -11,6 +12,11 @@ export const config: Config = {
     reactOutputTarget({
       componentCorePackage: '..',
       proxiesFile: './src/react.ts',
+      includeDefineCustomElements: false,
+    }),
+    vueOutputTarget({
+      componentCorePackage: '..',
+      proxiesFile: './src/vue.ts',
       includeDefineCustomElements: false,
     }),
     {

--- a/tsconfig.vue.json
+++ b/tsconfig.vue.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "outDir": "dist"
+  },
+  "include": ["./src/vue.ts"],
+  "exclude": ["node_modules"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -489,6 +489,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/parser@npm:^7.16.4":
+  version: 7.20.7
+  resolution: "@babel/parser@npm:7.20.7"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 25b5266e3bd4be837092685f6b7ef886f1308ff72659a24342eb646ae5014f61ed1771ce8fc20636c890fcae19304fc72c069564ca6075207b7fbf3f75367275
+  languageName: node
+  linkType: hard
+
 "@babel/parser@npm:^7.16.7":
   version: 7.16.12
   resolution: "@babel/parser@npm:7.16.12"
@@ -1160,6 +1169,7 @@ __metadata:
     "@stencil/eslint-plugin": ^0.4.0
     "@stencil/postcss": ^2.1.0
     "@stencil/react-output-target": ^0.3.1
+    "@stencil/vue-output-target": ^0.6.2
     "@types/jest": ^27.5.2
     "@types/js-cookie": ^3.0.2
     "@types/react": ^18.0.3
@@ -1219,15 +1229,19 @@ __metadata:
     ts-node: ^10.9.1
     typescript: ^4.9.3
     validate-branch-name: ^1.3.0
+    vue: ^3.2.45
     wicg-inert: ^3.1.2
     yargs: ^17.6.2
   peerDependencies:
     react: ">=17.0.0"
     react-dom: ">=17.0.0"
+    vue: ">=3.0.0"
   peerDependenciesMeta:
     react:
       optional: true
     react-dom:
+      optional: true
+    vue:
       optional: true
   bin:
     liquid: ./bin/cli.cjs
@@ -2379,6 +2393,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@stencil/vue-output-target@npm:^0.6.2":
+  version: 0.6.2
+  resolution: "@stencil/vue-output-target@npm:0.6.2"
+  peerDependencies:
+    "@stencil/core": ^2.9.0
+  checksum: bd25b6f88e93cce9450a90278d71b432f139d665446b77c841db7d09a644165075759c9e8dcd27e4b84fbbd0abaac8b39d11c28aaeb8cbe3156fef3e125080cc
+  languageName: node
+  linkType: hard
+
 "@stroncium/procfs@npm:^1.2.1":
   version: 1.2.1
   resolution: "@stroncium/procfs@npm:1.2.1"
@@ -2842,6 +2865,118 @@ __metadata:
     "@typescript-eslint/types": 5.45.0
     eslint-visitor-keys: ^3.3.0
   checksum: 050cc4275d8a3638a106c2915410710e775382996130a6b2af732269e55cbbc4ed438c8662ddf409635d2d8bd0d8a4389b3980bc2cb38c6105c77c6835222af0
+  languageName: node
+  linkType: hard
+
+"@vue/compiler-core@npm:3.2.45":
+  version: 3.2.45
+  resolution: "@vue/compiler-core@npm:3.2.45"
+  dependencies:
+    "@babel/parser": ^7.16.4
+    "@vue/shared": 3.2.45
+    estree-walker: ^2.0.2
+    source-map: ^0.6.1
+  checksum: e3c687b24c16c2b320c02ed38960f8bee7dcb88bddb09e60a80d2d4dc004070cbbd4eccbc99cc168d48d753ff60d0b9eefba835e1dec3b7f233a98c89af31c07
+  languageName: node
+  linkType: hard
+
+"@vue/compiler-dom@npm:3.2.45":
+  version: 3.2.45
+  resolution: "@vue/compiler-dom@npm:3.2.45"
+  dependencies:
+    "@vue/compiler-core": 3.2.45
+    "@vue/shared": 3.2.45
+  checksum: 89115538635f0da9cce615de5488d2759256fa573976a09a049536dbb94e9b5086b46f2f11e743cf0a7b14837161b3191c67611e0493054a5d4c4b96a322c901
+  languageName: node
+  linkType: hard
+
+"@vue/compiler-sfc@npm:3.2.45":
+  version: 3.2.45
+  resolution: "@vue/compiler-sfc@npm:3.2.45"
+  dependencies:
+    "@babel/parser": ^7.16.4
+    "@vue/compiler-core": 3.2.45
+    "@vue/compiler-dom": 3.2.45
+    "@vue/compiler-ssr": 3.2.45
+    "@vue/reactivity-transform": 3.2.45
+    "@vue/shared": 3.2.45
+    estree-walker: ^2.0.2
+    magic-string: ^0.25.7
+    postcss: ^8.1.10
+    source-map: ^0.6.1
+  checksum: bec375faa0012e953dc0887482cc01d52003ad424b6a8a9c8a2506fd4f0197ad62be22f77ce5691c2306068ae7bc0028399f25399e7d4beee668285d431f4d8f
+  languageName: node
+  linkType: hard
+
+"@vue/compiler-ssr@npm:3.2.45":
+  version: 3.2.45
+  resolution: "@vue/compiler-ssr@npm:3.2.45"
+  dependencies:
+    "@vue/compiler-dom": 3.2.45
+    "@vue/shared": 3.2.45
+  checksum: 830c475506d2b6d1a6872b3fde1024ef5132f725121fd9c34832c5cefcc8cfddf0dcaa3acc9b2da4754162fccdff48b3275b9ff31415a7793b224c04355dc632
+  languageName: node
+  linkType: hard
+
+"@vue/reactivity-transform@npm:3.2.45":
+  version: 3.2.45
+  resolution: "@vue/reactivity-transform@npm:3.2.45"
+  dependencies:
+    "@babel/parser": ^7.16.4
+    "@vue/compiler-core": 3.2.45
+    "@vue/shared": 3.2.45
+    estree-walker: ^2.0.2
+    magic-string: ^0.25.7
+  checksum: 401040818947eb04c782487a7861d3ba20f95c9f3ca14282b3d7624002bfe6000547bb48c561afe87ae6d302143fec71a7e0bc3ed3ae2bfad8a228adf7fd90d6
+  languageName: node
+  linkType: hard
+
+"@vue/reactivity@npm:3.2.45":
+  version: 3.2.45
+  resolution: "@vue/reactivity@npm:3.2.45"
+  dependencies:
+    "@vue/shared": 3.2.45
+  checksum: 4ba609744a6b4d6235e81afc3f455ae9349c04f54be11c15770139f58ff687b105b06ca78649218fab907fb76048c3dcf34144c677718192ce8b9927eb335f03
+  languageName: node
+  linkType: hard
+
+"@vue/runtime-core@npm:3.2.45":
+  version: 3.2.45
+  resolution: "@vue/runtime-core@npm:3.2.45"
+  dependencies:
+    "@vue/reactivity": 3.2.45
+    "@vue/shared": 3.2.45
+  checksum: 0ac376a7602663d51a37b460c1184e2e035649090e53e972c18d24b30f3c47e5d61b921baf2492203f041d9edd864b3e9024a3ecef243b840637b62e9c0169a1
+  languageName: node
+  linkType: hard
+
+"@vue/runtime-dom@npm:3.2.45":
+  version: 3.2.45
+  resolution: "@vue/runtime-dom@npm:3.2.45"
+  dependencies:
+    "@vue/runtime-core": 3.2.45
+    "@vue/shared": 3.2.45
+    csstype: ^2.6.8
+  checksum: c66c71a2fc3921b57a930999b1fb0ea64f1a9d1bc7019984b06f2dbdd93f51b5a328cc60ec5904d1754b9dc1c85653b536db9017ef86616fa4a35f53836a2f9d
+  languageName: node
+  linkType: hard
+
+"@vue/server-renderer@npm:3.2.45":
+  version: 3.2.45
+  resolution: "@vue/server-renderer@npm:3.2.45"
+  dependencies:
+    "@vue/compiler-ssr": 3.2.45
+    "@vue/shared": 3.2.45
+  peerDependencies:
+    vue: 3.2.45
+  checksum: 062812235c2be41ed699fb7b802cf4fc94618bf4efae7832210431ad16ea1b852056e4fb83f6c17b919bfe87bc8624afcadd973dab3e0965d3cf9875baaf7373
+  languageName: node
+  linkType: hard
+
+"@vue/shared@npm:3.2.45":
+  version: 3.2.45
+  resolution: "@vue/shared@npm:3.2.45"
+  checksum: ff3205056caed2a965aa0980e21319515ce13c859a9b269fdab0ee8b3c9f3d8eec7eefdb7fd6c6b47c12acdc7bf23c6c187b6191054221b4a29108139b20c221
   languageName: node
   linkType: hard
 
@@ -5307,6 +5442,13 @@ colors@latest:
   languageName: node
   linkType: hard
 
+"csstype@npm:^2.6.8":
+  version: 2.6.21
+  resolution: "csstype@npm:2.6.21"
+  checksum: 2ce8bc832375146eccdf6115a1f8565a27015b74cce197c35103b4494955e9516b246140425ad24103864076aa3e1257ac9bab25a06c8d931dd87a6428c9dccf
+  languageName: node
+  linkType: hard
+
 "csstype@npm:^3.0.2":
   version: 3.0.9
   resolution: "csstype@npm:3.0.9"
@@ -6489,6 +6631,13 @@ colors@latest:
   version: 5.3.0
   resolution: "estraverse@npm:5.3.0"
   checksum: 072780882dc8416ad144f8fe199628d2b3e7bbc9989d9ed43795d2c90309a2047e6bc5979d7e2322a341163d22cfad9e21f4110597fe487519697389497e4e2b
+  languageName: node
+  linkType: hard
+
+"estree-walker@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "estree-walker@npm:2.0.2"
+  checksum: 6151e6f9828abe2259e57f5fd3761335bb0d2ebd76dc1a01048ccee22fabcfef3c0859300f6d83ff0d1927849368775ec5a6d265dde2f6de5a1be1721cd94efc
   languageName: node
   linkType: hard
 
@@ -10247,6 +10396,15 @@ colors@latest:
   languageName: node
   linkType: hard
 
+"magic-string@npm:^0.25.7":
+  version: 0.25.9
+  resolution: "magic-string@npm:0.25.9"
+  dependencies:
+    sourcemap-codec: ^1.4.8
+  checksum: 9a0e55a15c7303fc360f9572a71cffba1f61451bc92c5602b1206c9d17f492403bf96f946dfce7483e66822d6b74607262e24392e87b0ac27b786e69a40e9b1a
+  languageName: node
+  linkType: hard
+
 "make-dir@npm:^3.0.0":
   version: 3.1.0
   resolution: "make-dir@npm:3.1.0"
@@ -13237,6 +13395,17 @@ opn@latest:
   languageName: node
   linkType: hard
 
+"postcss@npm:^8.1.10":
+  version: 8.4.20
+  resolution: "postcss@npm:8.4.20"
+  dependencies:
+    nanoid: ^3.3.4
+    picocolors: ^1.0.0
+    source-map-js: ^1.0.2
+  checksum: 1a5609ea1c1b204f9c2974a0019ae9eef2d99bf645c2c9aac675166c4cb1005be7b5e2ba196160bc771f5d9ac896ed883f236f888c891e835e59d28fff6651aa
+  languageName: node
+  linkType: hard
+
 "postcss@npm:^8.1.6, postcss@npm:^8.2.1, postcss@npm:^8.2.4, postcss@npm:~8.3.8":
   version: 8.3.11
   resolution: "postcss@npm:8.3.11"
@@ -14998,6 +15167,13 @@ send@latest:
   languageName: node
   linkType: hard
 
+"sourcemap-codec@npm:^1.4.8":
+  version: 1.4.8
+  resolution: "sourcemap-codec@npm:1.4.8"
+  checksum: b57981c05611afef31605732b598ccf65124a9fcb03b833532659ac4d29ac0f7bfacbc0d6c5a28a03e84c7510e7e556d758d0bb57786e214660016fb94279316
+  languageName: node
+  linkType: hard
+
 "spawn-error-forwarder@npm:~1.0.0":
   version: 1.0.0
   resolution: "spawn-error-forwarder@npm:1.0.0"
@@ -16644,6 +16820,19 @@ send@latest:
   version: 3.1.0
   resolution: "void-elements@npm:3.1.0"
   checksum: 0390f818107fa8fce55bb0a5c3f661056001c1d5a2a48c28d582d4d847347c2ab5b7f8272314cac58acf62345126b6b09bea623a185935f6b1c3bbce0dfd7f7f
+  languageName: node
+  linkType: hard
+
+"vue@npm:^3.2.45":
+  version: 3.2.45
+  resolution: "vue@npm:3.2.45"
+  dependencies:
+    "@vue/compiler-dom": 3.2.45
+    "@vue/compiler-sfc": 3.2.45
+    "@vue/runtime-dom": 3.2.45
+    "@vue/server-renderer": 3.2.45
+    "@vue/shared": 3.2.45
+  checksum: df60ca80cb9fdce408eccd0c7a4d44720df9855c62e340448650d8048b1edd25da6f3bd99ed7efc19efbe1f3fdcec4ae8067ab10ae50be5bb363d996ad29251a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

This pull request adds a Vue output target to the project (similar to the one we already have for React). It improves the DX for Vue developers by enabling type checking and intellisense in Vue templates. This has been tested and proved to be working well in Visual Studio Code in combination with the Volar plugin.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change includes a documentation update

# How Has This Been Tested?

- [x] tested manually in an modified version of the Vue sandbox app (which will be updated to use Vue templates instead of JSX as soon as the Vue bindings are released)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
