### PR TITLE
fix(ld-switch): switch has wrong height

### DIFF
--- a/src/liquid/components/ld-switch/ld-switch-item/ld-switch-item.css
+++ b/src/liquid/components/ld-switch/ld-switch-item/ld-switch-item.css
@@ -102,8 +102,9 @@
   display: inline-grid;
   font: var(--ld-switch-font);
   font-weight: 700;
-  grid-auto-flow: column;
   gap: var(--ld-switch-item-gap);
+  grid-auto-flow: column;
+  height: 100%;
   justify-content: var(--ld-switch-item-justify-content);
   line-height: 1.25;
   overflow: hidden;

--- a/src/liquid/components/ld-switch/ld-switch.css
+++ b/src/liquid/components/ld-switch/ld-switch.css
@@ -63,6 +63,7 @@
 
 :host fieldset {
   width: 100%;
+  height: 100%;
 }
 
 :host(.ld-switch--sm),


### PR DESCRIPTION
# Description

This is reproducible in the docs. It's hardly visible, but the switch in the code examples has a smaller height than the button. This change fixes that.

## Type of change

- [x] Bugfix

## Is it a breaking change?

- [x] No

# How Has This Been Tested?

- [x] tested manually

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes
