### PR TITLE
fix(ld-button): stop propagation of click event if disabled

### DIFF
--- a/src/liquid/components/ld-button/ld-button.tsx
+++ b/src/liquid/components/ld-button/ld-button.tsx
@@ -151,6 +151,10 @@ export class LdButton implements InnerFocusable, ClonesAttributes {
 
     if (this.disabled || (ariaDisabled && ariaDisabled !== 'false')) {
       ev.preventDefault()
+      // Stopping propagation is important for clicks on child elements,
+      // because otherwise event handlers attached to the ld-button
+      // are still called (no matter if the event was prevented or not).
+      ev.stopPropagation()
       return
     }
 

--- a/src/liquid/components/ld-button/test/ld-button.spec.ts
+++ b/src/liquid/components/ld-button/test/ld-button.spec.ts
@@ -207,6 +207,40 @@ describe('ld-button', () => {
     expect(clickHandler).not.toHaveBeenCalled()
   })
 
+  it('prevents default and propagation of click events, if disabled', async () => {
+    const page = await newSpecPage({
+      components: [LdButton],
+      html: `<ld-button disabled>Text</ld-button>`,
+    })
+    const ldButton = page.root
+
+    const ev = new MouseEvent('click', { bubbles: true, cancelable: true })
+
+    ldButton.dispatchEvent(ev)
+
+    await page.waitForChanges()
+
+    expect(ev.defaultPrevented).toBeTruthy()
+    expect(ev.cancelBubble).toBeTruthy()
+  })
+
+  it('prevents default and propagation of click events, if aria-disabled', async () => {
+    const page = await newSpecPage({
+      components: [LdButton],
+      html: `<ld-button aria-disabled="true">Text</ld-button>`,
+    })
+    const ldButton = page.root
+
+    const ev = new MouseEvent('click', { bubbles: true, cancelable: true })
+
+    ldButton.dispatchEvent(ev)
+
+    await page.waitForChanges()
+
+    expect(ev.defaultPrevented).toBeTruthy()
+    expect(ev.cancelBubble).toBeTruthy()
+  })
+
   it('allows to set inner focus', async () => {
     const { root } = await newSpecPage({
       components: [LdButton],


### PR DESCRIPTION
# Description

Stopping propagation of click events is important for clicks on child elements within the ld-button, because otherwise event handlers attached to the ld-button are still executed (no matter if the event was prevented or not).

The bug is reproducible in the current docs by clicking on the text of a disabled button.

## Type of change

- [x] Bugfix

## Is it a breaking change?

- [x] No

# How Has This Been Tested?

- [x] unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes
