### PR TITLE
fix(ld-stepper): z-index issue when in placed container without explicit z-order

### DIFF
--- a/src/liquid/components/ld-stepper/ld-step/ld-step.css
+++ b/src/liquid/components/ld-stepper/ld-step/ld-step.css
@@ -408,7 +408,6 @@
     right: calc(var(--ld-stepper-gap) / -2);
     top: calc(var(--ld-step-dot-size-with-icon) / 2);
     transform: translateY(-50%);
-    z-index: -1;
   }
 
   &.ld-step--vertical::after {


### PR DESCRIPTION
# Description

This PR removes a line of code that seems to have no useful effect, but results in the `::after` pseudo element, that draws a line from one step to the next, being covered by a container which wraps the `ld-stepper` component and has no explicit z-order:

<img width="728" alt="Screenshot 2023-01-12 at 13 03 10" src="https://user-images.githubusercontent.com/527049/212063209-8e1bcac0-49b1-4486-85e4-52f5f44e890b.png">

## Type of change

- [x] Bugfix

## Is it a breaking change?

- [x] No

# How Has This Been Tested?

Please describe the tests that you've added and run to verify your changes. 
Provide instructions, so we can reproduce.

- [x] e2e tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes
