### PR TITLE
ci: invalidate cloudfront cache

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -96,18 +96,14 @@ jobs:
           branch: gh-pages
           folder: dist_docs
 
-      #- name: Configure AWS
-      #  uses: aws-actions/configure-aws-credentials@v1
-      #  with:
-      #    aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      #    aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      #    aws-region: us-east-1
-
-      #- name: Invalidate CloudFront cache
-      #  run: |
-      #    aws cloudfront create-invalidation \
-      #    --distribution-id ${{ secrets.AWS_CF_DISTRIBUTION_ID }} \
-      #    --paths "/*" --region eu-central-1
+      - name: Invalidate Cloudfront
+        uses: chetan/invalidate-cloudfront-action@v2
+        env:
+          PATHS: '/*'
+          DISTRIBUTION_ID: ${{ secrets.AWS_CF_DISTRIBUTION_ID }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: us-east-1
 
   release:
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/rc'


### PR DESCRIPTION
# Description

Adds a step to the deployment action that invalidates the cloudfront cache.
Also added the required secrets to the repository settings.

## Type of change

Please delete options that are not relevant.

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Is it a breaking change?

- [ ] Yes
- [x] No

