### PR TITLE
docs(react): examples in code viewer

### DIFF
--- a/src/docs/components/docs-example/docs-example.css
+++ b/src/docs/components/docs-example/docs-example.css
@@ -4,7 +4,7 @@
   }
 
   .docs-example__tools-scroll-container {
-    background-color: var(--ld-col-neutral-100);
+    background-color: var(--ld-col-neutral-050);
     border-color: var(--ld-col-neutral-100);
   }
 
@@ -24,8 +24,8 @@
   }
 
   .docs-example__tools-scroll-container {
-    background-color: var(--ld-col-neutral-600);
-    border-color: var(--ld-col-neutral-600);
+    background-color: var(--ld-col-neutral-700);
+    border-color: var(--ld-col-neutral-700);
   }
 
   .docs-example__tools {
@@ -36,6 +36,10 @@
   .docs-example__tool-switch,
   .docs-example__copy-to-clipboard {
     filter: invert(1) hue-rotate(180deg);
+  }
+
+  .docs-example--has-border .docs-example__show {
+    border-color: transparent;
   }
 }
 
@@ -90,8 +94,6 @@
 .docs-example__tool-switch {
   background-color: var(--ld-col-wht);
   border-radius: calc(var(--ld-br-m) + 1px);
-  margin-right: var(--ld-sp-24);
-  flex-shrink: 0;
 }
 
 .docs-example__tool-buttons {
@@ -117,6 +119,7 @@
 
   .docs-example--has-border & {
     border: var(--ld-sp-1) solid var(--ld-col-neutral-100);
+    border-bottom: 0px;
   }
 
   .docs-example--has-padding & {
@@ -188,23 +191,39 @@
 
 .docs-example--web-component {
   [slot='showCssComponent'],
+  [slot='codeReactComponent'],
   [slot='codeCssComponent'] {
+    display: none;
+  }
+}
+
+.docs-example--react-component {
+  [slot='showCssComponent'],
+  [slot='codeCssComponent'],
+  [slot='code'] {
     display: none;
   }
 }
 
 .docs-example--css-component {
   [slot='show'],
+  [slot='codeReactComponent'],
   [slot='code'] {
     display: none;
   }
 }
 
-.docs-example__copy-to-clipboard {
-  background-color: var(--ld-col-wht);
-  border-radius: var(--ld-br-m);
+.docs-example__code-tools {
   position: absolute;
+  display: grid;
+  grid-auto-flow: column;
+  gap: var(--ld-sp-8);
   top: var(--ld-sp-8);
   right: var(--ld-sp-8);
   margin: var(--ld-sp-2) var(--ld-sp-1);
+}
+
+.docs-example__copy-to-clipboard {
+  background-color: var(--ld-col-wht);
+  border-radius: var(--ld-br-m);
 }

--- a/src/docs/components/docs-example/docs-example.tsx
+++ b/src/docs/components/docs-example/docs-example.tsx
@@ -104,7 +104,6 @@ export class DocsExample {
   }
 
   private hasCodeType(codeType: this['codeType']) {
-    console.info('codeType', codeType)
     if (codeType === 'wc') {
       return Boolean(this.el.querySelector('[slot="code"]'))
     }

--- a/src/docs/components/docs-example/docs-example.tsx
+++ b/src/docs/components/docs-example/docs-example.tsx
@@ -1,4 +1,14 @@
-import { Component, h, Host, Prop, State, Element } from '@stencil/core'
+import {
+  Component,
+  h,
+  Host,
+  Prop,
+  State,
+  Element,
+  Event,
+  EventEmitter,
+  Listen,
+} from '@stencil/core'
 import { getClassNames } from '../../../liquid/utils/getClassNames'
 
 /** @internal **/
@@ -21,6 +31,9 @@ export class DocsExample {
 
   /** CSS component markup encoded as URI component. */
   @Prop() codeCssComponent: string
+
+  /** React component markup encoded as URI component. */
+  @Prop() codeReactComponent: string
 
   /** Adds a thin border to the container. */
   @Prop() hasBorder = false
@@ -47,7 +60,10 @@ export class DocsExample {
   @State() isCodeVisible = this.opened
 
   /** Is Web Component visible (as opposed to the css component version) */
-  @State() isWebComponent = true
+  @State() codeType: 'wc' | 'css' | 'react' = 'wc'
+
+  /** Code type pick change event. */
+  @Event() pickCodeType: EventEmitter<this['codeType']>
 
   private handlePickTheme = (event: CustomEvent<string>) => {
     this.currentTheme = event.detail
@@ -57,16 +73,56 @@ export class DocsExample {
     this.isCodeVisible = event.detail
   }
 
-  private handleSwitchComponent = () => {
-    this.isWebComponent = !this.isWebComponent
-    this.isCodeVisible = true
+  @Listen('pickCodeType', {
+    target: 'window',
+  })
+  handleSwitchCode(ev: CustomEvent<this['codeType']>) {
+    if (!this.hasCodeType(ev.detail)) return
+    this.codeType = ev.detail
+    window.localStorage.setItem(
+      'liquid_docs_preferred_code_type',
+      this.codeType
+    )
   }
 
   private unescapeCode(code) {
-    return code.replaceAll(/\\{\\{/g, '{{').replaceAll(/\\}\\}/g, '}}')
+    return (
+      code
+        // lang html
+        .replaceAll(/\\{\\{/g, '{{')
+        .replaceAll(/\\}\\}/g, '}}')
+        // lang jsx
+        .replaceAll(
+          /<span class="token punctuation">{<\/span> <span class="token punctuation">{<\/span>/g,
+          '<span class="token punctuation">{</span><span class="token punctuation">{</span>'
+        )
+        .replaceAll(
+          /<span class="token punctuation">}<\/span> <span class="token punctuation">}<\/span>/g,
+          '<span class="token punctuation">}</span><span class="token punctuation">}</span>'
+        )
+    )
+  }
+
+  private hasCodeType(codeType: this['codeType']) {
+    console.info('codeType', codeType)
+    if (codeType === 'wc') {
+      return Boolean(this.el.querySelector('[slot="code"]'))
+    }
+    return Array.from(this.el.querySelectorAll('[slot^="code"]')).some(
+      (slot) =>
+        slot.getAttribute('slot').toLowerCase() === `code${codeType}component`
+    )
   }
 
   componentWillLoad() {
+    const preferredCodeType = window.localStorage.getItem(
+      'liquid_docs_preferred_code_type'
+    ) as this['codeType']
+    if (preferredCodeType) {
+      if (this.hasCodeType(preferredCodeType)) {
+        this.codeType = preferredCodeType as this['codeType']
+      }
+    }
     this.el.querySelectorAll('[slot^="code"]').forEach((slot) => {
       slot.innerHTML = this.unescapeCode(slot.innerHTML)
     })
@@ -78,9 +134,9 @@ export class DocsExample {
       this.isCodeVisible && 'docs-example--code-visible',
       this.hasBorder && 'docs-example--has-border',
       this.hasPadding && 'docs-example--has-padding',
-      this.isWebComponent
-        ? 'docs-example--web-component'
-        : ' docs-example--css-component',
+      this.codeType === 'wc' && 'docs-example--web-component',
+      this.codeType === 'css' && 'docs-example--css-component',
+      this.codeType === 'react' && 'docs-example--react-component',
     ]
 
     let clShow = 'docs-example__show'
@@ -99,13 +155,17 @@ export class DocsExample {
         </div>
         <div class="docs-example__tools-scroll-container">
           <div class="docs-example__tools">
-            {this.codeCssComponent && (
+            {(this.codeCssComponent || this.codeReactComponent) && (
               <ld-switch
-                onLdswitchchange={this.handleSwitchComponent}
+                onClick={() => (this.isCodeVisible = true)}
+                onLdswitchchange={(ev) => {
+                  this.handleSwitchCode(ev as CustomEvent<this['codeType']>)
+                  this.pickCodeType.emit(this.codeType)
+                }}
                 class="docs-example__tool-switch"
                 size="sm"
               >
-                <ld-switch-item checked={this.isWebComponent}>
+                <ld-switch-item value="wc" checked={this.codeType === 'wc'}>
                   <ld-icon
                     slot="icon-start"
                     size="sm"
@@ -119,23 +179,49 @@ export class DocsExample {
                     </svg>
                   </ld-icon>
                 </ld-switch-item>
-                <ld-switch-item checked={!this.isWebComponent}>
-                  <ld-icon
-                    slot="icon-start"
-                    size="sm"
-                    aria-label="CSS component"
+                {this.codeReactComponent && (
+                  <ld-switch-item
+                    value="react"
+                    checked={this.codeType === 'react'}
                   >
-                    <svg
-                      viewBox="0 0 800 300"
-                      style={{ transform: 'scale(1.2)' }}
+                    <ld-icon
+                      slot="icon-start"
+                      size="sm"
+                      aria-label="React component"
                     >
-                      <path
-                        fill="currentColor"
-                        d="M0 0h238.7v99.8H99.8v99.8h139v99.9H0V0zM283.2 0h235.3v85.6H381.6v17h136.9v196.9H283.2v-89.9h136.9v-17H283.2V0zM564.7 0H800v85.6H663.1v17H800v196.9H564.7v-89.9h136.9v-17H564.7V0z"
-                      />
-                    </svg>
-                  </ld-icon>
-                </ld-switch-item>
+                      <svg
+                        viewBox="-11.5 -10.2 23 20.5"
+                        style={{ transform: 'scale(1.1)' }}
+                      >
+                        <circle r="2" fill="currentColor" />
+                        <g stroke="currentColor" fill="none">
+                          <ellipse rx="11" ry="4.2" />
+                          <ellipse rx="11" ry="4.2" transform="rotate(60)" />
+                          <ellipse rx="11" ry="4.2" transform="rotate(120)" />
+                        </g>
+                      </svg>
+                    </ld-icon>
+                  </ld-switch-item>
+                )}
+                {this.codeCssComponent && (
+                  <ld-switch-item value="css" checked={this.codeType === 'css'}>
+                    <ld-icon
+                      slot="icon-start"
+                      size="sm"
+                      aria-label="CSS component"
+                    >
+                      <svg
+                        viewBox="0 0 800 300"
+                        style={{ transform: 'scale(1.2)' }}
+                      >
+                        <path
+                          fill="currentColor"
+                          d="M0 0h238.7v99.8H99.8v99.8h139v99.9H0V0zM283.2 0h235.3v85.6H381.6v17h136.9v196.9H283.2v-89.9h136.9v-17H283.2V0zM564.7 0H800v85.6H663.1v17H800v196.9H564.7v-89.9h136.9v-17H564.7V0z"
+                        />
+                      </svg>
+                    </ld-icon>
+                  </ld-switch-item>
+                )}
               </ld-switch>
             )}
             <div class="docs-example__tool-buttons">
@@ -150,15 +236,24 @@ export class DocsExample {
           </div>
         </div>
         <div class="docs-example__code">
-          <docs-copy-to-cb
-            class="docs-example__copy-to-clipboard"
-            textToCopy={this.unescapeCode(
-              decodeURIComponent(
-                this.isWebComponent ? this.code : this.codeCssComponent
-              )
-            )}
-          />
+          <div class="docs-example__code-tools">
+            <docs-copy-to-cb
+              class="docs-example__copy-to-clipboard"
+              textToCopy={this.unescapeCode(
+                decodeURIComponent(
+                  this.codeType === 'wc'
+                    ? this.code
+                    : this.codeType === 'css'
+                    ? this.codeCssComponent
+                    : this.codeType === 'react'
+                    ? this.codeReactComponent
+                    : ''
+                )
+              )}
+            />
+          </div>
           <slot name="code"></slot>
+          <slot name="codeReactComponent"></slot>
           <slot name="codeCssComponent"></slot>
         </div>
       </Host>

--- a/src/docs/components/docs-nav/docs-nav.css
+++ b/src/docs/components/docs-nav/docs-nav.css
@@ -81,7 +81,7 @@
 @define-mixin docs-nav-ui-dark {
   .docs-nav__content {
     background-color: var(--ld-col-neutral-900);
-    box-shadow: var(--ld-sp-1) 0 0 0 var(--ld-col-neutral-600);
+    box-shadow: none;
   }
   .docs-nav::before {
     background-color: var(--ld-col-neutral-900);

--- a/src/liquid/components/ld-accordion/readme.md
+++ b/src/liquid/components/ld-accordion/readme.md
@@ -43,6 +43,29 @@ The `ld-accordion` component hides content in expandable sections and thereby he
     </ld-accordion-panel>
   </ld-accordion-section>
 </ld-accordion>
+
+<!-- React component -->
+
+<LdAccordion>
+  <LdAccordionSection expanded>
+    <LdAccordionToggle>Fruits</LdAccordionToggle>
+    <LdAccordionPanel>
+      <LdTypo variant="body-s" style={ { padding: 'var(--ld-sp-12) var(--ld-accordion-padding-x)' } }>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Dolor quisque lectus morbi mauris, tortor dictum elementum. Morbi volutpat senectus lacus sapien viverra quis volutpat. Mauris sed lacus ipsum dictumst egestas. Elit cras at interdum id porta magnis accumsan sit pulvinar. Mi dignissim gravida venenatis, nibh dignissim tincidunt enim. Lectus diam lobortis pharetra amet et nec. Est vitae vitae porttitor varius ac. Faucibus enim augue ac sollicitudin massa. Ipsum quis elementum amet tristique. A felis nunc iaculis maecenas id.</LdTypo>
+    </LdAccordionPanel>
+  </LdAccordionSection>
+  <LdAccordionSection>
+    <LdAccordionToggle>Vegetables</LdAccordionToggle>
+    <LdAccordionPanel>
+      <LdTypo variant="body-s" style={ { padding: 'var(--ld-sp-12) var(--ld-accordion-padding-x)' } }>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Dolor quisque lectus morbi mauris, tortor dictum elementum. Morbi volutpat senectus lacus sapien viverra quis volutpat. Mauris sed lacus ipsum dictumst egestas. Elit cras at interdum id porta magnis accumsan sit pulvinar. Mi dignissim gravida venenatis, nibh dignissim tincidunt enim. Lectus diam lobortis pharetra amet et nec. Est vitae vitae porttitor varius ac. Faucibus enim augue ac sollicitudin massa. Ipsum quis elementum amet tristique. A felis nunc iaculis maecenas id.</LdTypo>
+    </LdAccordionPanel>
+  </LdAccordionSection>
+  <LdAccordionSection>
+    <LdAccordionToggle disabled>Nuts</LdAccordionToggle>
+    <LdAccordionPanel>
+      <LdTypo variant="body-s" style={ { padding: 'var(--ld-sp-12) var(--ld-accordion-padding-x)' } }>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Dolor quisque lectus morbi mauris, tortor dictum elementum. Morbi volutpat senectus lacus sapien viverra quis volutpat. Mauris sed lacus ipsum dictumst egestas. Elit cras at interdum id porta magnis accumsan sit pulvinar. Mi dignissim gravida venenatis, nibh dignissim tincidunt enim. Lectus diam lobortis pharetra amet et nec. Est vitae vitae porttitor varius ac. Faucibus enim augue ac sollicitudin massa. Ipsum quis elementum amet tristique. A felis nunc iaculis maecenas id.</LdTypo>
+    </LdAccordionPanel>
+  </LdAccordionSection>
+</LdAccordion>
 {% endexample %}
 
 ### Rounded
@@ -51,7 +74,7 @@ Use the `rounded` prop to apply small border-radii to the accordion sections.
 
 {% example %}
 <ld-accordion rounded>
-  <ld-accordion-section expanded>
+  <ld-accordion-section>
     <ld-accordion-toggle>Fruits</ld-accordion-toggle>
     <ld-accordion-panel>
       <ld-typo variant="body-s" style="padding: var(--ld-sp-12) var(--ld-accordion-padding-x)">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Dolor quisque lectus morbi mauris, tortor dictum elementum. Morbi volutpat senectus lacus sapien viverra quis volutpat. Mauris sed lacus ipsum dictumst egestas. Elit cras at interdum id porta magnis accumsan sit pulvinar. Mi dignissim gravida venenatis, nibh dignissim tincidunt enim. Lectus diam lobortis pharetra amet et nec. Est vitae vitae porttitor varius ac. Faucibus enim augue ac sollicitudin massa. Ipsum quis elementum amet tristique. A felis nunc iaculis maecenas id.</ld-typo>
@@ -70,6 +93,29 @@ Use the `rounded` prop to apply small border-radii to the accordion sections.
     </ld-accordion-panel>
   </ld-accordion-section>
 </ld-accordion>
+
+<!-- React component -->
+
+<LdAccordion rounded>
+  <LdAccordionSection>
+    <LdAccordionToggle>Fruits</LdAccordionToggle>
+    <LdAccordionPanel>
+      <LdTypo variant="body-s" style={ { padding: 'var(--ld-sp-12) var(--ld-accordion-padding-x)' } }>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Dolor quisque lectus morbi mauris, tortor dictum elementum. Morbi volutpat senectus lacus sapien viverra quis volutpat. Mauris sed lacus ipsum dictumst egestas. Elit cras at interdum id porta magnis accumsan sit pulvinar. Mi dignissim gravida venenatis, nibh dignissim tincidunt enim. Lectus diam lobortis pharetra amet et nec. Est vitae vitae porttitor varius ac. Faucibus enim augue ac sollicitudin massa. Ipsum quis elementum amet tristique. A felis nunc iaculis maecenas id.</LdTypo>
+    </LdAccordionPanel>
+  </LdAccordionSection>
+  <LdAccordionSection>
+    <LdAccordionToggle>Vegetables</LdAccordionToggle>
+    <LdAccordionPanel>
+      <LdTypo variant="body-s" style={ { padding: 'var(--ld-sp-12) var(--ld-accordion-padding-x)' } }>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Dolor quisque lectus morbi mauris, tortor dictum elementum. Morbi volutpat senectus lacus sapien viverra quis volutpat. Mauris sed lacus ipsum dictumst egestas. Elit cras at interdum id porta magnis accumsan sit pulvinar. Mi dignissim gravida venenatis, nibh dignissim tincidunt enim. Lectus diam lobortis pharetra amet et nec. Est vitae vitae porttitor varius ac. Faucibus enim augue ac sollicitudin massa. Ipsum quis elementum amet tristique. A felis nunc iaculis maecenas id.</LdTypo>
+    </LdAccordionPanel>
+  </LdAccordionSection>
+  <LdAccordionSection>
+    <LdAccordionToggle disabled>Nuts</LdAccordionToggle>
+    <LdAccordionPanel>
+      <LdTypo variant="body-s" style={ { padding: 'var(--ld-sp-12) var(--ld-accordion-padding-x)' } }>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Dolor quisque lectus morbi mauris, tortor dictum elementum. Morbi volutpat senectus lacus sapien viverra quis volutpat. Mauris sed lacus ipsum dictumst egestas. Elit cras at interdum id porta magnis accumsan sit pulvinar. Mi dignissim gravida venenatis, nibh dignissim tincidunt enim. Lectus diam lobortis pharetra amet et nec. Est vitae vitae porttitor varius ac. Faucibus enim augue ac sollicitudin massa. Ipsum quis elementum amet tristique. A felis nunc iaculis maecenas id.</LdTypo>
+    </LdAccordionPanel>
+  </LdAccordionSection>
+</LdAccordion>
 {% endexample %}
 
 ### Dark
@@ -97,6 +143,29 @@ Use this mode on a white background.
     </ld-accordion-panel>
   </ld-accordion-section>
 </ld-accordion>
+
+<!-- React component -->
+
+<LdAccordion rounded tone="dark">
+  <LdAccordionSection>
+    <LdAccordionToggle>Fruits</LdAccordionToggle>
+    <LdAccordionPanel>
+      <LdTypo variant="body-s" style={ { padding: 'var(--ld-sp-12) var(--ld-accordion-padding-x)' } }>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Dolor quisque lectus morbi mauris, tortor dictum elementum. Morbi volutpat senectus lacus sapien viverra quis volutpat. Mauris sed lacus ipsum dictumst egestas. Elit cras at interdum id porta magnis accumsan sit pulvinar. Mi dignissim gravida venenatis, nibh dignissim tincidunt enim. Lectus diam lobortis pharetra amet et nec. Est vitae vitae porttitor varius ac. Faucibus enim augue ac sollicitudin massa. Ipsum quis elementum amet tristique. A felis nunc iaculis maecenas id.</LdTypo>
+    </LdAccordionPanel>
+  </LdAccordionSection>
+  <LdAccordionSection>
+    <LdAccordionToggle>Vegetables</LdAccordionToggle>
+    <LdAccordionPanel>
+      <LdTypo variant="body-s" style={ { padding: 'var(--ld-sp-12) var(--ld-accordion-padding-x)' } }>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Dolor quisque lectus morbi mauris, tortor dictum elementum. Morbi volutpat senectus lacus sapien viverra quis volutpat. Mauris sed lacus ipsum dictumst egestas. Elit cras at interdum id porta magnis accumsan sit pulvinar. Mi dignissim gravida venenatis, nibh dignissim tincidunt enim. Lectus diam lobortis pharetra amet et nec. Est vitae vitae porttitor varius ac. Faucibus enim augue ac sollicitudin massa. Ipsum quis elementum amet tristique. A felis nunc iaculis maecenas id.</LdTypo>
+    </LdAccordionPanel>
+  </LdAccordionSection>
+  <LdAccordionSection>
+    <LdAccordionToggle disabled>Nuts</LdAccordionToggle>
+    <LdAccordionPanel>
+      <LdTypo variant="body-s" style={ { padding: 'var(--ld-sp-12) var(--ld-accordion-padding-x)' } }>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Dolor quisque lectus morbi mauris, tortor dictum elementum. Morbi volutpat senectus lacus sapien viverra quis volutpat. Mauris sed lacus ipsum dictumst egestas. Elit cras at interdum id porta magnis accumsan sit pulvinar. Mi dignissim gravida venenatis, nibh dignissim tincidunt enim. Lectus diam lobortis pharetra amet et nec. Est vitae vitae porttitor varius ac. Faucibus enim augue ac sollicitudin massa. Ipsum quis elementum amet tristique. A felis nunc iaculis maecenas id.</LdTypo>
+    </LdAccordionPanel>
+  </LdAccordionSection>
+</LdAccordion>
 {% endexample %}
 
 ### On brand color
@@ -124,6 +193,29 @@ Use this mode on backgrounds with brand color.
     </ld-accordion-panel>
   </ld-accordion-section>
 </ld-accordion>
+
+<!-- React component -->
+
+<LdAccordion rounded brandColor>
+  <LdAccordionSection>
+    <LdAccordionToggle>Fruits</LdAccordionToggle>
+    <LdAccordionPanel>
+      <LdTypo variant="body-s" style={ { padding: 'var(--ld-sp-12) var(--ld-accordion-padding-x)' } }>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Dolor quisque lectus morbi mauris, tortor dictum elementum. Morbi volutpat senectus lacus sapien viverra quis volutpat. Mauris sed lacus ipsum dictumst egestas. Elit cras at interdum id porta magnis accumsan sit pulvinar. Mi dignissim gravida venenatis, nibh dignissim tincidunt enim. Lectus diam lobortis pharetra amet et nec. Est vitae vitae porttitor varius ac. Faucibus enim augue ac sollicitudin massa. Ipsum quis elementum amet tristique. A felis nunc iaculis maecenas id.</LdTypo>
+    </LdAccordionPanel>
+  </LdAccordionSection>
+  <LdAccordionSection>
+    <LdAccordionToggle>Vegetables</LdAccordionToggle>
+    <LdAccordionPanel>
+      <LdTypo variant="body-s" style={ { padding: 'var(--ld-sp-12) var(--ld-accordion-padding-x)' } }>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Dolor quisque lectus morbi mauris, tortor dictum elementum. Morbi volutpat senectus lacus sapien viverra quis volutpat. Mauris sed lacus ipsum dictumst egestas. Elit cras at interdum id porta magnis accumsan sit pulvinar. Mi dignissim gravida venenatis, nibh dignissim tincidunt enim. Lectus diam lobortis pharetra amet et nec. Est vitae vitae porttitor varius ac. Faucibus enim augue ac sollicitudin massa. Ipsum quis elementum amet tristique. A felis nunc iaculis maecenas id.</LdTypo>
+    </LdAccordionPanel>
+  </LdAccordionSection>
+  <LdAccordionSection>
+    <LdAccordionToggle disabled>Nuts</LdAccordionToggle>
+    <LdAccordionPanel>
+      <LdTypo variant="body-s" style={ { padding: 'var(--ld-sp-12) var(--ld-accordion-padding-x)' } }>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Dolor quisque lectus morbi mauris, tortor dictum elementum. Morbi volutpat senectus lacus sapien viverra quis volutpat. Mauris sed lacus ipsum dictumst egestas. Elit cras at interdum id porta magnis accumsan sit pulvinar. Mi dignissim gravida venenatis, nibh dignissim tincidunt enim. Lectus diam lobortis pharetra amet et nec. Est vitae vitae porttitor varius ac. Faucibus enim augue ac sollicitudin massa. Ipsum quis elementum amet tristique. A felis nunc iaculis maecenas id.</LdTypo>
+    </LdAccordionPanel>
+  </LdAccordionSection>
+</LdAccordion>
 {% endexample %}
 
 ### Single mode
@@ -151,6 +243,29 @@ When the prop `single` is set, only a single accordion panel can be expanded at 
     </ld-accordion-panel>
   </ld-accordion-section>
 </ld-accordion>
+
+<!-- React component -->
+
+<LdAccordion rounded single>
+  <LdAccordionSection>
+    <LdAccordionToggle>Fruits</LdAccordionToggle>
+    <LdAccordionPanel>
+      <LdTypo variant="body-s" style={ { padding: 'var(--ld-sp-12) var(--ld-accordion-padding-x)' } }>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Dolor quisque lectus morbi mauris, tortor dictum elementum. Morbi volutpat senectus lacus sapien viverra quis volutpat. Mauris sed lacus ipsum dictumst egestas. Elit cras at interdum id porta magnis accumsan sit pulvinar. Mi dignissim gravida venenatis, nibh dignissim tincidunt enim. Lectus diam lobortis pharetra amet et nec. Est vitae vitae porttitor varius ac. Faucibus enim augue ac sollicitudin massa. Ipsum quis elementum amet tristique. A felis nunc iaculis maecenas id.</LdTypo>
+    </LdAccordionPanel>
+  </LdAccordionSection>
+  <LdAccordionSection>
+    <LdAccordionToggle>Vegetables</LdAccordionToggle>
+    <LdAccordionPanel>
+      <LdTypo variant="body-s" style={ { padding: 'var(--ld-sp-12) var(--ld-accordion-padding-x)' } }>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Dolor quisque lectus morbi mauris, tortor dictum elementum. Morbi volutpat senectus lacus sapien viverra quis volutpat. Mauris sed lacus ipsum dictumst egestas. Elit cras at interdum id porta magnis accumsan sit pulvinar. Mi dignissim gravida venenatis, nibh dignissim tincidunt enim. Lectus diam lobortis pharetra amet et nec. Est vitae vitae porttitor varius ac. Faucibus enim augue ac sollicitudin massa. Ipsum quis elementum amet tristique. A felis nunc iaculis maecenas id.</LdTypo>
+    </LdAccordionPanel>
+  </LdAccordionSection>
+  <LdAccordionSection>
+    <LdAccordionToggle disabled>Nuts</LdAccordionToggle>
+    <LdAccordionPanel>
+      <LdTypo variant="body-s" style={ { padding: 'var(--ld-sp-12) var(--ld-accordion-padding-x)' } }>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Dolor quisque lectus morbi mauris, tortor dictum elementum. Morbi volutpat senectus lacus sapien viverra quis volutpat. Mauris sed lacus ipsum dictumst egestas. Elit cras at interdum id porta magnis accumsan sit pulvinar. Mi dignissim gravida venenatis, nibh dignissim tincidunt enim. Lectus diam lobortis pharetra amet et nec. Est vitae vitae porttitor varius ac. Faucibus enim augue ac sollicitudin massa. Ipsum quis elementum amet tristique. A felis nunc iaculis maecenas id.</LdTypo>
+    </LdAccordionPanel>
+  </LdAccordionSection>
+</LdAccordion>
 {% endexample %}
 
 ### Detached mode
@@ -178,6 +293,29 @@ In `detached` mode there is a small gap between each accordion section element.
     </ld-accordion-panel>
   </ld-accordion-section>
 </ld-accordion>
+
+<!-- React component -->
+
+<LdAccordion rounded detached>
+  <LdAccordionSection>
+    <LdAccordionToggle>Fruits</LdAccordionToggle>
+    <LdAccordionPanel>
+      <LdTypo variant="body-s" style={ { padding: 'var(--ld-sp-12) var(--ld-accordion-padding-x)' } }>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Dolor quisque lectus morbi mauris, tortor dictum elementum. Morbi volutpat senectus lacus sapien viverra quis volutpat. Mauris sed lacus ipsum dictumst egestas. Elit cras at interdum id porta magnis accumsan sit pulvinar. Mi dignissim gravida venenatis, nibh dignissim tincidunt enim. Lectus diam lobortis pharetra amet et nec. Est vitae vitae porttitor varius ac. Faucibus enim augue ac sollicitudin massa. Ipsum quis elementum amet tristique. A felis nunc iaculis maecenas id.</LdTypo>
+    </LdAccordionPanel>
+  </LdAccordionSection>
+  <LdAccordionSection>
+    <LdAccordionToggle>Vegetables</LdAccordionToggle>
+    <LdAccordionPanel>
+      <LdTypo variant="body-s" style={ { padding: 'var(--ld-sp-12) var(--ld-accordion-padding-x)' } }>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Dolor quisque lectus morbi mauris, tortor dictum elementum. Morbi volutpat senectus lacus sapien viverra quis volutpat. Mauris sed lacus ipsum dictumst egestas. Elit cras at interdum id porta magnis accumsan sit pulvinar. Mi dignissim gravida venenatis, nibh dignissim tincidunt enim. Lectus diam lobortis pharetra amet et nec. Est vitae vitae porttitor varius ac. Faucibus enim augue ac sollicitudin massa. Ipsum quis elementum amet tristique. A felis nunc iaculis maecenas id.</LdTypo>
+    </LdAccordionPanel>
+  </LdAccordionSection>
+  <LdAccordionSection>
+    <LdAccordionToggle disabled>Nuts</LdAccordionToggle>
+    <LdAccordionPanel>
+      <LdTypo variant="body-s" style={ { padding: 'var(--ld-sp-12) var(--ld-accordion-padding-x)' } }>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Dolor quisque lectus morbi mauris, tortor dictum elementum. Morbi volutpat senectus lacus sapien viverra quis volutpat. Mauris sed lacus ipsum dictumst egestas. Elit cras at interdum id porta magnis accumsan sit pulvinar. Mi dignissim gravida venenatis, nibh dignissim tincidunt enim. Lectus diam lobortis pharetra amet et nec. Est vitae vitae porttitor varius ac. Faucibus enim augue ac sollicitudin massa. Ipsum quis elementum amet tristique. A felis nunc iaculis maecenas id.</LdTypo>
+    </LdAccordionPanel>
+  </LdAccordionSection>
+</LdAccordion>
 {% endexample %}
 
 ### Split toggle
@@ -205,6 +343,29 @@ The `split` prop allows you to separate an accordion toggle in two click areas. 
     </ld-accordion-panel>
   </ld-accordion-section>
 </ld-accordion>
+
+<!-- React component -->
+
+<LdAccordion rounded>
+  <LdAccordionSection>
+    <LdAccordionToggle split>Fruits</LdAccordionToggle>
+    <LdAccordionPanel>
+      <LdTypo variant="body-s" style={ { padding: 'var(--ld-sp-12) var(--ld-accordion-padding-x)' } }>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Dolor quisque lectus morbi mauris, tortor dictum elementum. Morbi volutpat senectus lacus sapien viverra quis volutpat. Mauris sed lacus ipsum dictumst egestas. Elit cras at interdum id porta magnis accumsan sit pulvinar. Mi dignissim gravida venenatis, nibh dignissim tincidunt enim. Lectus diam lobortis pharetra amet et nec. Est vitae vitae porttitor varius ac. Faucibus enim augue ac sollicitudin massa. Ipsum quis elementum amet tristique. A felis nunc iaculis maecenas id.</LdTypo>
+    </LdAccordionPanel>
+  </LdAccordionSection>
+  <LdAccordionSection>
+    <LdAccordionToggle split>Vegetables</LdAccordionToggle>
+    <LdAccordionPanel>
+      <LdTypo variant="body-s" style={ { padding: 'var(--ld-sp-12) var(--ld-accordion-padding-x)' } }>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Dolor quisque lectus morbi mauris, tortor dictum elementum. Morbi volutpat senectus lacus sapien viverra quis volutpat. Mauris sed lacus ipsum dictumst egestas. Elit cras at interdum id porta magnis accumsan sit pulvinar. Mi dignissim gravida venenatis, nibh dignissim tincidunt enim. Lectus diam lobortis pharetra amet et nec. Est vitae vitae porttitor varius ac. Faucibus enim augue ac sollicitudin massa. Ipsum quis elementum amet tristique. A felis nunc iaculis maecenas id.</LdTypo>
+    </LdAccordionPanel>
+  </LdAccordionSection>
+  <LdAccordionSection>
+    <LdAccordionToggle split disabled>Nuts</LdAccordionToggle>
+    <LdAccordionPanel>
+      <LdTypo variant="body-s" style={ { padding: 'var(--ld-sp-12) var(--ld-accordion-padding-x)' } }>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Dolor quisque lectus morbi mauris, tortor dictum elementum. Morbi volutpat senectus lacus sapien viverra quis volutpat. Mauris sed lacus ipsum dictumst egestas. Elit cras at interdum id porta magnis accumsan sit pulvinar. Mi dignissim gravida venenatis, nibh dignissim tincidunt enim. Lectus diam lobortis pharetra amet et nec. Est vitae vitae porttitor varius ac. Faucibus enim augue ac sollicitudin massa. Ipsum quis elementum amet tristique. A felis nunc iaculis maecenas id.</LdTypo>
+    </LdAccordionPanel>
+  </LdAccordionSection>
+</LdAccordion>
 {% endexample %}
 
 ## Events
@@ -212,7 +373,7 @@ The `split` prop allows you to separate an accordion toggle in two click areas. 
 You can listen for several events on the `ld-accordion` component and its subcomponents. Please refer to each subcomponent's documentation for details on all available events. The following example demonstrates how you can listen to the `ldaccordionchange` event which is emitted each time a (non-disabled) section expands or collapses.
 
 {% example %}
-<ld-accordion rounded id="accordion-events">
+<ld-accordion rounded>
   <ld-accordion-section>
     <ld-accordion-toggle>Fruits</ld-accordion-toggle>
     <ld-accordion-panel>
@@ -232,12 +393,89 @@ You can listen for several events on the `ld-accordion` component and its subcom
     </ld-accordion-panel>
   </ld-accordion-section>
 </ld-accordion>
-
 <script>
-  document.getElementById('accordion-events').addEventListener('ldaccordionchange', ev => {
+  document.currentScript.previousElementSibling.addEventListener('ldaccordionchange', ev => {
     window.alert(`${ev.detail ? 'Expanding' : 'Collapsing'} "${ev.target.querySelector('ld-accordion-toggle').textContent}".`)
   })
 </script>
+
+<!-- React component -->
+
+<LdAccordion
+  {...{
+    onLdaccordionchange: (ev) => {
+      window.alert(
+        `${ev.detail ? 'Expanding' : 'Collapsing'} "${
+          ev.target.querySelector('ld-accordion-toggle').textContent
+        }".`
+      )
+    },
+  }}
+>
+  <LdAccordionSection>
+    <LdAccordionToggle>Fruits</LdAccordionToggle>
+    <LdAccordionPanel>
+      <LdTypo
+        variant="body-s"
+        style={ {
+          padding: 'var(--ld-sp-12) var(--ld-accordion-padding-x)',
+        } }
+      >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Dolor
+        quisque lectus morbi mauris, tortor dictum elementum. Morbi
+        volutpat senectus lacus sapien viverra quis volutpat. Mauris sed
+        lacus ipsum dictumst egestas. Elit cras at interdum id porta
+        magnis accumsan sit pulvinar. Mi dignissim gravida venenatis, nibh
+        dignissim tincidunt enim. Lectus diam lobortis pharetra amet et
+        nec. Est vitae vitae porttitor varius ac. Faucibus enim augue ac
+        sollicitudin massa. Ipsum quis elementum amet tristique. A felis
+        nunc iaculis maecenas id.
+      </LdTypo>
+    </LdAccordionPanel>
+  </LdAccordionSection>
+  <LdAccordionSection>
+    <LdAccordionToggle>Vegetables</LdAccordionToggle>
+    <LdAccordionPanel>
+      <LdTypo
+        variant="body-s"
+        style={ {
+          padding: 'var(--ld-sp-12) var(--ld-accordion-padding-x)',
+        } }
+      >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Dolor
+        quisque lectus morbi mauris, tortor dictum elementum. Morbi
+        volutpat senectus lacus sapien viverra quis volutpat. Mauris sed
+        lacus ipsum dictumst egestas. Elit cras at interdum id porta
+        magnis accumsan sit pulvinar. Mi dignissim gravida venenatis, nibh
+        dignissim tincidunt enim. Lectus diam lobortis pharetra amet et
+        nec. Est vitae vitae porttitor varius ac. Faucibus enim augue ac
+        sollicitudin massa. Ipsum quis elementum amet tristique. A felis
+        nunc iaculis maecenas id.
+      </LdTypo>
+    </LdAccordionPanel>
+  </LdAccordionSection>
+  <LdAccordionSection>
+    <LdAccordionToggle disabled>Nuts</LdAccordionToggle>
+    <LdAccordionPanel>
+      <LdTypo
+        variant="body-s"
+        style={ {
+          padding: 'var(--ld-sp-12) var(--ld-accordion-padding-x)',
+        } }
+      >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Dolor
+        quisque lectus morbi mauris, tortor dictum elementum. Morbi
+        volutpat senectus lacus sapien viverra quis volutpat. Mauris sed
+        lacus ipsum dictumst egestas. Elit cras at interdum id porta
+        magnis accumsan sit pulvinar. Mi dignissim gravida venenatis, nibh
+        dignissim tincidunt enim. Lectus diam lobortis pharetra amet et
+        nec. Est vitae vitae porttitor varius ac. Faucibus enim augue ac
+        sollicitudin massa. Ipsum quis elementum amet tristique. A felis
+        nunc iaculis maecenas id.
+      </LdTypo>
+    </LdAccordionPanel>
+  </LdAccordionSection>
+</LdAccordion>
 {% endexample %}
 
 ## Expand and collapse accordion sections programmatically
@@ -247,7 +485,7 @@ You can programmatically expand or collapse an accordion section by toggling the
 {% example '{ "stacked": true }' %}
 <ld-label>
   Toggle "Vegetables"
-  <ld-toggle id="vegetables-toggle">Toggle vegetables tab</ld-toggle>
+  <ld-toggle>Toggle vegetables tab</ld-toggle>
 </ld-label>
 
 <ld-accordion rounded id="accordion-programmatic">
@@ -272,9 +510,9 @@ You can programmatically expand or collapse an accordion section by toggling the
 </ld-accordion>
 
 <script>
-  const toggleVegetables = document.getElementById('vegetables-toggle')
-  const sectionVegetables = document.querySelector('#accordion-programmatic ld-accordion-section:nth-of-type(2)')
-
+  const accordion = document.currentScript.previousElementSibling
+  const sectionVegetables = accordion.querySelector('ld-accordion-section:nth-of-type(2)')
+  const toggleVegetables = accordion.previousElementSibling.querySelector('ld-toggle')
   toggleVegetables.addEventListener('ldinput', ev => {
     sectionVegetables.expanded = ev.target.checked
   })
@@ -282,6 +520,97 @@ You can programmatically expand or collapse an accordion section by toggling the
     toggleVegetables.checked = ev.detail
   })
 </script>
+
+<!-- React component -->
+
+const App = () => {
+  const [vegetablesExpanded, setVegetablesExpanded] = useState(false)
+  return (
+    <>
+      <LdLabel>
+        Toggle "Vegetables"
+        <LdToggle
+          checked={vegetablesExpanded}
+          onLdinput={(ev) => {
+            setVegetablesExpanded(ev.target.checked)
+          }}
+        >
+          Toggle vegetables tab
+        </LdToggle>
+      </LdLabel>
+      <LdAccordion>
+        <LdAccordionSection>
+          <LdAccordionToggle>Fruits</LdAccordionToggle>
+          <LdAccordionPanel>
+            <LdTypo
+              variant="body-s"
+              style={ {
+                padding: 'var(--ld-sp-12) var(--ld-accordion-padding-x)',
+              } }
+            >
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Dolor
+              quisque lectus morbi mauris, tortor dictum elementum. Morbi
+              volutpat senectus lacus sapien viverra quis volutpat. Mauris sed
+              lacus ipsum dictumst egestas. Elit cras at interdum id porta
+              magnis accumsan sit pulvinar. Mi dignissim gravida venenatis, nibh
+              dignissim tincidunt enim. Lectus diam lobortis pharetra amet et
+              nec. Est vitae vitae porttitor varius ac. Faucibus enim augue ac
+              sollicitudin massa. Ipsum quis elementum amet tristique. A felis
+              nunc iaculis maecenas id.
+            </LdTypo>
+          </LdAccordionPanel>
+        </LdAccordionSection>
+        <LdAccordionSection
+          onLdaccordionchange={(ev) => {
+            setVegetablesExpanded(ev.detail)
+          }}
+          expanded={vegetablesExpanded}
+        >
+          <LdAccordionToggle>Vegetables</LdAccordionToggle>
+          <LdAccordionPanel>
+            <LdTypo
+              variant="body-s"
+              style={ {
+                padding: 'var(--ld-sp-12) var(--ld-accordion-padding-x)',
+              } }
+            >
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Dolor
+              quisque lectus morbi mauris, tortor dictum elementum. Morbi
+              volutpat senectus lacus sapien viverra quis volutpat. Mauris sed
+              lacus ipsum dictumst egestas. Elit cras at interdum id porta
+              magnis accumsan sit pulvinar. Mi dignissim gravida venenatis, nibh
+              dignissim tincidunt enim. Lectus diam lobortis pharetra amet et
+              nec. Est vitae vitae porttitor varius ac. Faucibus enim augue ac
+              sollicitudin massa. Ipsum quis elementum amet tristique. A felis
+              nunc iaculis maecenas id.
+            </LdTypo>
+          </LdAccordionPanel>
+        </LdAccordionSection>
+        <LdAccordionSection>
+          <LdAccordionToggle disabled>Nuts</LdAccordionToggle>
+          <LdAccordionPanel>
+            <LdTypo
+              variant="body-s"
+              style={ {
+                padding: 'var(--ld-sp-12) var(--ld-accordion-padding-x)',
+              } }
+            >
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Dolor
+              quisque lectus morbi mauris, tortor dictum elementum. Morbi
+              volutpat senectus lacus sapien viverra quis volutpat. Mauris sed
+              lacus ipsum dictumst egestas. Elit cras at interdum id porta
+              magnis accumsan sit pulvinar. Mi dignissim gravida venenatis, nibh
+              dignissim tincidunt enim. Lectus diam lobortis pharetra amet et
+              nec. Est vitae vitae porttitor varius ac. Faucibus enim augue ac
+              sollicitudin massa. Ipsum quis elementum amet tristique. A felis
+              nunc iaculis maecenas id.
+            </LdTypo>
+          </LdAccordionPanel>
+        </LdAccordionSection>
+      </LdAccordion>
+    </>
+  )
+}
 {% endexample %}
 
 ## Nesting
@@ -334,6 +663,153 @@ You can nest an accordion inside another.
     </ld-accordion-panel>
   </ld-accordion-section>
 </ld-accordion>
+
+<!-- React component -->
+
+<LdAccordion>
+  <LdAccordionSection expanded>
+    <LdAccordionToggle>Fruits</LdAccordionToggle>
+    <LdAccordionPanel>
+      <LdAccordion
+        tone="dark"
+        style={ {
+          padding: 'var(--ld-sp-24) var(--ld-accordion-padding-x)',
+        } }
+      >
+        <LdAccordionSection>
+          <LdAccordionToggle>Sweet</LdAccordionToggle>
+          <LdAccordionPanel>
+            <LdTypo
+              variant="body-s"
+              style={ {
+                padding: 'var(--ld-sp-12) var(--ld-accordion-padding-x)',
+              } }
+            >
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+              Dolor quisque lectus morbi mauris, tortor dictum elementum.
+              Morbi volutpat senectus lacus sapien viverra quis volutpat.
+              Mauris sed lacus ipsum dictumst egestas. Elit cras at
+              interdum id porta magnis accumsan sit pulvinar. Mi dignissim
+              gravida venenatis, nibh dignissim tincidunt enim. Lectus
+              diam lobortis pharetra amet et nec. Est vitae vitae
+              porttitor varius ac. Faucibus enim augue ac sollicitudin
+              massa. Ipsum quis elementum amet tristique. A felis nunc
+              iaculis maecenas id.
+            </LdTypo>
+          </LdAccordionPanel>
+        </LdAccordionSection>
+        <LdAccordionSection expanded>
+          <LdAccordionToggle>Sour</LdAccordionToggle>
+          <LdAccordionPanel>
+            <LdTypo
+              variant="body-s"
+              style={ {
+                padding: 'var(--ld-sp-12) var(--ld-accordion-padding-x)',
+              } }
+            >
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+              Dolor quisque lectus morbi mauris, tortor dictum elementum.
+              Morbi volutpat senectus lacus sapien viverra quis volutpat.
+              Mauris sed lacus ipsum dictumst egestas. Elit cras at
+              interdum id porta magnis accumsan sit pulvinar. Mi dignissim
+              gravida venenatis, nibh dignissim tincidunt enim. Lectus
+              diam lobortis pharetra amet et nec. Est vitae vitae
+              porttitor varius ac. Faucibus enim augue ac sollicitudin
+              massa. Ipsum quis elementum amet tristique. A felis nunc
+              iaculis maecenas id.
+            </LdTypo>
+          </LdAccordionPanel>
+        </LdAccordionSection>
+        <LdAccordionSection>
+          <LdAccordionToggle>Bitter</LdAccordionToggle>
+          <LdAccordionPanel>
+            <LdTypo
+              variant="body-s"
+              style={ {
+                padding: 'var(--ld-sp-12) var(--ld-accordion-padding-x)',
+              } }
+            >
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+              Dolor quisque lectus morbi mauris, tortor dictum elementum.
+              Morbi volutpat senectus lacus sapien viverra quis volutpat.
+              Mauris sed lacus ipsum dictumst egestas. Elit cras at
+              interdum id porta magnis accumsan sit pulvinar. Mi dignissim
+              gravida venenatis, nibh dignissim tincidunt enim. Lectus
+              diam lobortis pharetra amet et nec. Est vitae vitae
+              porttitor varius ac. Faucibus enim augue ac sollicitudin
+              massa. Ipsum quis elementum amet tristique. A felis nunc
+              iaculis maecenas id.
+            </LdTypo>
+          </LdAccordionPanel>
+        </LdAccordionSection>
+        <LdAccordionSection>
+          <LdAccordionToggle disabled>Salty</LdAccordionToggle>
+          <LdAccordionPanel>
+            <LdTypo
+              variant="body-s"
+              style={ {
+                padding: 'var(--ld-sp-12) var(--ld-accordion-padding-x)',
+              } }
+            >
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+              Dolor quisque lectus morbi mauris, tortor dictum elementum.
+              Morbi volutpat senectus lacus sapien viverra quis volutpat.
+              Mauris sed lacus ipsum dictumst egestas. Elit cras at
+              interdum id porta magnis accumsan sit pulvinar. Mi dignissim
+              gravida venenatis, nibh dignissim tincidunt enim. Lectus
+              diam lobortis pharetra amet et nec. Est vitae vitae
+              porttitor varius ac. Faucibus enim augue ac sollicitudin
+              massa. Ipsum quis elementum amet tristique. A felis nunc
+              iaculis maecenas id.
+            </LdTypo>
+          </LdAccordionPanel>
+        </LdAccordionSection>
+      </LdAccordion>
+    </LdAccordionPanel>
+  </LdAccordionSection>
+  <LdAccordionSection>
+    <LdAccordionToggle>Vegetables</LdAccordionToggle>
+    <LdAccordionPanel>
+      <LdTypo
+        variant="body-s"
+        style={ {
+          padding: 'var(--ld-sp-12) var(--ld-accordion-padding-x)',
+        } }
+      >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Dolor
+        quisque lectus morbi mauris, tortor dictum elementum. Morbi
+        volutpat senectus lacus sapien viverra quis volutpat. Mauris sed
+        lacus ipsum dictumst egestas. Elit cras at interdum id porta
+        magnis accumsan sit pulvinar. Mi dignissim gravida venenatis, nibh
+        dignissim tincidunt enim. Lectus diam lobortis pharetra amet et
+        nec. Est vitae vitae porttitor varius ac. Faucibus enim augue ac
+        sollicitudin massa. Ipsum quis elementum amet tristique. A felis
+        nunc iaculis maecenas id.
+      </LdTypo>
+    </LdAccordionPanel>
+  </LdAccordionSection>
+  <LdAccordionSection>
+    <LdAccordionToggle disabled>Nuts</LdAccordionToggle>
+    <LdAccordionPanel>
+      <LdTypo
+        variant="body-s"
+        style={ {
+          padding: 'var(--ld-sp-12) var(--ld-accordion-padding-x)',
+        } }
+      >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Dolor
+        quisque lectus morbi mauris, tortor dictum elementum. Morbi
+        volutpat senectus lacus sapien viverra quis volutpat. Mauris sed
+        lacus ipsum dictumst egestas. Elit cras at interdum id porta
+        magnis accumsan sit pulvinar. Mi dignissim gravida venenatis, nibh
+        dignissim tincidunt enim. Lectus diam lobortis pharetra amet et
+        nec. Est vitae vitae porttitor varius ac. Faucibus enim augue ac
+        sollicitudin massa. Ipsum quis elementum amet tristique. A felis
+        nunc iaculis maecenas id.
+      </LdTypo>
+    </LdAccordionPanel>
+  </LdAccordionSection>
+</LdAccordion>
 {% endexample %}
 
 <!-- Auto Generated Below -->

--- a/src/liquid/components/ld-button/readme.md
+++ b/src/liquid/components/ld-button/readme.md
@@ -24,6 +24,10 @@ Icon-buttons without visual text should either contain a [screen-reader-only](co
 {% example %}
 <ld-button>Text</ld-button>
 
+<!-- React component -->
+
+<LdButton>Text</LdButton>
+
 <!-- CSS component -->
 
 <button class="ld-button">Text</button>
@@ -32,18 +36,32 @@ Icon-buttons without visual text should either contain a [screen-reader-only](co
 ### Disabled
 
 {% example %}
-<ld-button id="disabled-button-1" disabled>Text</ld-button>
+<ld-button disabled>Text</ld-button>
 <script>
-  document.getElementById('disabled-button-1').addEventListener('click', () => { window.alert('click') })
-  // The event handler won't be called.
+  document.currentScript.previousElementSibling
+    .addEventListener('click', (ev) => { window.alert('click') })
+    // The event handler won't be called.
 </script>
+
+<!-- React component -->
+
+<LdButton
+  disabled
+  onClick={() => {
+    window.alert('click')
+    // The event handler won't be called.
+  }}
+>
+  Text
+</LdButton>
 
 <!-- CSS component -->
 
-<button id="disabled-button-2" class="ld-button" disabled>Text</button>
+<button class="ld-button" disabled>Text</button>
 <script>
-  document.getElementById('disabled-button-2').addEventListener('click', () => { window.alert('click') })
-  // The event handler won't be called.
+  document.currentScript.previousElementSibling
+    .addEventListener('click', (ev) => { window.alert('click') })
+    // The event handler won't be called.
 </script>
 {% endexample %}
 
@@ -53,20 +71,32 @@ Although `aria-disabled="true"` is not necessary on a `button` element (or any o
 **If you want the button to stay focusable** even if it is disabled, use `aria-disabled` in place of `disabled`:
 
 {% example %}
-<ld-button id="disabled-button-3" aria-disabled="true">Text</ld-button>
+<ld-button aria-disabled="true">Text</ld-button>
 <script>
-  document.getElementById('disabled-button-3').addEventListener('click', () => { window.alert('click') })
+  document.currentScript.previousElementSibling.addEventListener('click', () => { window.alert('click') })
   // The event handler won't be called.
 </script>
 
+<!-- React component -->
+
+<LdButton
+  aria-disabled="true"
+  onClick={() => {
+    window.alert('click')
+    // The event handler won't be called.
+  }}
+>
+  Text
+</LdButton>
+
 <!-- CSS component -->
 
-<button id="disabled-button-4" class="ld-button" aria-disabled="true">
+<button class="ld-button" aria-disabled="true">
   Text
 </button>
 <script>
   // When using the CSS component, you will need to prevent the default behaviour of the button yourself.
-  document.getElementById('disabled-button-4').addEventListener('click', (ev) => {
+  document.currentScript.previousElementSibling.addEventListener('click', (ev) => {
     console.info('preventing default behaviour')
     ev.preventDefault()
     ev.stopImmediatePropagation()
@@ -84,13 +114,13 @@ Although `aria-disabled="true"` is not necessary on a `button` element (or any o
 {% example %}
 <ld-button mode="secondary">Text</ld-button>
 
-<ld-button mode="secondary" disabled>Text</ld-button>
+<!-- React component -->
+
+<LdButton mode="secondary">Text</LdButton>
 
 <!-- CSS component -->
 
 <button class="ld-button ld-button--secondary">Text</button>
-
-<button class="ld-button ld-button--secondary" disabled>Text</button>
 {% endexample %}
 
 ### Ghost
@@ -98,13 +128,13 @@ Although `aria-disabled="true"` is not necessary on a `button` element (or any o
 {% example %}
 <ld-button mode="ghost">Text</ld-button>
 
-<ld-button mode="ghost" disabled>Text</ld-button>
+<!-- React component -->
+
+<LdButton mode="ghost">Text</LdButton>
 
 <!-- CSS component -->
 
 <button class="ld-button ld-button--ghost">Text</button>
-
-<button class="ld-button ld-button--ghost" disabled>Text</button>
 {% endexample %}
 
 ### On brand color
@@ -112,29 +142,25 @@ Although `aria-disabled="true"` is not necessary on a `button` element (or any o
 {% example '{ "background": "brand", "hasBorder": false }' %}
 <ld-button brand-color>Text</ld-button>
 
-<ld-button brand-color disabled>Text</ld-button>
-
 <ld-button mode="secondary" brand-color>Text</ld-button>
-
-<ld-button mode="secondary" brand-color disabled>Text</ld-button>
 
 <ld-button mode="ghost" brand-color>Text</ld-button>
 
-<ld-button mode="ghost" brand-color disabled>Text</ld-button>
+<!-- React component -->
+
+<LdButton brandColor>Text</LdButton>
+
+<LdButton mode="secondary" brandColor>Text</LdButton>
+
+<LdButton mode="ghost" brandColor>Text</LdButton>
 
 <!-- CSS component -->
 
 <button class="ld-button ld-button--brand-color">Text</button>
 
-<button class="ld-button ld-button--brand-color" disabled>Text</button>
-
 <button class="ld-button ld-button--secondary ld-button--brand-color">Text</button>
 
-<button class="ld-button ld-button--secondary ld-button--brand-color" disabled>Text</button>
-
 <button class="ld-button ld-button--ghost ld-button--brand-color">Text</button>
-
-<button class="ld-button ld-button--ghost ld-button--brand-color" disabled>Text</button>
 {% endexample %}
 
 ### Highlight
@@ -142,13 +168,13 @@ Although `aria-disabled="true"` is not necessary on a `button` element (or any o
 {% example %}
 <ld-button mode="highlight">Text</ld-button>
 
-<ld-button mode="highlight" disabled>Text</ld-button>
+<!-- React component -->
+
+<LdButton mode="highlight">Text</LdButton>
 
 <!-- CSS component -->
 
 <button class="ld-button ld-button--highlight">Text</button>
-
-<button class="ld-button ld-button--highlight" disabled>Text</button>
 {% endexample %}
 
 ### Danger
@@ -156,13 +182,13 @@ Although `aria-disabled="true"` is not necessary on a `button` element (or any o
 {% example %}
 <ld-button mode="danger">Text</ld-button>
 
-<ld-button mode="danger" disabled>Text</ld-button>
+<!-- React component -->
+
+<LdButton mode="danger">Text</LdButton>
 
 <!-- CSS component -->
 
 <button class="ld-button ld-button--danger">Text</button>
-
-<button class="ld-button ld-button--danger" disabled>Text</button>
 {% endexample %}
 
 ### Danger secondary
@@ -170,13 +196,13 @@ Although `aria-disabled="true"` is not necessary on a `button` element (or any o
 {% example %}
 <ld-button mode="danger-secondary">Text</ld-button>
 
-<ld-button mode="danger-secondary" disabled>Text</ld-button>
+<!-- React component -->
+
+<LdButton mode="danger-secondary">Text</LdButton>
 
 <!-- CSS component -->
 
 <button class="ld-button ld-button--danger-secondary">Text</button>
-
-<button class="ld-button ld-button--danger-secondary" disabled>Text</button>
 {% endexample %}
 
 ### Size
@@ -187,6 +213,14 @@ Although `aria-disabled="true"` is not necessary on a `button` element (or any o
 <ld-button>Text</ld-button>
 
 <ld-button size="lg">Text</ld-button>
+
+<!-- React component -->
+
+<LdButton size="sm">Text</LdButton>
+
+<LdButton>Text</LdButton>
+
+<LdButton size="lg">Text</LdButton>
 
 <!-- CSS component -->
 
@@ -226,6 +260,35 @@ Although `aria-disabled="true"` is not necessary on a `button` element (or any o
   <ld-icon name="placeholder" size="lg"></ld-icon>
   Text
 </ld-button>
+
+<!-- React component -->
+
+<LdButton size="sm">
+  <LdIcon name="placeholder" size="sm" aria-label="Text" />
+</LdButton>
+
+<LdButton>
+  <LdIcon name="placeholder" aria-label="Text" />
+</LdButton>
+
+<LdButton size="lg">
+  <LdIcon name="placeholder" size="lg" aria-label="Text" />
+</LdButton>
+
+<LdButton mode="highlight" size="sm">
+  <LdIcon name="placeholder" size="sm" />
+  Text
+</LdButton>
+
+<LdButton mode="danger">
+  Text
+  <LdIcon name="placeholder" />
+</LdButton>
+
+<LdButton mode="secondary" size="lg">
+  <LdIcon name="placeholder" size="lg" />
+  Text
+</LdButton>
 
 <!-- CSS component -->
 
@@ -301,6 +364,16 @@ To give a button a custom width, simply assign the `width` or `min-width` CSS pr
   <ld-button>Text</ld-button>
 </div>
 
+<!-- React component -->
+
+<LdButton style={ { width: '18rem' } }>
+  Text
+</LdButton>
+
+<div style={ { display: 'inline-grid', width: '18rem' } }>
+  <LdButton>Text</LdButton>
+</div>
+
 <!-- CSS component -->
 
 <button class="ld-button" style="width: 18rem">Text</button>
@@ -313,7 +386,7 @@ To give a button a custom width, simply assign the `width` or `min-width` CSS pr
 ### Justify content
 
 {% example %}
-<ld-button style="width: 8rem" justify-content="center">
+<ld-button style="width: 8rem">
   Text
   <ld-icon name="placeholder"></ld-icon>
 </ld-button>
@@ -332,6 +405,39 @@ To give a button a custom width, simply assign the `width` or `min-width` CSS pr
   Text
   <ld-icon name="placeholder"></ld-icon>
 </ld-button>
+
+<!-- React component -->
+
+<LdButton
+  style={ { width: '8rem' } }
+>
+  Text
+  <LdIcon name="placeholder" />
+</LdButton>
+
+<LdButton
+  style={ { width: '8rem' } }
+  justifyContent="start"
+>
+  Text
+  <LdIcon name="placeholder" />
+</LdButton>
+
+<LdButton
+  style={ { width: '8rem' } }
+  justifyContent="end"
+>
+  Text
+  <LdIcon name="placeholder" />
+</LdButton>
+
+<LdButton
+  style={ { width: '8rem' } }
+  justifyContent="between"
+>
+  Text
+  <LdIcon name="placeholder" />
+</LdButton>
 
 <!-- CSS component -->
 
@@ -405,6 +511,28 @@ You can align the text inside the button using the `align-text` propperty.
   <ld-icon name="placeholder"></ld-icon>
 </ld-button>
 
+<!-- React component -->
+
+<LdButton>
+  Almost before we knew it, we had left the ground.
+  A shining crescent far beneath the flying vessel.
+  Then came the night of the first falling star.
+</LdButton>
+
+<LdButton alignText="left">
+  <LdIcon name="placeholder" />
+  Almost before we knew it, we had left the ground.
+  A shining crescent far beneath the flying vessel.
+  Then came the night of the first falling star.
+</LdButton>
+
+<LdButton alignText="right">
+  Almost before we knew it, we had left the ground.
+  A shining crescent far beneath the flying vessel.
+  Then came the night of the first falling star.
+  <LdIcon name="placeholder" />
+</LdButton>
+
 <!-- CSS component -->
 
 <button class="ld-button">
@@ -443,6 +571,10 @@ You can align the text inside the button using the `align-text` propperty.
 {% example '{ "opened": true }' %}
 <ld-button href="#" target="_blank">Text</ld-button>
 
+<!-- React component -->
+
+<LdButton href="#" target="_blank">Text</LdButton>
+
 <!-- CSS component -->
 
 <a class="ld-button" href="#" target="_blank" rel="noreferrer noopener">Text</a>
@@ -459,15 +591,11 @@ You can align the text inside the button using the `align-text` propperty.
 
 <ld-button progress="pending">Text</ld-button>
 
-<ld-button progress="pending" mode="highlight">Text</ld-button>
+<!-- React component -->
 
-<ld-button progress="pending" mode="danger">Text</ld-button>
+<LdButton progress={0.75}>Text</LdButton>
 
-<ld-button progress="pending" mode="secondary">Text</ld-button>
-
-<ld-button progress="pending" mode="danger-secondary">Text</ld-button>
-
-<ld-button progress="pending" mode="ghost">Text</ld-button>
+<LdButton progress="pending">Text</LdButton>
 
 <!-- CSS component -->
 
@@ -477,31 +605,6 @@ You can align the text inside the button using the `align-text` propperty.
 </button>
 
 <button class="ld-button" aria-busy="true" aria-live="polite">
-  Text
-  <span class="ld-button__progress ld-button__progress--pending"></span>
-</button>
-
-<button class="ld-button ld-button--highlight" aria-busy="true" aria-live="polite">
-  Text
-  <span class="ld-button__progress ld-button__progress--pending"></span>
-</button>
-
-<button class="ld-button ld-button--danger" aria-busy="true" aria-live="polite">
-  Text
-  <span class="ld-button__progress ld-button__progress--pending"></span>
-</button>
-
-<button class="ld-button ld-button--secondary" aria-busy="true" aria-live="polite">
-  Text
-  <span class="ld-button__progress ld-button__progress--pending"></span>
-</button>
-
-<button class="ld-button ld-button--danger-secondary" aria-busy="true" aria-live="polite">
-  Text
-  <span class="ld-button__progress ld-button__progress--pending"></span>
-</button>
-
-<button class="ld-button ld-button--ghost" aria-busy="true" aria-live="polite">
   Text
   <span class="ld-button__progress ld-button__progress--pending"></span>
 </button>


### PR DESCRIPTION
# Description

This PR changes how we document components, by adding the ability to add code examples for React. This is the [option 6 from #459](https://github.com/emdgroup-liquid/liquid/issues/459#issuecomment-1385278038).

## Type of change

- [x] Documentation content changes

## Is it a breaking change?

- [x] No

# How Has This Been Tested?

Please describe the tests that you've added and run to verify your changes. 
Provide instructions, so we can reproduce.

- [x] tested manually

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes
