### PR TITLE
docs: add more react examples

### DIFF
--- a/src/liquid/components/ld-pagination/readme.md
+++ b/src/liquid/components/ld-pagination/readme.md
@@ -92,7 +92,7 @@ An pagination provides a visual hint for content or interactions. Combine it wit
 
 <!-- React component -->
 
-<LdPagination endLabel="Last" length={15} nextLabel="Next" prevLabel="Prev" start-label="First" />
+<LdPagination endLabel="Last" length={15} nextLabel="Next" prevLabel="Prev" startLabel="First" />
 <LdPagination hidePrevNext length={15} startLabel="First" endLabel="Last" />
 <LdPagination hideStartEnd length={15} nextLabel="Next" prevLabel="Prev" />
 {% endexample %}

--- a/src/liquid/components/ld-pagination/readme.md
+++ b/src/liquid/components/ld-pagination/readme.md
@@ -22,7 +22,7 @@ An pagination provides a visual hint for content or interactions. Combine it wit
 
 <!-- React component -->
 
-<LdPagination length={15}></LdPagination>
+<LdPagination length={15} />
 {% endexample %}
 
 ### With sticky items
@@ -33,8 +33,8 @@ An pagination provides a visual hint for content or interactions. Combine it wit
 
 <!-- React component -->
 
-<LdPagination sticky={1} length={15}></LdPagination>
-<LdPagination sticky={3} length={15}></LdPagination>
+<LdPagination sticky={1} length={15} />
+<LdPagination sticky={3} length={15} />
 {% endexample %}
 
 ### Offset
@@ -45,8 +45,8 @@ An pagination provides a visual hint for content or interactions. Combine it wit
 
 <!-- React component -->
 
-<LdPagination offset={1} length={15}></LdPagination>
-<LdPagination offset={0} length={15}></LdPagination>
+<LdPagination offset={1} length={15} />
+<LdPagination offset={0} length={15} />
 {% endexample %}
 
 ### Indefinite length
@@ -56,7 +56,7 @@ An pagination provides a visual hint for content or interactions. Combine it wit
 
 <!-- React component -->
 
-<LdPagination></LdPagination>
+<LdPagination />
 {% endexample %}
 
 ### Item label
@@ -66,7 +66,7 @@ An pagination provides a visual hint for content or interactions. Combine it wit
 
 <!-- React component -->
 
-<LdPagination itemLabel="Slide" length={15}></LdPagination>
+<LdPagination itemLabel="Slide" length={15} />
 {% endexample %}
 
 ### Hide arrow buttons
@@ -78,9 +78,9 @@ An pagination provides a visual hint for content or interactions. Combine it wit
 
 <!-- React component -->
 
-<LdPagination hidePrevNext hideStartEnd length={15}></LdPagination>
-<LdPagination hidePrevNext length={15}></LdPagination>
-<LdPagination hideStartEnd length={15}></LdPagination>
+<LdPagination hidePrevNext hideStartEnd length={15} />
+<LdPagination hidePrevNext length={15} />
+<LdPagination hideStartEnd length={15} />
 {% endexample %}
 
 ### Text instead of arrow buttons
@@ -92,9 +92,9 @@ An pagination provides a visual hint for content or interactions. Combine it wit
 
 <!-- React component -->
 
-<LdPagination endLabel="Last" length={15} nextLabel="Next" prevLabel="Prev" start-label="First"></LdPagination>
-<LdPagination hidePrevNext length={15} startLabel="First" endLabel="Last"></LdPagination>
-<LdPagination hideStartEnd length={15} nextLabel="Next" prevLabel="Prev"></LdPagination>
+<LdPagination endLabel="Last" length={15} nextLabel="Next" prevLabel="Prev" start-label="First" />
+<LdPagination hidePrevNext length={15} startLabel="First" endLabel="Last" />
+<LdPagination hideStartEnd length={15} nextLabel="Next" prevLabel="Prev" />
 {% endexample %}
 
 ### Size
@@ -106,9 +106,9 @@ An pagination provides a visual hint for content or interactions. Combine it wit
 
 <!-- React component -->
 
-<LdPagination length={15} size="sm"></LdPagination>
-<LdPagination length={15}></LdPagination>
-<LdPagination length={15} size="lg"></LdPagination>
+<LdPagination length={15} size="sm" />
+<LdPagination length={15} />
+<LdPagination length={15} size="lg" />
 {% endexample %}
 
 ### Preselected index
@@ -118,7 +118,7 @@ An pagination provides a visual hint for content or interactions. Combine it wit
 
 <!-- React component -->
 
-<LdPagination selectedIndex={7} length={15}></LdPagination>
+<LdPagination selectedIndex={7} length={15} />
 {% endexample %}
 
 ### Programmatic manipulation
@@ -154,7 +154,7 @@ const add = useCallback((amount) => {
 return (
   <>
     <LdButton onClick={() => jump(-10)}>&lt;&lt; 10</LdButton>
-    <LdPagination length={15} ref={paginationRef}></LdPagination>
+    <LdPagination length={15} ref={paginationRef} />
     <LdButton onClick={() => jump(10)}>&gt;&gt; 10</LdButton>
     <LdButton onClick={() => add(-10)}>Remove 10</LdButton>
     <LdButton onClick={() => add(10)}>Add 10</LdButton>
@@ -181,7 +181,7 @@ return (
   onLdchange={(event) => {
     console.log('Selected index is:', event.detail)
   }}
-></LdPagination>
+ />
 {% endexample %}
 
 ### Dots mode
@@ -193,9 +193,9 @@ return (
 
 <!-- React component -->
 
-<LdPagination mode="dots" hidePrevNext hideStartEnd selectedIndex={3} size="sm" length={7}></LdPagination>
-<LdPagination mode="dots" hidePrevNext hideStartEnd selectedIndex={3} length={15}></LdPagination>
-<LdPagination mode="dots" hidePrevNext hideStartEnd selectedIndex={3} size="lg" length={7}></LdPagination>
+<LdPagination mode="dots" hidePrevNext hideStartEnd selectedIndex={3} size="sm" length={7} />
+<LdPagination mode="dots" hidePrevNext hideStartEnd selectedIndex={3} length={15} />
+<LdPagination mode="dots" hidePrevNext hideStartEnd selectedIndex={3} size="lg" length={7} />
 {% endexample %}
 
 ### Dots mode with custom space
@@ -205,7 +205,7 @@ return (
 
 <!-- React component -->
 
-<LdPagination space="1.5rem" mode="dots" hidePrevNext hideStartEnd length={7}></LdPagination>
+<LdPagination space="1.5rem" mode="dots" hidePrevNext hideStartEnd length={7} />
 {% endexample %}
 
 ### On brand color
@@ -216,8 +216,8 @@ return (
 
 <!-- React component -->
 
-<LdPagination brandColor mode="dots" hidePrevNext hideStartEnd length={7}></LdPagination>
-<LdPagination brandColor length={7}></LdPagination>
+<LdPagination brandColor mode="dots" hidePrevNext hideStartEnd length={7} />
+<LdPagination brandColor length={7} />
 {% endexample %}
 
 <!-- Auto Generated Below -->

--- a/src/liquid/components/ld-pagination/readme.md
+++ b/src/liquid/components/ld-pagination/readme.md
@@ -19,6 +19,10 @@ An pagination provides a visual hint for content or interactions. Combine it wit
 
 {% example '{ "centered": true, "stacked": true }' %}
 <ld-pagination length="15"></ld-pagination>
+
+<!-- React component -->
+
+<LdPagination length={15}></LdPagination>
 {% endexample %}
 
 ### With sticky items
@@ -26,6 +30,11 @@ An pagination provides a visual hint for content or interactions. Combine it wit
 {% example '{ "centered": true, "stacked": true }' %}
 <ld-pagination sticky="1" length="15"></ld-pagination>
 <ld-pagination sticky="3" length="15"></ld-pagination>
+
+<!-- React component -->
+
+<LdPagination sticky={1} length={15}></LdPagination>
+<LdPagination sticky={3} length={15}></LdPagination>
 {% endexample %}
 
 ### Offset
@@ -33,18 +42,31 @@ An pagination provides a visual hint for content or interactions. Combine it wit
 {% example '{ "centered": true, "stacked": true }'  %}
 <ld-pagination offset="1" length="15"></ld-pagination>
 <ld-pagination offset="0" length="15"></ld-pagination>
+
+<!-- React component -->
+
+<LdPagination offset={1} length={15}></LdPagination>
+<LdPagination offset={0} length={15}></LdPagination>
 {% endexample %}
 
 ### Indefinite length
 
 {% example %}
 <ld-pagination></ld-pagination>
+
+<!-- React component -->
+
+<LdPagination></LdPagination>
 {% endexample %}
 
 ### Item label
 
 {% example %}
 <ld-pagination item-label="Slide" length="15"></ld-pagination>
+
+<!-- React component -->
+
+<LdPagination itemLabel="Slide" length={15}></LdPagination>
 {% endexample %}
 
 ### Hide arrow buttons
@@ -53,6 +75,12 @@ An pagination provides a visual hint for content or interactions. Combine it wit
 <ld-pagination hide-prev-next hide-start-end length="15"></ld-pagination>
 <ld-pagination hide-prev-next length="15"></ld-pagination>
 <ld-pagination hide-start-end length="15"></ld-pagination>
+
+<!-- React component -->
+
+<LdPagination hidePrevNext hideStartEnd length={15}></LdPagination>
+<LdPagination hidePrevNext length={15}></LdPagination>
+<LdPagination hideStartEnd length={15}></LdPagination>
 {% endexample %}
 
 ### Text instead of arrow buttons
@@ -61,6 +89,12 @@ An pagination provides a visual hint for content or interactions. Combine it wit
 <ld-pagination end-label="Last" length="15" next-label="Next" prev-label="Prev" start-label="First"></ld-pagination>
 <ld-pagination hide-prev-next length="15" start-label="First" end-label="Last"></ld-pagination>
 <ld-pagination hide-start-end length="15" next-label="Next" prev-label="Prev"></ld-pagination>
+
+<!-- React component -->
+
+<LdPagination endLabel="Last" length={15} nextLabel="Next" prevLabel="Prev" start-label="First"></LdPagination>
+<LdPagination hidePrevNext length={15} startLabel="First" endLabel="Last"></LdPagination>
+<LdPagination hideStartEnd length={15} nextLabel="Next" prevLabel="Prev"></LdPagination>
 {% endexample %}
 
 ### Size
@@ -69,20 +103,30 @@ An pagination provides a visual hint for content or interactions. Combine it wit
 <ld-pagination length="15" size="sm"></ld-pagination>
 <ld-pagination length="15"></ld-pagination>
 <ld-pagination length="15" size="lg"></ld-pagination>
+
+<!-- React component -->
+
+<LdPagination length={15} size="sm"></LdPagination>
+<LdPagination length={15}></LdPagination>
+<LdPagination length={15} size="lg"></LdPagination>
 {% endexample %}
 
 ### Preselected index
 
 {% example %}
 <ld-pagination selected-index="7" length="15"></ld-pagination>
+
+<!-- React component -->
+
+<LdPagination selectedIndex={7} length={15}></LdPagination>
 {% endexample %}
 
 ### Programmatic manipulation
 
 {% example %}
-<ld-button onclick="jump(-10);"><< 10</ld-button>
+<ld-button onclick="jump(-10);">&lt;&lt; 10</ld-button>
 <ld-pagination id="pagination-1" length="15"></ld-pagination>
-<ld-button onclick="jump(10);">>> 10</ld-button>
+<ld-button onclick="jump(10);">&gt;&gt; 10</ld-button>
 <ld-button onclick="add(-10);">Remove 10</ld-button>
 <ld-button onclick="add(10);">Add 10</ld-button>
 
@@ -96,6 +140,26 @@ An pagination provides a visual hint for content or interactions. Combine it wit
     pagination1.length += amount;
   }
 </script>
+
+<!-- React component -->
+
+const paginationRef = useRef(null)
+const jump = useCallback((steps) => {
+  paginationRef.current.selectedIndex += steps
+}, [])
+const add = useCallback((amount) => {
+  paginationRef.current.length += amount
+}, [])
+
+return (
+  <>
+    <LdButton onClick={() => jump(-10)}>&lt;&lt; 10</LdButton>
+    <LdPagination length={15} ref={paginationRef}></LdPagination>
+    <LdButton onClick={() => jump(10)}>&gt;&gt; 10</LdButton>
+    <LdButton onClick={() => add(-10)}>Remove 10</LdButton>
+    <LdButton onClick={() => add(10)}>Add 10</LdButton>
+  </>
+)
 {% endexample %}
 
 ### Event handling
@@ -109,6 +173,15 @@ An pagination provides a visual hint for content or interactions. Combine it wit
     console.log("Selected index is:", event.detail)
   })
 </script>
+
+<!-- React component -->
+
+<LdPagination
+  length={15}
+  onLdchange={(event) => {
+    console.log('Selected index is:', event.detail)
+  }}
+></LdPagination>
 {% endexample %}
 
 ### Dots mode
@@ -117,12 +190,22 @@ An pagination provides a visual hint for content or interactions. Combine it wit
 <ld-pagination mode="dots" hide-prev-next hide-start-end selected-index="3" size="sm" length="7"></ld-pagination>
 <ld-pagination mode="dots" hide-prev-next hide-start-end selected-index="3" length="15"></ld-pagination>
 <ld-pagination mode="dots" hide-prev-next hide-start-end selected-index="3" size="lg" length="7"></ld-pagination>
+
+<!-- React component -->
+
+<LdPagination mode="dots" hidePrevNext hideStartEnd selectedIndex={3} size="sm" length={7}></LdPagination>
+<LdPagination mode="dots" hidePrevNext hideStartEnd selectedIndex={3} length={15}></LdPagination>
+<LdPagination mode="dots" hidePrevNext hideStartEnd selectedIndex={3} size="lg" length={7}></LdPagination>
 {% endexample %}
 
 ### Dots mode with custom space
 
 {% example %}
 <ld-pagination space="1.5rem" mode="dots" hide-prev-next hide-start-end length="7"></ld-pagination>
+
+<!-- React component -->
+
+<LdPagination space="1.5rem" mode="dots" hidePrevNext hideStartEnd length={7}></LdPagination>
 {% endexample %}
 
 ### On brand color
@@ -130,6 +213,11 @@ An pagination provides a visual hint for content or interactions. Combine it wit
 {% example '{ "background": "brand", "hasBorder": false }' %}
 <ld-pagination brand-color mode="dots" hide-prev-next hide-start-end length="7"></ld-pagination>
 <ld-pagination brand-color length="7"></ld-pagination>
+
+<!-- React component -->
+
+<LdPagination brandColor mode="dots" hidePrevNext hideStartEnd length={7}></LdPagination>
+<LdPagination brandColor length={7}></LdPagination>
 {% endexample %}
 
 <!-- Auto Generated Below -->

--- a/src/liquid/components/ld-progress/ld-progress.css
+++ b/src/liquid/components/ld-progress/ld-progress.css
@@ -40,6 +40,7 @@
       var(--ld-col-wht-alpha-high),
     inset 0px 0px 0px calc(var(--ld-progress-has-overflow) * 99rem)
       var(--ld-progress-bg-col-overflow);
+  display: block;
   height: var(--ld-progress-height);
   max-width: 100%;
   overflow: hidden;

--- a/src/liquid/components/ld-progress/readme.md
+++ b/src/liquid/components/ld-progress/readme.md
@@ -22,6 +22,11 @@ The `ld-progress` component can be used to displays the progress status for task
 <ld-sr-only id="progress-label">Progress</ld-sr-only>
 <ld-progress aria-labeledby="progress-label" aria-valuenow="25"></ld-progress>
 
+<!-- React component -->
+
+<LdSrOnly id="progress-label">Progress</LdSrOnly>
+<LdProgress aria-labeledby="progress-label" aria-valuenow={25}></LdProgress>
+
 <!-- CSS component -->
 
 <span class="ld-sr-only" id="progress-label-css">Progress</span>
@@ -44,11 +49,36 @@ Interactive example:
   void function() {
     const slider = document.currentScript.previousElementSibling
     const progress = slider.previousElementSibling
+
     slider.addEventListener('ldchange', ev => {
       progress.ariaValuenow = ev.detail[0]
     })
   }()
 </script>
+
+<!-- React component -->
+
+const progressRef = useRef(null)
+
+return (
+  <>
+    <LdSrOnly id="progress-label">Progress</LdSrOnly>
+    <LdProgress
+      aria-labeledby="progress-label"
+      aria-valuenow={25}
+      ref={progressRef}
+    ></LdProgress>
+
+    <LdSlider
+      value="25"
+      max={200}
+      width="14rem"
+      onLdchange={(ev) => {
+        progressRef.current.ariaValuenow = ev.detail[0]
+      }}
+    ></LdSlider>
+  </>
+)
 
 <!-- CSS component -->
 
@@ -81,6 +111,12 @@ Interactive example:
              aria-valuemin="100"
              aria-valuenow="150"></ld-progress>
 
+<!-- React component -->
+
+<LdProgress aria-valuemax={300}
+            aria-valuemin={100}
+            aria-valuenow={150}></LdProgress>
+
 <!-- CSS component -->
 
 <div class="ld-progress"
@@ -99,7 +135,13 @@ The component can visualize an overflow value up to 200% of the maximum progress
 <ld-progress aria-valuenow="125"></ld-progress>
 <ld-progress aria-valuenow="225"></ld-progress>
 
+<!-- React component -->
+
+<LdProgress aria-valuenow={125}></LdProgress>
+<LdProgress aria-valuenow={225}></LdProgress>
+
 <!-- CSS component -->
+
 <div class="ld-progress"
      aria-valuenow="125"
      role="progressbar"
@@ -115,6 +157,10 @@ The component can visualize an overflow value up to 200% of the maximum progress
 {% example %}
 <ld-progress aria-valuemax="4" aria-valuenow="1" steps></ld-progress>
 
+<!-- React component -->
+
+<LdProgress aria-valuemax={4} aria-valuenow={1} steps></LdProgress>
+
 <!-- CSS component -->
 
 <div class="ld-progress ld-progress--steps"
@@ -129,6 +175,11 @@ The component can visualize an overflow value up to 200% of the maximum progress
 {% example %}
 <ld-progress pending aria-valuetext="indeterminate"></ld-progress>
 <ld-progress pending aria-valuenow="25"></ld-progress>
+
+<!-- React component -->
+
+<LdProgress pending aria-valuetext="indeterminate"></LdProgress>
+<LdProgress pending aria-valuenow={25}></LdProgress>
 
 <!-- CSS component -->
 
@@ -148,6 +199,10 @@ Use this mode on backgrounds with brand color.
 
 {% example '{ "background": "brand", "hasBorder": false }' %}
 <ld-progress brand-color aria-valuenow="25"></ld-progress>
+
+<!-- React component -->
+
+<LdProgress brandColor aria-valuenow={25}></LdProgress>
 
 <!-- CSS component -->
 

--- a/src/liquid/components/ld-progress/readme.md
+++ b/src/liquid/components/ld-progress/readme.md
@@ -25,7 +25,7 @@ The `ld-progress` component can be used to displays the progress status for task
 <!-- React component -->
 
 <LdSrOnly id="progress-label">Progress</LdSrOnly>
-<LdProgress aria-labeledby="progress-label" aria-valuenow={25}></LdProgress>
+<LdProgress aria-labeledby="progress-label" aria-valuenow={25} />
 
 <!-- CSS component -->
 
@@ -67,7 +67,7 @@ return (
       aria-labeledby="progress-label"
       aria-valuenow={25}
       ref={progressRef}
-    ></LdProgress>
+     />
 
     <LdSlider
       value="25"
@@ -76,7 +76,7 @@ return (
       onLdchange={(ev) => {
         progressRef.current.ariaValuenow = ev.detail[0]
       }}
-    ></LdSlider>
+    />
   </>
 )
 
@@ -115,7 +115,7 @@ return (
 
 <LdProgress aria-valuemax={300}
             aria-valuemin={100}
-            aria-valuenow={150}></LdProgress>
+            aria-valuenow={150} />
 
 <!-- CSS component -->
 
@@ -137,8 +137,8 @@ The component can visualize an overflow value up to 200% of the maximum progress
 
 <!-- React component -->
 
-<LdProgress aria-valuenow={125}></LdProgress>
-<LdProgress aria-valuenow={225}></LdProgress>
+<LdProgress aria-valuenow={125} />
+<LdProgress aria-valuenow={225} />
 
 <!-- CSS component -->
 
@@ -159,7 +159,7 @@ The component can visualize an overflow value up to 200% of the maximum progress
 
 <!-- React component -->
 
-<LdProgress aria-valuemax={4} aria-valuenow={1} steps></LdProgress>
+<LdProgress aria-valuemax={4} aria-valuenow={1} steps />
 
 <!-- CSS component -->
 
@@ -178,8 +178,8 @@ The component can visualize an overflow value up to 200% of the maximum progress
 
 <!-- React component -->
 
-<LdProgress pending aria-valuetext="indeterminate"></LdProgress>
-<LdProgress pending aria-valuenow={25}></LdProgress>
+<LdProgress pending aria-valuetext="indeterminate" />
+<LdProgress pending aria-valuenow={25} />
 
 <!-- CSS component -->
 
@@ -202,7 +202,7 @@ Use this mode on backgrounds with brand color.
 
 <!-- React component -->
 
-<LdProgress brandColor aria-valuenow={25}></LdProgress>
+<LdProgress brandColor aria-valuenow={25} />
 
 <!-- CSS component -->
 

--- a/src/liquid/components/ld-radio/readme.md
+++ b/src/liquid/components/ld-radio/readme.md
@@ -28,6 +28,11 @@ This component can be used in conjunction with the [`ld-label`](components/ld-la
 <ld-radio name="example-1"></ld-radio>
 <ld-radio name="example-1" checked></ld-radio>
 
+<!-- React component -->
+
+<LdRadio name="example-1"></LdRadio>
+<LdRadio name="example-1" checked></LdRadio>
+
 <!-- CSS component -->
 
 <div class="ld-radio">
@@ -48,6 +53,11 @@ This component can be used in conjunction with the [`ld-label`](components/ld-la
 <ld-radio name="example-2" disabled></ld-radio>
 <ld-radio name="example-2" disabled checked></ld-radio>
 
+<!-- React component -->
+
+<LdRadio name="example-2" disabled></LdRadio>
+<LdRadio name="example-2" disabled checked></LdRadio>
+
 <!-- CSS component -->
 
 <div class="ld-radio">
@@ -67,6 +77,11 @@ This component can be used in conjunction with the [`ld-label`](components/ld-la
 {% example %}
 <ld-radio name="example-3" aria-disabled="true"></ld-radio>
 <ld-radio name="example-3" aria-disabled="true" checked></ld-radio>
+
+<!-- React component -->
+
+<LdRadio name="example-3" aria-disabled="true"></LdRadio>
+<LdRadio name="example-3" aria-disabled="true" checked></LdRadio>
 
 <!-- CSS component -->
 
@@ -115,6 +130,11 @@ This component can be used in conjunction with the [`ld-label`](components/ld-la
 <ld-radio name="example-4" tone="dark"></ld-radio>
 <ld-radio name="example-4" tone="dark" checked></ld-radio>
 
+<!-- React component -->
+
+<LdRadio name="example-4" tone="dark"></LdRadio>
+<LdRadio name="example-4" tone="dark" checked></LdRadio>
+
 <!-- CSS component -->
 
 <div class="ld-radio ld-radio--dark">
@@ -134,6 +154,11 @@ This component can be used in conjunction with the [`ld-label`](components/ld-la
 {% example %}
 <ld-radio name="example-5" mode="highlight"></ld-radio>
 <ld-radio name="example-5" mode="highlight" checked></ld-radio>
+
+<!-- React component -->
+
+<LdRadio name="example-5" mode="highlight"></LdRadio>
+<LdRadio name="example-5" mode="highlight" checked></LdRadio>
 
 <!-- CSS component -->
 
@@ -157,6 +182,11 @@ An invalid state for a radio inputs inside a group makes sense, if for instance 
 <ld-radio name="example-6" invalid required></ld-radio>
 <ld-radio name="example-6" invalid required></ld-radio>
 
+<!-- React component -->
+
+<LdRadio name="example-6" invalid required></LdRadio>
+<LdRadio name="example-6" invalid required></LdRadio>
+
 <!-- CSS component -->
 
 <div class="ld-radio ld-radio--invalid">
@@ -178,6 +208,11 @@ The radio button in mode "danger" looks and behaves the same as a radio button w
 {% example %}
 <ld-radio name="example-7" mode="danger"></ld-radio>
 <ld-radio name="example-7" mode="danger" checked></ld-radio>
+
+<!-- React component -->
+
+<LdRadio name="example-7" mode="danger"></LdRadio>
+<LdRadio name="example-7" mode="danger" checked></LdRadio>
 
 <!-- CSS component -->
 
@@ -205,6 +240,18 @@ The radio button in mode "danger" looks and behaves the same as a radio button w
   Banana
   <ld-radio name="example-8" value="banana"></ld-radio>
 </ld-label>
+
+<!-- React component -->
+
+<LdLabel position="right" size="m">
+  Orange
+  <LdRadio name="example-8" value="orange"></LdRadio>
+</LdLabel>
+
+<LdLabel position="right" size="m">
+  Banana
+  <LdRadio name="example-8" value="banana"></LdRadio>
+</LdLabel>
 
 <!-- CSS component -->
 
@@ -243,6 +290,20 @@ Please reffer to the [ld-label](components/ld-label/) docs for more information 
   <ld-radio name="example-9"></ld-radio>
   <ld-input-message mode="info">You'll join the banana team.</ld-input-message>
 </ld-label>
+
+<!-- React component -->
+
+<LdLabel position="right" size="m">
+  Orange
+  <LdRadio name="example-9"></LdRadio>
+  <LdInputMessage mode="info">You'll join the orange team.</LdInputMessage>
+</LdLabel>
+
+<LdLabel position="right" size="m">
+  Banana
+  <LdRadio name="example-9"></LdRadio>
+  <LdInputMessage mode="info">You'll join the banana team.</LdInputMessage>
+</LdLabel>
 
 <!-- CSS component -->
 

--- a/src/liquid/components/ld-radio/readme.md
+++ b/src/liquid/components/ld-radio/readme.md
@@ -30,8 +30,8 @@ This component can be used in conjunction with the [`ld-label`](components/ld-la
 
 <!-- React component -->
 
-<LdRadio name="example-1"></LdRadio>
-<LdRadio name="example-1" checked></LdRadio>
+<LdRadio name="example-1" />
+<LdRadio name="example-1" checked />
 
 <!-- CSS component -->
 
@@ -55,8 +55,8 @@ This component can be used in conjunction with the [`ld-label`](components/ld-la
 
 <!-- React component -->
 
-<LdRadio name="example-2" disabled></LdRadio>
-<LdRadio name="example-2" disabled checked></LdRadio>
+<LdRadio name="example-2" disabled />
+<LdRadio name="example-2" disabled checked />
 
 <!-- CSS component -->
 
@@ -80,8 +80,8 @@ This component can be used in conjunction with the [`ld-label`](components/ld-la
 
 <!-- React component -->
 
-<LdRadio name="example-3" aria-disabled="true"></LdRadio>
-<LdRadio name="example-3" aria-disabled="true" checked></LdRadio>
+<LdRadio name="example-3" aria-disabled="true" />
+<LdRadio name="example-3" aria-disabled="true" checked />
 
 <!-- CSS component -->
 
@@ -132,8 +132,8 @@ This component can be used in conjunction with the [`ld-label`](components/ld-la
 
 <!-- React component -->
 
-<LdRadio name="example-4" tone="dark"></LdRadio>
-<LdRadio name="example-4" tone="dark" checked></LdRadio>
+<LdRadio name="example-4" tone="dark" />
+<LdRadio name="example-4" tone="dark" checked />
 
 <!-- CSS component -->
 
@@ -157,8 +157,8 @@ This component can be used in conjunction with the [`ld-label`](components/ld-la
 
 <!-- React component -->
 
-<LdRadio name="example-5" mode="highlight"></LdRadio>
-<LdRadio name="example-5" mode="highlight" checked></LdRadio>
+<LdRadio name="example-5" mode="highlight" />
+<LdRadio name="example-5" mode="highlight" checked />
 
 <!-- CSS component -->
 
@@ -184,8 +184,8 @@ An invalid state for a radio inputs inside a group makes sense, if for instance 
 
 <!-- React component -->
 
-<LdRadio name="example-6" invalid required></LdRadio>
-<LdRadio name="example-6" invalid required></LdRadio>
+<LdRadio name="example-6" invalid required />
+<LdRadio name="example-6" invalid required />
 
 <!-- CSS component -->
 
@@ -211,8 +211,8 @@ The radio button in mode "danger" looks and behaves the same as a radio button w
 
 <!-- React component -->
 
-<LdRadio name="example-7" mode="danger"></LdRadio>
-<LdRadio name="example-7" mode="danger" checked></LdRadio>
+<LdRadio name="example-7" mode="danger" />
+<LdRadio name="example-7" mode="danger" checked />
 
 <!-- CSS component -->
 
@@ -245,12 +245,12 @@ The radio button in mode "danger" looks and behaves the same as a radio button w
 
 <LdLabel position="right" size="m">
   Orange
-  <LdRadio name="example-8" value="orange"></LdRadio>
+  <LdRadio name="example-8" value="orange" />
 </LdLabel>
 
 <LdLabel position="right" size="m">
   Banana
-  <LdRadio name="example-8" value="banana"></LdRadio>
+  <LdRadio name="example-8" value="banana" />
 </LdLabel>
 
 <!-- CSS component -->
@@ -295,13 +295,13 @@ Please reffer to the [ld-label](components/ld-label/) docs for more information 
 
 <LdLabel position="right" size="m">
   Orange
-  <LdRadio name="example-9"></LdRadio>
+  <LdRadio name="example-9" />
   <LdInputMessage mode="info">You'll join the orange team.</LdInputMessage>
 </LdLabel>
 
 <LdLabel position="right" size="m">
   Banana
-  <LdRadio name="example-9"></LdRadio>
+  <LdRadio name="example-9" />
   <LdInputMessage mode="info">You'll join the banana team.</LdInputMessage>
 </LdLabel>
 

--- a/src/liquid/components/ld-select/readme.md
+++ b/src/liquid/components/ld-select/readme.md
@@ -48,6 +48,26 @@ The feature set of the `ld-select` Web Component differs from its CSS Component 
   <ld-option value="plum">Plum</ld-option>
 </ld-select>
 
+<!-- React component -->
+
+<LdSelect placeholder="Pick a fruit" name="fruit">
+  <LdOption value="apple">Apple</LdOption>
+  <LdOption value="banana">Banana</LdOption>
+  <LdOption value="strawberry">Strawberry</LdOption>
+  <LdOption value="watermelon" disabled>Watermelon</LdOption>
+  <LdOption value="honeymelon">Honeymelon</LdOption>
+  <LdOption value="rasberry">Rasberry</LdOption>
+  <LdOption value="cherry">Cherry</LdOption>
+  <LdOption value="blueberry">Blueberry</LdOption>
+  <LdOption value="peach">Peach</LdOption>
+  <LdOption value="grape">Grape</LdOption>
+  <LdOption value="fuyu persimmon">Fuyu Persimmon</LdOption>
+  <LdOption value="monstera deliciosa">Monstera Deliciosa</LdOption>
+  <LdOption value="pear">Pear</LdOption>
+  <LdOption value="pineapple">Pineapple</LdOption>
+  <LdOption value="plum">Plum</LdOption>
+</LdSelect>
+
 <!-- CSS component -->
 
 <div class='ld-select'>
@@ -107,6 +127,26 @@ You can prevent a state with no options selected after initial selection in sing
   <ld-option value="pineapple">Pineapple</ld-option>
   <ld-option value="plum">Plum</ld-option>
 </ld-select>
+
+<!-- React component -->
+
+<LdSelect placeholder="Pick a fruit" name="fruit" preventDeselection>
+  <LdOption value="apple">Apple</LdOption>
+  <LdOption value="banana">Banana</LdOption>
+  <LdOption value="strawberry">Strawberry</LdOption>
+  <LdOption value="watermelon" disabled>Watermelon</LdOption>
+  <LdOption value="honeymelon">Honeymelon</LdOption>
+  <LdOption value="rasberry">Rasberry</LdOption>
+  <LdOption value="cherry">Cherry</LdOption>
+  <LdOption value="blueberry">Blueberry</LdOption>
+  <LdOption value="peach">Peach</LdOption>
+  <LdOption value="grape">Grape</LdOption>
+  <LdOption value="fuyu persimmon">Fuyu Persimmon</LdOption>
+  <LdOption value="monstera deliciosa">Monstera Deliciosa</LdOption>
+  <LdOption value="pear">Pear</LdOption>
+  <LdOption value="pineapple">Pineapple</LdOption>
+  <LdOption value="plum">Plum</LdOption>
+</LdSelect>
 {% endexample %}
 
 ### Multiple select mode
@@ -129,6 +169,26 @@ You can prevent a state with no options selected after initial selection in sing
   <ld-option value="pineapple">Pineapple</ld-option>
   <ld-option value="plum">Plum</ld-option>
 </ld-select>
+
+<!-- React component -->
+
+<LdSelect placeholder="Pick some fruits" name="fruits" multiple>
+  <LdOption value="apple">Apple</LdOption>
+  <LdOption value="banana">Banana</LdOption>
+  <LdOption value="strawberry">Strawberry</LdOption>
+  <LdOption value="watermelon" disabled>Watermelon</LdOption>
+  <LdOption value="honeymelon">Honeymelon</LdOption>
+  <LdOption value="rasberry">Rasberry</LdOption>
+  <LdOption value="cherry">Cherry</LdOption>
+  <LdOption value="blueberry">Blueberry</LdOption>
+  <LdOption value="peach">Peach</LdOption>
+  <LdOption value="grape">Grape</LdOption>
+  <LdOption value="fuyu persimmon">Fuyu Persimmon</LdOption>
+  <LdOption value="monstera deliciosa">Monstera Deliciosa</LdOption>
+  <LdOption value="pear">Pear</LdOption>
+  <LdOption value="pineapple">Pineapple</LdOption>
+  <LdOption value="plum">Plum</LdOption>
+</LdSelect>
 {% endexample %}
 
 #### Width
@@ -136,16 +196,7 @@ You can prevent a state with no options selected after initial selection in sing
 You may have noticed, that in multiple mode the component grows horizontally with the number of selected options. You can prevent this behaviour by either applying a `width` or a `max-width` style on the `ld-select` element:
 
 {% example %}
-<style>
-.my-select-width {
-  width: 14rem;
-}
-.my-select-max-width {
-  max-width: 24rem;
-}
-</style>
-
-<ld-select class="my-select-width" placeholder="Pick some fruits" name="fruits" multiple>
+<ld-select placeholder="Pick some fruits" name="fruits" multiple style="width: 14rem">
   <ld-option value="apple">Apple</ld-option>
   <ld-option value="banana" selected>Banana</ld-option>
   <ld-option value="strawberry" selected>Strawberry</ld-option>
@@ -163,7 +214,7 @@ You may have noticed, that in multiple mode the component grows horizontally wit
   <ld-option value="plum" selected>Plum</ld-option>
 </ld-select>
 
-<ld-select class="my-select-max-width" placeholder="Pick some fruits" name="fruits" multiple>
+<ld-select class="my-select-max-width" placeholder="Pick some fruits" name="fruits" multiple style="max-width: 24rem">
   <ld-option value="apple">Apple</ld-option>
   <ld-option value="banana" selected>Banana</ld-option>
   <ld-option value="strawberry" selected>Strawberry</ld-option>
@@ -180,6 +231,44 @@ You may have noticed, that in multiple mode the component grows horizontally wit
   <ld-option value="pineapple" selected>Pineapple</ld-option>
   <ld-option value="plum" selected>Plum</ld-option>
 </ld-select>
+
+<!-- React component -->
+
+<LdSelect placeholder="Pick some fruits" name="fruits" multiple style={ { width: '14rem' } }>
+  <LdOption value="apple">Apple</LdOption>
+  <LdOption value="banana" selected>Banana</LdOption>
+  <LdOption value="strawberry" selected>Strawberry</LdOption>
+  <LdOption value="watermelon" disabled>Watermelon</LdOption>
+  <LdOption value="honeymelon">Honeymelon</LdOption>
+  <LdOption value="rasberry">Rasberry</LdOption>
+  <LdOption value="cherry" selected>Cherry</LdOption>
+  <LdOption value="blueberry">Blueberry</LdOption>
+  <LdOption value="peach" selected>Peach</LdOption>
+  <LdOption value="grape" selected>Grape</LdOption>
+  <LdOption value="fuyu persimmon" selected>Fuyu Persimmon</LdOption>
+  <LdOption value="monstera deliciosa">Monstera Deliciosa</LdOption>
+  <LdOption value="pear" selected>Pear</LdOption>
+  <LdOption value="pineapple" selected>Pineapple</LdOption>
+  <LdOption value="plum" selected>Plum</LdOption>
+</LdSelect>
+
+<LdSelect placeholder="Pick some fruits" name="fruits" multiple style={ { maxWidth: '24rem' } }>
+  <LdOption value="apple">Apple</LdOption>
+  <LdOption value="banana" selected>Banana</LdOption>
+  <LdOption value="strawberry" selected>Strawberry</LdOption>
+  <LdOption value="watermelon" disabled>Watermelon</LdOption>
+  <LdOption value="honeymelon">Honeymelon</LdOption>
+  <LdOption value="rasberry">Rasberry</LdOption>
+  <LdOption value="cherry" selected>Cherry</LdOption>
+  <LdOption value="blueberry">Blueberry</LdOption>
+  <LdOption value="peach" selected>Peach</LdOption>
+  <LdOption value="grape" selected>Grape</LdOption>
+  <LdOption value="fuyu persimmon" selected>Fuyu Persimmon</LdOption>
+  <LdOption value="monstera deliciosa">Monstera Deliciosa</LdOption>
+  <LdOption value="pear" selected>Pear</LdOption>
+  <LdOption value="pineapple" selected>Pineapple</LdOption>
+  <LdOption value="plum" selected>Plum</LdOption>
+</LdSelect>
 {% endexample %}
 
 #### Max rows
@@ -222,6 +311,44 @@ If you have limited vertical space (this may especially be the case on mobile de
   <ld-option value="pineapple" selected>Pineapple</ld-option>
   <ld-option value="plum" selected>Plum</ld-option>
 </ld-select>
+
+<!-- React component -->
+
+<LdSelect placeholder="Pick some fruits" name="fruits" multiple maxRows={1} style={ { width: '14rem' } }>
+  <LdOption value="apple">Apple</LdOption>
+  <LdOption value="banana" selected>Banana</LdOption>
+  <LdOption value="strawberry" selected>Strawberry</LdOption>
+  <LdOption value="watermelon" disabled>Watermelon</LdOption>
+  <LdOption value="honeymelon">Honeymelon</LdOption>
+  <LdOption value="rasberry">Rasberry</LdOption>
+  <LdOption value="cherry" selected>Cherry</LdOption>
+  <LdOption value="blueberry">Blueberry</LdOption>
+  <LdOption value="peach" selected>Peach</LdOption>
+  <LdOption value="grape" selected>Grape</LdOption>
+  <LdOption value="fuyu persimmon" selected>Fuyu Persimmon</LdOption>
+  <LdOption value="monstera deliciosa">Monstera Deliciosa</LdOption>
+  <LdOption value="pear" selected>Pear</LdOption>
+  <LdOption value="pineapple" selected>Pineapple</LdOption>
+  <LdOption value="plum" selected>Plum</LdOption>
+</LdSelect>
+
+<LdSelect placeholder="Pick some fruits" name="fruits" multiple maxRows={2} style={ { maxWidth: '24rem' } }>
+  <LdOption value="apple">Apple</LdOption>
+  <LdOption value="banana" selected>Banana</LdOption>
+  <LdOption value="strawberry" selected>Strawberry</LdOption>
+  <LdOption value="watermelon" disabled>Watermelon</LdOption>
+  <LdOption value="honeymelon">Honeymelon</LdOption>
+  <LdOption value="rasberry">Rasberry</LdOption>
+  <LdOption value="cherry" selected>Cherry</LdOption>
+  <LdOption value="blueberry">Blueberry</LdOption>
+  <LdOption value="peach" selected>Peach</LdOption>
+  <LdOption value="grape" selected>Grape</LdOption>
+  <LdOption value="fuyu persimmon" selected>Fuyu Persimmon</LdOption>
+  <LdOption value="monstera deliciosa">Monstera Deliciosa</LdOption>
+  <LdOption value="pear" selected>Pear</LdOption>
+  <LdOption value="pineapple" selected>Pineapple</LdOption>
+  <LdOption value="plum" selected>Plum</LdOption>
+</LdSelect>
 {% endexample %}
 
 ### Disabled
@@ -298,6 +425,80 @@ If you have limited vertical space (this may especially be the case on mobile de
   <ld-option value="pineapple">Pineapple</ld-option>
   <ld-option value="plum">Plum</ld-option>
 </ld-select>
+
+<!-- React component -->
+
+<LdSelect placeholder="Pick a fruit" name="fruit" disabled>
+  <LdOption value="apple">Apple</LdOption>
+  <LdOption value="banana">Banana</LdOption>
+  <LdOption value="strawberry">Strawberry</LdOption>
+  <LdOption value="watermelon" disabled>Watermelon</LdOption>
+  <LdOption value="honeymelon">Honeymelon</LdOption>
+  <LdOption value="rasberry">Rasberry</LdOption>
+  <LdOption value="cherry">Cherry</LdOption>
+  <LdOption value="blueberry">Blueberry</LdOption>
+  <LdOption value="peach">Peach</LdOption>
+  <LdOption value="grape">Grape</LdOption>
+  <LdOption value="fuyu persimmon">Fuyu Persimmon</LdOption>
+  <LdOption value="monstera deliciosa">Monstera Deliciosa</LdOption>
+  <LdOption value="pear">Pear</LdOption>
+  <LdOption value="pineapple">Pineapple</LdOption>
+  <LdOption value="plum">Plum</LdOption>
+</LdSelect>
+
+<LdSelect placeholder="Pick some fruits" name="fruits" multiple disabled>
+  <LdOption value="apple">Apple</LdOption>
+  <LdOption value="banana">Banana</LdOption>
+  <LdOption value="strawberry">Strawberry</LdOption>
+  <LdOption value="watermelon" disabled>Watermelon</LdOption>
+  <LdOption value="honeymelon">Honeymelon</LdOption>
+  <LdOption value="rasberry">Rasberry</LdOption>
+  <LdOption value="cherry">Cherry</LdOption>
+  <LdOption value="blueberry">Blueberry</LdOption>
+  <LdOption value="peach">Peach</LdOption>
+  <LdOption value="grape">Grape</LdOption>
+  <LdOption value="fuyu persimmon">Fuyu Persimmon</LdOption>
+  <LdOption value="monstera deliciosa">Monstera Deliciosa</LdOption>
+  <LdOption value="pear">Pear</LdOption>
+  <LdOption value="pineapple">Pineapple</LdOption>
+  <LdOption value="plum">Plum</LdOption>
+</LdSelect>
+
+<LdSelect placeholder="Pick a fruit" name="fruit" disabled>
+  <LdOption value="apple">Apple</LdOption>
+  <LdOption value="banana" selected>Banana</LdOption>
+  <LdOption value="strawberry">Strawberry</LdOption>
+  <LdOption value="watermelon" disabled>Watermelon</LdOption>
+  <LdOption value="honeymelon">Honeymelon</LdOption>
+  <LdOption value="rasberry">Rasberry</LdOption>
+  <LdOption value="cherry">Cherry</LdOption>
+  <LdOption value="blueberry">Blueberry</LdOption>
+  <LdOption value="peach">Peach</LdOption>
+  <LdOption value="grape">Grape</LdOption>
+  <LdOption value="fuyu persimmon">Fuyu Persimmon</LdOption>
+  <LdOption value="monstera deliciosa">Monstera Deliciosa</LdOption>
+  <LdOption value="pear">Pear</LdOption>
+  <LdOption value="pineapple">Pineapple</LdOption>
+  <LdOption value="plum">Plum</LdOption>
+</LdSelect>
+
+<LdSelect placeholder="Pick some fruits" name="fruits" multiple disabled>
+  <LdOption value="apple">Apple</LdOption>
+  <LdOption value="banana" selected>Banana</LdOption>
+  <LdOption value="strawberry">Strawberry</LdOption>
+  <LdOption value="watermelon" disabled>Watermelon</LdOption>
+  <LdOption value="honeymelon">Honeymelon</LdOption>
+  <LdOption value="rasberry">Rasberry</LdOption>
+  <LdOption value="cherry" selected>Cherry</LdOption>
+  <LdOption value="blueberry">Blueberry</LdOption>
+  <LdOption value="peach">Peach</LdOption>
+  <LdOption value="grape">Grape</LdOption>
+  <LdOption value="fuyu persimmon" selected>Fuyu Persimmon</LdOption>
+  <LdOption value="monstera deliciosa">Monstera Deliciosa</LdOption>
+  <LdOption value="pear">Pear</LdOption>
+  <LdOption value="pineapple">Pineapple</LdOption>
+  <LdOption value="plum">Plum</LdOption>
+</LdSelect>
 
 <!-- CSS component -->
 
@@ -411,6 +612,80 @@ If you have limited vertical space (this may especially be the case on mobile de
   <ld-option value="plum">Plum</ld-option>
 </ld-select>
 
+<!-- React component -->
+
+<LdSelect placeholder="Pick a fruit" name="fruit" aria-disabled="true">
+  <LdOption value="apple">Apple</LdOption>
+  <LdOption value="banana">Banana</LdOption>
+  <LdOption value="strawberry">Strawberry</LdOption>
+  <LdOption value="watermelon" disabled>Watermelon</LdOption>
+  <LdOption value="honeymelon">Honeymelon</LdOption>
+  <LdOption value="rasberry">Rasberry</LdOption>
+  <LdOption value="cherry">Cherry</LdOption>
+  <LdOption value="blueberry">Blueberry</LdOption>
+  <LdOption value="peach">Peach</LdOption>
+  <LdOption value="grape">Grape</LdOption>
+  <LdOption value="fuyu persimmon">Fuyu Persimmon</LdOption>
+  <LdOption value="monstera deliciosa">Monstera Deliciosa</LdOption>
+  <LdOption value="pear">Pear</LdOption>
+  <LdOption value="pineapple">Pineapple</LdOption>
+  <LdOption value="plum">Plum</LdOption>
+</LdSelect>
+
+<LdSelect placeholder="Pick some fruits" name="fruits" multiple aria-disabled="true">
+  <LdOption value="apple">Apple</LdOption>
+  <LdOption value="banana">Banana</LdOption>
+  <LdOption value="strawberry">Strawberry</LdOption>
+  <LdOption value="watermelon" disabled>Watermelon</LdOption>
+  <LdOption value="honeymelon">Honeymelon</LdOption>
+  <LdOption value="rasberry">Rasberry</LdOption>
+  <LdOption value="cherry">Cherry</LdOption>
+  <LdOption value="blueberry">Blueberry</LdOption>
+  <LdOption value="peach">Peach</LdOption>
+  <LdOption value="grape">Grape</LdOption>
+  <LdOption value="fuyu persimmon">Fuyu Persimmon</LdOption>
+  <LdOption value="monstera deliciosa">Monstera Deliciosa</LdOption>
+  <LdOption value="pear">Pear</LdOption>
+  <LdOption value="pineapple">Pineapple</LdOption>
+  <LdOption value="plum">Plum</LdOption>
+</LdSelect>
+
+<LdSelect placeholder="Pick a fruit" name="fruit" aria-disabled="true">
+  <LdOption value="apple">Apple</LdOption>
+  <LdOption value="banana" selected>Banana</LdOption>
+  <LdOption value="strawberry">Strawberry</LdOption>
+  <LdOption value="watermelon" disabled>Watermelon</LdOption>
+  <LdOption value="honeymelon">Honeymelon</LdOption>
+  <LdOption value="rasberry">Rasberry</LdOption>
+  <LdOption value="cherry">Cherry</LdOption>
+  <LdOption value="blueberry">Blueberry</LdOption>
+  <LdOption value="peach">Peach</LdOption>
+  <LdOption value="grape">Grape</LdOption>
+  <LdOption value="fuyu persimmon">Fuyu Persimmon</LdOption>
+  <LdOption value="monstera deliciosa">Monstera Deliciosa</LdOption>
+  <LdOption value="pear">Pear</LdOption>
+  <LdOption value="pineapple">Pineapple</LdOption>
+  <LdOption value="plum">Plum</LdOption>
+</LdSelect>
+
+<LdSelect placeholder="Pick some fruits" name="fruits" multiple aria-disabled="true">
+  <LdOption value="apple">Apple</LdOption>
+  <LdOption value="banana" selected>Banana</LdOption>
+  <LdOption value="strawberry">Strawberry</LdOption>
+  <LdOption value="watermelon" disabled>Watermelon</LdOption>
+  <LdOption value="honeymelon">Honeymelon</LdOption>
+  <LdOption value="rasberry">Rasberry</LdOption>
+  <LdOption value="cherry" selected>Cherry</LdOption>
+  <LdOption value="blueberry">Blueberry</LdOption>
+  <LdOption value="peach">Peach</LdOption>
+  <LdOption value="grape">Grape</LdOption>
+  <LdOption value="fuyu persimmon" selected>Fuyu Persimmon</LdOption>
+  <LdOption value="monstera deliciosa">Monstera Deliciosa</LdOption>
+  <LdOption value="pear">Pear</LdOption>
+  <LdOption value="pineapple">Pineapple</LdOption>
+  <LdOption value="plum">Plum</LdOption>
+</LdSelect>
+
 <!-- CSS component -->
 
 <div class='ld-select'>
@@ -491,6 +766,44 @@ If you have limited vertical space (this may especially be the case on mobile de
   <ld-option value="plum">Plum</ld-option>
 </ld-select>
 
+<!-- React component -->
+
+<LdSelect placeholder="Pick a fruit" name="fruit" invalid>
+  <LdOption value="apple">Apple</LdOption>
+  <LdOption value="banana">Banana</LdOption>
+  <LdOption value="strawberry">Strawberry</LdOption>
+  <LdOption value="watermelon" disabled>Watermelon</LdOption>
+  <LdOption value="honeymelon">Honeymelon</LdOption>
+  <LdOption value="rasberry">Rasberry</LdOption>
+  <LdOption value="cherry">Cherry</LdOption>
+  <LdOption value="blueberry">Blueberry</LdOption>
+  <LdOption value="peach">Peach</LdOption>
+  <LdOption value="grape">Grape</LdOption>
+  <LdOption value="fuyu persimmon">Fuyu Persimmon</LdOption>
+  <LdOption value="monstera deliciosa">Monstera Deliciosa</LdOption>
+  <LdOption value="pear">Pear</LdOption>
+  <LdOption value="pineapple">Pineapple</LdOption>
+  <LdOption value="plum">Plum</LdOption>
+</LdSelect>
+
+<LdSelect placeholder="Pick some fruits" name="fruits" multiple invalid>
+  <LdOption value="apple">Apple</LdOption>
+  <LdOption value="banana" selected>Banana</LdOption>
+  <LdOption value="strawberry">Strawberry</LdOption>
+  <LdOption value="watermelon" disabled>Watermelon</LdOption>
+  <LdOption value="honeymelon">Honeymelon</LdOption>
+  <LdOption value="rasberry">Rasberry</LdOption>
+  <LdOption value="cherry" selected>Cherry</LdOption>
+  <LdOption value="blueberry">Blueberry</LdOption>
+  <LdOption value="peach">Peach</LdOption>
+  <LdOption value="grape">Grape</LdOption>
+  <LdOption value="fuyu persimmon" selected>Fuyu Persimmon</LdOption>
+  <LdOption value="monstera deliciosa">Monstera Deliciosa</LdOption>
+  <LdOption value="pear">Pear</LdOption>
+  <LdOption value="pineapple">Pineapple</LdOption>
+  <LdOption value="plum">Plum</LdOption>
+</LdSelect>
+
 <!-- CSS component -->
 
 <div class='ld-select ld-select--invalid'>
@@ -550,6 +863,26 @@ In detached mode the component positions the popper element with a small vertica
   <ld-option value="pineapple">Pineapple</ld-option>
   <ld-option value="plum">Plum</ld-option>
 </ld-select>
+
+<!-- React component -->
+
+<LdSelect placeholder="Pick a fruit" name="fruit" mode="detached">
+  <LdOption value="apple">Apple</LdOption>
+  <LdOption value="banana">Banana</LdOption>
+  <LdOption value="strawberry">Strawberry</LdOption>
+  <LdOption value="watermelon" disabled>Watermelon</LdOption>
+  <LdOption value="honeymelon">Honeymelon</LdOption>
+  <LdOption value="rasberry">Rasberry</LdOption>
+  <LdOption value="cherry">Cherry</LdOption>
+  <LdOption value="blueberry">Blueberry</LdOption>
+  <LdOption value="peach">Peach</LdOption>
+  <LdOption value="grape">Grape</LdOption>
+  <LdOption value="fuyu persimmon">Fuyu Persimmon</LdOption>
+  <LdOption value="monstera deliciosa">Monstera Deliciosa</LdOption>
+  <LdOption value="pear">Pear</LdOption>
+  <LdOption value="pineapple">Pineapple</LdOption>
+  <LdOption value="plum">Plum</LdOption>
+</LdSelect>
 {% endexample %}
 
 ### Inline
@@ -610,6 +943,62 @@ In inline mode, while the popper element has a minimum width, the component's tr
   <ld-option value="pineapple">Pineapple</ld-option>
   <ld-option value="plum">Plum</ld-option>
 </ld-select>
+
+<!-- React component -->
+
+<LdSelect placeholder="Pick a fruit" name="fruit" mode="inline">
+  <LdOption value="apple">Apple</LdOption>
+  <LdOption value="banana">Banana</LdOption>
+  <LdOption value="strawberry">Strawberry</LdOption>
+  <LdOption value="watermelon" disabled>Watermelon</LdOption>
+  <LdOption value="honeymelon">Honeymelon</LdOption>
+  <LdOption value="rasberry">Rasberry</LdOption>
+  <LdOption value="cherry">Cherry</LdOption>
+  <LdOption value="blueberry">Blueberry</LdOption>
+  <LdOption value="peach">Peach</LdOption>
+  <LdOption value="grape">Grape</LdOption>
+  <LdOption value="fuyu persimmon">Fuyu Persimmon</LdOption>
+  <LdOption value="monstera deliciosa">Monstera Deliciosa</LdOption>
+  <LdOption value="pear">Pear</LdOption>
+  <LdOption value="pineapple">Pineapple</LdOption>
+  <LdOption value="plum">Plum</LdOption>
+</LdSelect>
+
+<LdSelect placeholder="Pick some fruits" name="fruits" multiple mode="inline">
+  <LdOption value="apple">Apple</LdOption>
+  <LdOption value="banana">Banana</LdOption>
+  <LdOption value="strawberry">Strawberry</LdOption>
+  <LdOption value="watermelon" disabled>Watermelon</LdOption>
+  <LdOption value="honeymelon">Honeymelon</LdOption>
+  <LdOption value="rasberry">Rasberry</LdOption>
+  <LdOption value="cherry">Cherry</LdOption>
+  <LdOption value="blueberry">Blueberry</LdOption>
+  <LdOption value="peach">Peach</LdOption>
+  <LdOption value="grape">Grape</LdOption>
+  <LdOption value="fuyu persimmon">Fuyu Persimmon</LdOption>
+  <LdOption value="monstera deliciosa">Monstera Deliciosa</LdOption>
+  <LdOption value="pear">Pear</LdOption>
+  <LdOption value="pineapple">Pineapple</LdOption>
+  <LdOption value="plum">Plum</LdOption>
+</LdSelect>
+
+<LdSelect placeholder="Pick some fruits" name="fruits" multiple mode="inline" style={ { width: '6.9375rem' } } maxRows={1}>
+  <LdOption value="apple">Apple</LdOption>
+  <LdOption value="banana">Banana</LdOption>
+  <LdOption value="strawberry">Strawberry</LdOption>
+  <LdOption value="watermelon" disabled>Watermelon</LdOption>
+  <LdOption value="honeymelon">Honeymelon</LdOption>
+  <LdOption value="rasberry">Rasberry</LdOption>
+  <LdOption value="cherry">Cherry</LdOption>
+  <LdOption value="blueberry">Blueberry</LdOption>
+  <LdOption value="peach">Peach</LdOption>
+  <LdOption value="grape">Grape</LdOption>
+  <LdOption value="fuyu persimmon">Fuyu Persimmon</LdOption>
+  <LdOption value="monstera deliciosa">Monstera Deliciosa</LdOption>
+  <LdOption value="pear">Pear</LdOption>
+  <LdOption value="pineapple">Pineapple</LdOption>
+  <LdOption value="plum">Plum</LdOption>
+</LdSelect>
 {% endexample %}
 
 ### Ghost
@@ -634,6 +1023,26 @@ In ghost mode the component works the same way as it does in inline mode while a
   <ld-option value="pineapple">Pineapple</ld-option>
   <ld-option value="plum">Plum</ld-option>
 </ld-select>
+
+<!-- React component -->
+
+<LdSelect placeholder="Pick a fruit" name="fruit" mode="ghost">
+  <LdOption value="apple">Apple</LdOption>
+  <LdOption value="banana">Banana</LdOption>
+  <LdOption value="strawberry">Strawberry</LdOption>
+  <LdOption value="watermelon" disabled>Watermelon</LdOption>
+  <LdOption value="honeymelon">Honeymelon</LdOption>
+  <LdOption value="rasberry">Rasberry</LdOption>
+  <LdOption value="cherry">Cherry</LdOption>
+  <LdOption value="blueberry">Blueberry</LdOption>
+  <LdOption value="peach">Peach</LdOption>
+  <LdOption value="grape">Grape</LdOption>
+  <LdOption value="fuyu persimmon">Fuyu Persimmon</LdOption>
+  <LdOption value="monstera deliciosa">Monstera Deliciosa</LdOption>
+  <LdOption value="pear">Pear</LdOption>
+  <LdOption value="pineapple">Pineapple</LdOption>
+  <LdOption value="plum">Plum</LdOption>
+</LdSelect>
 {% endexample %}
 
 ### Size
@@ -746,6 +1155,116 @@ In ghost mode the component works the same way as it does in inline mode while a
   <ld-option value="pineapple">Pineapple</ld-option>
   <ld-option value="plum">Plum</ld-option>
 </ld-select>
+
+<!-- React component -->
+
+<LdSelect placeholder="Pick a fruit" name="fruit" size="sm">
+  <LdOption value="apple">Apple</LdOption>
+  <LdOption value="banana">Banana</LdOption>
+  <LdOption value="strawberry">Strawberry</LdOption>
+  <LdOption value="watermelon" disabled>Watermelon</LdOption>
+  <LdOption value="honeymelon">Honeymelon</LdOption>
+  <LdOption value="rasberry">Rasberry</LdOption>
+  <LdOption value="cherry">Cherry</LdOption>
+  <LdOption value="blueberry">Blueberry</LdOption>
+  <LdOption value="peach">Peach</LdOption>
+  <LdOption value="grape">Grape</LdOption>
+  <LdOption value="fuyu persimmon">Fuyu Persimmon</LdOption>
+  <LdOption value="monstera deliciosa">Monstera Deliciosa</LdOption>
+  <LdOption value="pear">Pear</LdOption>
+  <LdOption value="pineapple">Pineapple</LdOption>
+  <LdOption value="plum">Plum</LdOption>
+</LdSelect>
+
+<LdSelect placeholder="Pick a fruit" name="fruit">
+  <LdOption value="apple">Apple</LdOption>
+  <LdOption value="banana">Banana</LdOption>
+  <LdOption value="strawberry">Strawberry</LdOption>
+  <LdOption value="watermelon" disabled>Watermelon</LdOption>
+  <LdOption value="honeymelon">Honeymelon</LdOption>
+  <LdOption value="rasberry">Rasberry</LdOption>
+  <LdOption value="cherry">Cherry</LdOption>
+  <LdOption value="blueberry">Blueberry</LdOption>
+  <LdOption value="peach">Peach</LdOption>
+  <LdOption value="grape">Grape</LdOption>
+  <LdOption value="fuyu persimmon">Fuyu Persimmon</LdOption>
+  <LdOption value="monstera deliciosa">Monstera Deliciosa</LdOption>
+  <LdOption value="pear">Pear</LdOption>
+  <LdOption value="pineapple">Pineapple</LdOption>
+  <LdOption value="plum">Plum</LdOption>
+</LdSelect>
+
+<LdSelect placeholder="Pick a fruit" name="fruit" size="lg">
+  <LdOption value="apple">Apple</LdOption>
+  <LdOption value="banana">Banana</LdOption>
+  <LdOption value="strawberry">Strawberry</LdOption>
+  <LdOption value="watermelon" disabled>Watermelon</LdOption>
+  <LdOption value="honeymelon">Honeymelon</LdOption>
+  <LdOption value="rasberry">Rasberry</LdOption>
+  <LdOption value="cherry">Cherry</LdOption>
+  <LdOption value="blueberry">Blueberry</LdOption>
+  <LdOption value="peach">Peach</LdOption>
+  <LdOption value="grape">Grape</LdOption>
+  <LdOption value="fuyu persimmon">Fuyu Persimmon</LdOption>
+  <LdOption value="monstera deliciosa">Monstera Deliciosa</LdOption>
+  <LdOption value="pear">Pear</LdOption>
+  <LdOption value="pineapple">Pineapple</LdOption>
+  <LdOption value="plum">Plum</LdOption>
+</LdSelect>
+
+<LdSelect placeholder="Pick some fruits" name="fruits" multiple size="sm">
+  <LdOption value="apple">Apple</LdOption>
+  <LdOption value="banana">Banana</LdOption>
+  <LdOption value="strawberry">Strawberry</LdOption>
+  <LdOption value="watermelon" disabled>Watermelon</LdOption>
+  <LdOption value="honeymelon">Honeymelon</LdOption>
+  <LdOption value="rasberry">Rasberry</LdOption>
+  <LdOption value="cherry">Cherry</LdOption>
+  <LdOption value="blueberry">Blueberry</LdOption>
+  <LdOption value="peach">Peach</LdOption>
+  <LdOption value="grape">Grape</LdOption>
+  <LdOption value="fuyu persimmon">Fuyu Persimmon</LdOption>
+  <LdOption value="monstera deliciosa">Monstera Deliciosa</LdOption>
+  <LdOption value="pear">Pear</LdOption>
+  <LdOption value="pineapple">Pineapple</LdOption>
+  <LdOption value="plum">Plum</LdOption>
+</LdSelect>
+
+<LdSelect placeholder="Pick some fruits" name="fruits" multiple>
+  <LdOption value="apple">Apple</LdOption>
+  <LdOption value="banana">Banana</LdOption>
+  <LdOption value="strawberry">Strawberry</LdOption>
+  <LdOption value="watermelon" disabled>Watermelon</LdOption>
+  <LdOption value="honeymelon">Honeymelon</LdOption>
+  <LdOption value="rasberry">Rasberry</LdOption>
+  <LdOption value="cherry">Cherry</LdOption>
+  <LdOption value="blueberry">Blueberry</LdOption>
+  <LdOption value="peach">Peach</LdOption>
+  <LdOption value="grape">Grape</LdOption>
+  <LdOption value="fuyu persimmon">Fuyu Persimmon</LdOption>
+  <LdOption value="monstera deliciosa">Monstera Deliciosa</LdOption>
+  <LdOption value="pear">Pear</LdOption>
+  <LdOption value="pineapple">Pineapple</LdOption>
+  <LdOption value="plum">Plum</LdOption>
+</LdSelect>
+
+<LdSelect placeholder="Pick some fruits" name="fruits" multiple size="lg">
+  <LdOption value="apple">Apple</LdOption>
+  <LdOption value="banana">Banana</LdOption>
+  <LdOption value="strawberry">Strawberry</LdOption>
+  <LdOption value="watermelon" disabled>Watermelon</LdOption>
+  <LdOption value="honeymelon">Honeymelon</LdOption>
+  <LdOption value="rasberry">Rasberry</LdOption>
+  <LdOption value="cherry">Cherry</LdOption>
+  <LdOption value="blueberry">Blueberry</LdOption>
+  <LdOption value="peach">Peach</LdOption>
+  <LdOption value="grape">Grape</LdOption>
+  <LdOption value="fuyu persimmon">Fuyu Persimmon</LdOption>
+  <LdOption value="monstera deliciosa">Monstera Deliciosa</LdOption>
+  <LdOption value="pear">Pear</LdOption>
+  <LdOption value="pineapple">Pineapple</LdOption>
+  <LdOption value="plum">Plum</LdOption>
+</LdSelect>
 
 <!-- CSS component -->
 
@@ -914,6 +1433,65 @@ For both, the ld-select Web Component and the CSS Component, you can use a custo
   <ld-icon slot="icon" name="placeholder"></ld-icon>
 </ld-select>
 
+<!-- React component -->
+
+<LdSelect placeholder="Pick a fruit" name="fruit" size="sm">
+  <LdOption value="apple">Apple</LdOption>
+  <LdOption value="banana">Banana</LdOption>
+  <LdOption value="strawberry">Strawberry</LdOption>
+  <LdOption value="watermelon" disabled>Watermelon</LdOption>
+  <LdOption value="honeymelon">Honeymelon</LdOption>
+  <LdOption value="rasberry">Rasberry</LdOption>
+  <LdOption value="cherry">Cherry</LdOption>
+  <LdOption value="blueberry">Blueberry</LdOption>
+  <LdOption value="peach">Peach</LdOption>
+  <LdOption value="grape">Grape</LdOption>
+  <LdOption value="fuyu persimmon">Fuyu Persimmon</LdOption>
+  <LdOption value="monstera deliciosa">Monstera Deliciosa</LdOption>
+  <LdOption value="pear">Pear</LdOption>
+  <LdOption value="pineapple">Pineapple</LdOption>
+  <LdOption value="plum">Plum</LdOption>
+  <LdIcon slot="icon" name="placeholder"></LdIcon>
+</LdSelect>
+
+<LdSelect placeholder="Pick a fruit" name="fruit">
+  <LdOption value="apple">Apple</LdOption>
+  <LdOption value="banana">Banana</LdOption>
+  <LdOption value="strawberry">Strawberry</LdOption>
+  <LdOption value="watermelon" disabled>Watermelon</LdOption>
+  <LdOption value="honeymelon">Honeymelon</LdOption>
+  <LdOption value="rasberry">Rasberry</LdOption>
+  <LdOption value="cherry">Cherry</LdOption>
+  <LdOption value="blueberry">Blueberry</LdOption>
+  <LdOption value="peach">Peach</LdOption>
+  <LdOption value="grape">Grape</LdOption>
+  <LdOption value="fuyu persimmon">Fuyu Persimmon</LdOption>
+  <LdOption value="monstera deliciosa">Monstera Deliciosa</LdOption>
+  <LdOption value="pear">Pear</LdOption>
+  <LdOption value="pineapple">Pineapple</LdOption>
+  <LdOption value="plum">Plum</LdOption>
+  <LdIcon slot="icon" name="placeholder"></LdIcon>
+</LdSelect>
+
+<LdSelect placeholder="Pick a fruit" name="fruit" size="lg">
+  <LdOption value="apple">Apple</LdOption>
+  <LdOption value="banana">Banana</LdOption>
+  <LdOption value="strawberry">Strawberry</LdOption>
+  <LdOption value="watermelon" disabled>Watermelon</LdOption>
+  <LdOption value="honeymelon">Honeymelon</LdOption>
+  <LdOption value="rasberry">Rasberry</LdOption>
+  <LdOption value="cherry">Cherry</LdOption>
+  <LdOption value="blueberry">Blueberry</LdOption>
+  <LdOption value="peach">Peach</LdOption>
+  <LdOption value="grape">Grape</LdOption>
+  <LdOption value="fuyu persimmon">Fuyu Persimmon</LdOption>
+  <LdOption value="monstera deliciosa">Monstera Deliciosa</LdOption>
+  <LdOption value="pear">Pear</LdOption>
+  <LdOption value="pineapple">Pineapple</LdOption>
+  <LdOption value="plum">Plum</LdOption>
+  <LdIcon slot="icon" name="placeholder"></LdIcon>
+</LdSelect>
+
 <!-- CSS component -->
 
 <div class='ld-select ld-select--sm'>
@@ -1030,6 +1608,44 @@ For both, the ld-select Web Component and the CSS Component, you can use a custo
   <ld-option value="pineapple">Pineapple</ld-option>
   <ld-option value="plum">Plum</ld-option>
 </ld-select>
+
+<!-- React component -->
+
+<LdSelect filter placeholder="Pick a fruit" name="fruit">
+  <LdOption value="apple">Apple</LdOption>
+  <LdOption value="banana">Banana</LdOption>
+  <LdOption value="strawberry">Strawberry</LdOption>
+  <LdOption value="watermelon" disabled>Watermelon</LdOption>
+  <LdOption value="honeymelon">Honeymelon</LdOption>
+  <LdOption value="rasberry">Rasberry</LdOption>
+  <LdOption value="cherry">Cherry</LdOption>
+  <LdOption value="blueberry">Blueberry</LdOption>
+  <LdOption value="peach">Peach</LdOption>
+  <LdOption value="grape">Grape</LdOption>
+  <LdOption value="fuyu persimmon">Fuyu Persimmon</LdOption>
+  <LdOption value="monstera deliciosa">Monstera Deliciosa</LdOption>
+  <LdOption value="pear">Pear</LdOption>
+  <LdOption value="pineapple">Pineapple</LdOption>
+  <LdOption value="plum">Plum</LdOption>
+</LdSelect>
+
+<LdSelect filter placeholder="Pick some fruits" name="fruits" multiple maxRows={2} style={ { maxWidth: '17rem' } }>
+  <LdOption value="apple">Apple</LdOption>
+  <LdOption value="banana" selected>Banana</LdOption>
+  <LdOption value="strawberry">Strawberry</LdOption>
+  <LdOption value="watermelon" disabled>Watermelon</LdOption>
+  <LdOption value="honeymelon">Honeymelon</LdOption>
+  <LdOption value="rasberry">Rasberry</LdOption>
+  <LdOption value="cherry" selected>Cherry</LdOption>
+  <LdOption value="blueberry">Blueberry</LdOption>
+  <LdOption value="peach">Peach</LdOption>
+  <LdOption value="grape">Grape</LdOption>
+  <LdOption value="fuyu persimmon" selected>Fuyu Persimmon</LdOption>
+  <LdOption value="monstera deliciosa">Monstera Deliciosa</LdOption>
+  <LdOption value="pear">Pear</LdOption>
+  <LdOption value="pineapple">Pineapple</LdOption>
+  <LdOption value="plum">Plum</LdOption>
+</LdSelect>
 {% endexample %}
 
 ### With label
@@ -1055,6 +1671,29 @@ For both, the ld-select Web Component and the CSS Component, you can use a custo
     <ld-option value="plum">Plum</ld-option>
   </ld-select>
 </ld-label>
+
+<!-- React component -->
+
+<LdLabel>
+  Favorite fruit
+  <LdSelect placeholder="Pick a fruit" name="fruit">
+    <LdOption value="apple">Apple</LdOption>
+    <LdOption value="banana">Banana</LdOption>
+    <LdOption value="strawberry">Strawberry</LdOption>
+    <LdOption value="watermelon" disabled>Watermelon</LdOption>
+    <LdOption value="honeymelon">Honeymelon</LdOption>
+    <LdOption value="rasberry">Rasberry</LdOption>
+    <LdOption value="cherry">Cherry</LdOption>
+    <LdOption value="blueberry">Blueberry</LdOption>
+    <LdOption value="peach">Peach</LdOption>
+    <LdOption value="grape">Grape</LdOption>
+    <LdOption value="fuyu persimmon">Fuyu Persimmon</LdOption>
+    <LdOption value="monstera deliciosa">Monstera Deliciosa</LdOption>
+    <LdOption value="pear">Pear</LdOption>
+    <LdOption value="pineapple">Pineapple</LdOption>
+    <LdOption value="plum">Plum</LdOption>
+  </LdSelect>
+</LdLabel>
 
 <!-- CSS component -->
 
@@ -1120,6 +1759,30 @@ For both, the ld-select Web Component and the CSS Component, you can use a custo
   </ld-select>
   <ld-input-message mode="info">Not available today.</ld-input-message>
 </ld-label>
+
+<!-- React component -->
+
+<LdLabel>
+  Favorite fruit
+  <LdSelect placeholder="Pick a fruit" name="fruit">
+    <LdOption value="apple">Apple</LdOption>
+    <LdOption value="banana">Banana</LdOption>
+    <LdOption value="strawberry">Strawberry</LdOption>
+    <LdOption value="watermelon" disabled>Watermelon</LdOption>
+    <LdOption value="honeymelon">Honeymelon</LdOption>
+    <LdOption value="rasberry">Rasberry</LdOption>
+    <LdOption value="cherry">Cherry</LdOption>
+    <LdOption value="blueberry">Blueberry</LdOption>
+    <LdOption value="peach">Peach</LdOption>
+    <LdOption value="grape">Grape</LdOption>
+    <LdOption value="fuyu persimmon">Fuyu Persimmon</LdOption>
+    <LdOption value="monstera deliciosa" selected>Monstera Deliciosa</LdOption>
+    <LdOption value="pear">Pear</LdOption>
+    <LdOption value="pineapple">Pineapple</LdOption>
+    <LdOption value="plum">Plum</LdOption>
+  </LdSelect>
+  <LdInputMessage mode="info">Not available today.</LdInputMessage>
+</LdLabel>
 
 <!-- CSS component -->
 

--- a/src/liquid/components/ld-select/readme.md
+++ b/src/liquid/components/ld-select/readme.md
@@ -1451,7 +1451,7 @@ For both, the ld-select Web Component and the CSS Component, you can use a custo
   <LdOption value="pear">Pear</LdOption>
   <LdOption value="pineapple">Pineapple</LdOption>
   <LdOption value="plum">Plum</LdOption>
-  <LdIcon slot="icon" name="placeholder"></LdIcon>
+  <LdIcon slot="icon" name="placeholder" />
 </LdSelect>
 
 <LdSelect placeholder="Pick a fruit" name="fruit">
@@ -1470,7 +1470,7 @@ For both, the ld-select Web Component and the CSS Component, you can use a custo
   <LdOption value="pear">Pear</LdOption>
   <LdOption value="pineapple">Pineapple</LdOption>
   <LdOption value="plum">Plum</LdOption>
-  <LdIcon slot="icon" name="placeholder"></LdIcon>
+  <LdIcon slot="icon" name="placeholder" />
 </LdSelect>
 
 <LdSelect placeholder="Pick a fruit" name="fruit" size="lg">
@@ -1489,7 +1489,7 @@ For both, the ld-select Web Component and the CSS Component, you can use a custo
   <LdOption value="pear">Pear</LdOption>
   <LdOption value="pineapple">Pineapple</LdOption>
   <LdOption value="plum">Plum</LdOption>
-  <LdIcon slot="icon" name="placeholder"></LdIcon>
+  <LdIcon slot="icon" name="placeholder" />
 </LdSelect>
 
 <!-- CSS component -->

--- a/src/liquid/components/ld-sr-live/readme.md
+++ b/src/liquid/components/ld-sr-live/readme.md
@@ -93,7 +93,7 @@ const formStyle = {
 
 return (
   <>
-    <LdSrLive></LdSrLive>
+    <LdSrLive />
 
     <form
       onSubmit={(ev) => {
@@ -108,7 +108,7 @@ return (
     >
       <LdLabel>
         Info message
-        <LdInput ref={infoInputRef}></LdInput>
+        <LdInput ref={infoInputRef} />
       </LdLabel>
       <LdButton type="submit">Submit</LdButton>
     </form>
@@ -126,7 +126,7 @@ return (
     >
       <LdLabel>
         Alert message
-        <LdInput ref={alertInputRef}></LdInput>
+        <LdInput ref={alertInputRef} />
       </LdLabel>
       <LdButton type="submit">Submit</LdButton>
     </form>

--- a/src/liquid/components/ld-sr-live/readme.md
+++ b/src/liquid/components/ld-sr-live/readme.md
@@ -79,6 +79,59 @@ formAlert.addEventListener('submit', ev => {
   }))
 })
 </script>
+
+<!-- React component -->
+
+const infoInputRef = React.useRef(null)
+const alertInputRef = React.useRef(null)
+const formStyle = {
+  display: 'grid',
+  gridAutoFlow: 'column',
+  alignItems: 'flex-end',
+  gridGap: '1rem'
+}
+
+return (
+  <>
+    <LdSrLive></LdSrLive>
+
+    <form
+      onSubmit={(ev) => {
+        ev.preventDefault()
+        dispatchEvent(
+          new CustomEvent('ldSrLiveInfo', {
+            detail: infoInputRef.current.value || '',
+          })
+        )
+      }}
+      style={formStyle}
+    >
+      <LdLabel>
+        Info message
+        <LdInput ref={infoInputRef}></LdInput>
+      </LdLabel>
+      <LdButton type="submit">Submit</LdButton>
+    </form>
+
+    <form
+      onSubmit={(ev) => {
+        ev.preventDefault()
+        dispatchEvent(
+          new CustomEvent('ldSrLiveAlert', {
+            detail: alertInputRef.current.value || '',
+          })
+        )
+      }}
+      style={formStyle}
+    >
+      <LdLabel>
+        Alert message
+        <LdInput ref={alertInputRef}></LdInput>
+      </LdLabel>
+      <LdButton type="submit">Submit</LdButton>
+    </form>
+  </>
+)
 {% endexample %}
 
 

--- a/src/liquid/components/ld-sr-only/readme.md
+++ b/src/liquid/components/ld-sr-only/readme.md
@@ -22,6 +22,10 @@ The CSS class `ld-sr-only` works the same way as its Web Component counterpart, 
 {% example '{ "opened": true }' %}
 <ld-sr-only>Hello screen reader</ld-sr-only>
 
+<!-- React component -->
+
+<LdSrOnly>Hello screen reader</LdSrOnly>
+
 <!-- CSS component -->
 
 <span class="ld-sr-only">Hello screen reader</span>


### PR DESCRIPTION
# Description

Adds React examples for the following components:

- ld-select
- ld-sr-only
- ld-sr-live
- ld-radio
- ld-progress
- ld-pagination

Fixes a CSS issue for `ld-progress`.

## Type of change

Please delete options that are not relevant.

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## Is it a breaking change?

- [ ] Yes
- [x] No

# How Has This Been Tested?

Please describe the tests that you've added and run to verify your changes. 
Provide instructions, so we can reproduce.

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes