### PR TITLE
Fix/ld header

### DIFF
--- a/screenshot/builds/master.json
+++ b/screenshot/builds/master.json
@@ -7792,6 +7792,32 @@
       "isMobile": false
     },
     {
+      "id": "87a3acbb",
+      "image": "26807b10fdae0172f414f8b77f1f6779.png",
+      "userAgent": "default",
+      "desc": "ld-circular-progress reset renders with box-sizing reset as CSS component",
+      "testPath": "./src/liquid/components/ld-circular-progress/test/ld-circular-progress.e2e.ts",
+      "width": 600,
+      "height": 600,
+      "deviceScaleFactor": 1,
+      "hasTouch": false,
+      "isLandscape": false,
+      "isMobile": false
+    },
+    {
+      "id": "00aa03af",
+      "image": "26807b10fdae0172f414f8b77f1f6779.png",
+      "userAgent": "default",
+      "desc": "ld-circular-progress reset renders with box-sizing reset as Web Component",
+      "testPath": "./src/liquid/components/ld-circular-progress/test/ld-circular-progress.e2e.ts",
+      "width": 600,
+      "height": 600,
+      "deviceScaleFactor": 1,
+      "hasTouch": false,
+      "isLandscape": false,
+      "isMobile": false
+    },
+    {
       "id": "3d455876",
       "image": "5b450704fa5ce1ba379630649c5afab8.png",
       "userAgent": "default",

--- a/src/docs/components/docs-example/docs-example.css
+++ b/src/docs/components/docs-example/docs-example.css
@@ -89,6 +89,7 @@
   justify-content: space-between;
   align-items: center;
   flex-grow: 1;
+  line-height: 0; /* Firefox fix */
 }
 
 .docs-example__tool-switch {

--- a/src/docs/components/docs-nav/docs-nav.css
+++ b/src/docs/components/docs-nav/docs-nav.css
@@ -32,7 +32,7 @@
       background-image: url('dist/build/assets/chevron-guides-dark.svg');
     }
     .docs-nav__summary-toggle {
-      background-color: var(--ld-col-vc);
+      background-color: var(--ld-col-vc-200);
     }
   }
   .docs-nav__summary--globals,

--- a/src/liquid/components/ld-breadcrumbs/readme.md
+++ b/src/liquid/components/ld-breadcrumbs/readme.md
@@ -28,6 +28,13 @@ This component is meant to be used in conjunction with the [`ld-crumb`](./ld-cru
   <ld-crumb href="components/ld-breadcrumbs/">Breadcrumbs</ld-crumb>
 </ld-breadcrumbs>
 
+<!-- React component -->
+
+<LdBreadcrumbs>
+  <LdCrumb href="components/">Components</LdCrumb>
+  <LdCrumb href="components/ld-breadcrumbs/">Breadcrumbs</LdCrumb>
+</LdBreadcrumbs>
+
 <!-- CSS component -->
 
 <nav class="ld-breadcrumbs" aria-label="Breadcrumbs">
@@ -55,6 +62,19 @@ This component is meant to be used in conjunction with the [`ld-crumb`](./ld-cru
     Breadcrumbs
   </ld-crumb>
 </ld-breadcrumbs>
+
+<!-- React component -->
+
+<LdBreadcrumbs>
+  <LdCrumb href="components/">
+    <LdIcon name="placeholder" size="sm" />
+    Components
+  </LdCrumb>
+  <LdCrumb href="components/ld-breadcrumbs/">
+    <LdIcon name="placeholder" size="sm" />
+    Breadcrumbs
+  </LdCrumb>
+</LdBreadcrumbs>
 
 <!-- CSS component -->
 

--- a/src/liquid/components/ld-card/ld-card-stack/readme.md
+++ b/src/liquid/components/ld-card/ld-card-stack/readme.md
@@ -31,6 +31,16 @@ Use the `ld-card-stack` component to display multiple [`ld-card`](components/ld-
   <ld-card>Card E</ld-card>
 </ld-card-stack>
 
+<!-- React component -->
+
+<LdCardStack>
+  <LdCard>Card A</LdCard>
+  <LdCard>Card B</LdCard>
+  <LdCard>Card C</LdCard>
+  <LdCard>Card D</LdCard>
+  <LdCard>Card E</LdCard>
+</LdCardStack>
+
 <!-- CSS component -->
 
 <ol class="ld-card-stack">
@@ -55,6 +65,16 @@ Use the `ld-card-stack` component to display multiple [`ld-card`](components/ld-
   <ld-card>Card E</ld-card>
 </ld-card-stack>
 
+<!-- React component -->
+
+<LdCardStack direction="ltr">
+  <LdCard>Card A</LdCard>
+  <LdCard>Card B</LdCard>
+  <LdCard>Card C</LdCard>
+  <LdCard>Card D</LdCard>
+  <LdCard>Card E</LdCard>
+</LdCardStack>
+
 <!-- CSS component -->
 
 <ol class="ld-card-stack ld-card-stack--ltr">
@@ -77,6 +97,16 @@ Use the `ld-card-stack` component to display multiple [`ld-card`](components/ld-
   <ld-card>Card E</ld-card>
 </ld-card-stack>
 
+<!-- React component -->
+
+<LdCardStack direction="rtl">
+  <LdCard>Card A</LdCard>
+  <LdCard>Card B</LdCard>
+  <LdCard>Card C</LdCard>
+  <LdCard>Card D</LdCard>
+  <LdCard>Card E</LdCard>
+</LdCardStack>
+
 <!-- CSS component -->
 
 <ol class="ld-card-stack ld-card-stack--rtl">
@@ -98,6 +128,16 @@ Use the `ld-card-stack` component to display multiple [`ld-card`](components/ld-
   <ld-card>Card D</ld-card>
   <ld-card>Card E</ld-card>
 </ld-card-stack>
+
+<!-- React component -->
+
+<LdCardStack direction="vertical">
+  <LdCard>Card A</LdCard>
+  <LdCard>Card B</LdCard>
+  <LdCard>Card C</LdCard>
+  <LdCard>Card D</LdCard>
+  <LdCard>Card E</LdCard>
+</LdCardStack>
 
 <!-- CSS component -->
 

--- a/src/liquid/components/ld-card/readme.md
+++ b/src/liquid/components/ld-card/readme.md
@@ -25,6 +25,12 @@ Additionally, there is the [`ld-card-stack`](components/ld-card/ld-card-stack/) 
   <ld-typo>Lorem ipsum dolor sit amet.</ld-typo>
 </ld-card>
 
+<!-- React component -->
+
+<LdCard>
+  <LdTypo>Lorem ipsum dolor sit amet.</LdTypo>
+</LdCard>
+
 <!-- CSS component -->
 
 <div class="ld-card">
@@ -44,6 +50,16 @@ The `size` prop effects the card padding only.
 <ld-card size="sm">
   <ld-typo>Lorem ipsum dolor sit amet.</ld-typo>
 </ld-card>
+
+<!-- React component -->
+
+<LdCard>
+  <LdTypo>Lorem ipsum dolor sit amet.</LdTypo>
+</LdCard>
+
+<LdCard size="sm">
+  <LdTypo>Lorem ipsum dolor sit amet.</LdTypo>
+</LdCard>
 
 <!-- CSS component -->
 
@@ -75,6 +91,24 @@ The `size` prop effects the card padding only.
   <ld-typo>Lorem ipsum dolor sit amet.</ld-typo>
 </ld-card>
 
+<!-- React component -->
+
+<LdCard>
+  <LdTypo>Lorem ipsum dolor sit amet.</LdTypo>
+</LdCard>
+
+<LdCard shadow="active">
+  <LdTypo>Lorem ipsum dolor sit amet.</LdTypo>
+</LdCard>
+
+<LdCard shadow="hover">
+  <LdTypo>Lorem ipsum dolor sit amet.</LdTypo>
+</LdCard>
+
+<LdCard shadow="sticky">
+  <LdTypo>Lorem ipsum dolor sit amet.</LdTypo>
+</LdCard>
+
 <!-- CSS component -->
 
 <div class="ld-card">
@@ -100,25 +134,53 @@ Use the `shadow-interactive` prop for a transition to a different shadow on hove
 
 {% example %}
 <ld-card shadow-interactive="sticky">
-  <ld-typo style="margin-bottom: 1rem">Lorem ipsum dolor sit amet.</ld-typo>
+  <ld-typo style="margin-bottom: 1rem">
+    Lorem ipsum dolor sit amet.
+  </ld-typo>
   <ld-button mode="highlight">Click me</ld-button>
 </ld-card>
 
 <ld-card shadow="sticky" shadow-interactive="stacked">
-  <ld-typo style="margin-bottom: 1rem">Lorem ipsum dolor sit amet.</ld-typo>
+  <ld-typo style="margin-bottom: 1rem">
+    Lorem ipsum dolor sit amet.
+  </ld-typo>
   <ld-button mode="highlight">Click me</ld-button>
 </ld-card>
+
+<!-- React component -->
+
+<LdCard shadowInteractive="sticky">
+  <LdTypo style={ { marginBottom: '1rem' } }>
+    Lorem ipsum dolor sit amet.
+  </LdTypo>
+  <LdButton mode="highlight">Click me</LdButton>
+</LdCard>
+
+<LdCard shadow="sticky" shadowInteractive="stacked">
+  <LdTypo style={ { marginBottom: '1rem' } }>
+    Lorem ipsum dolor sit amet.
+  </LdTypo>
+  <LdButton mode="highlight">Click me</LdButton>
+</LdCard>
 
 <!-- CSS component -->
 
 <div class="ld-card ld-card--interactive-sticky">
-  <p class="ld-typo ld-typo--body-m" style="margin-bottom: 1rem">Lorem ipsum dolor sit amet.</p>
-  <button class="ld-button ld-button--highlight">Click me</button>
+  <p class="ld-typo ld-typo--body-m" style="margin-bottom: 1rem">
+    Lorem ipsum dolor sit amet.
+  </p>
+  <button class="ld-button ld-button--highlight">
+    Click me
+  </button>
 </div>
 
 <div class="ld-card ld-card--sticky ld-card--interactive-stacked">
-  <p class="ld-typo ld-typo--body-m" style="margin-bottom: 1rem">Lorem ipsum dolor sit amet.</p>
-  <button class="ld-button ld-button--highlight">Click me</button>
+  <p class="ld-typo ld-typo--body-m" style="margin-bottom: 1rem">
+    Lorem ipsum dolor sit amet.
+  </p>
+  <button class="ld-button ld-button--highlight">
+    Click me
+  </button>
 </div>
 {% endexample %}
 

--- a/src/liquid/components/ld-checkbox/readme.md
+++ b/src/liquid/components/ld-checkbox/readme.md
@@ -27,6 +27,10 @@ This component can be used in conjunction with the [`ld-label`](components/ld-la
 {% example %}
 <ld-checkbox></ld-checkbox>
 
+<!-- React component -->
+
+<LdCheckbox />
+
 <!-- CSS component -->
 
 <div class="ld-checkbox">
@@ -56,6 +60,12 @@ This component can be used in conjunction with the [`ld-label`](components/ld-la
 <ld-checkbox disabled></ld-checkbox>
 
 <ld-checkbox disabled checked></ld-checkbox>
+
+<!-- React component -->
+
+<LdCheckbox disabled />
+
+<LdCheckbox disabled checked />
 
 <!-- CSS component -->
 
@@ -107,13 +117,18 @@ This component can be used in conjunction with the [`ld-label`](components/ld-la
 
 <ld-checkbox aria-disabled="true" checked></ld-checkbox>
 
+<!-- React component -->
+
+<LdCheckbox aria-disabled="true" />
+
+<LdCheckbox aria-disabled="true" checked />
+
 <!-- CSS component -->
 
 <div class="ld-checkbox">
   <input
     type="checkbox"
-    aria-disabled="true"
-    id="focusable-disabled-checkbox-1">
+    aria-disabled="true">
   <svg
     class="ld-checkbox__check"
     width="14"
@@ -136,8 +151,7 @@ This component can be used in conjunction with the [`ld-label`](components/ld-la
   <input
     type="checkbox"
     aria-disabled="true"
-    checked
-    id="focusable-disabled-checkbox-2">
+    checked>
   <svg
     class="ld-checkbox__check"
     width="14"
@@ -158,7 +172,7 @@ This component can be used in conjunction with the [`ld-label`](components/ld-la
 
 <!-- Example code for input prevention on aria-disabled checkbox elements -->
 <script>
-  const inputs = document.querySelectorAll('#focusable-disabled-checkbox-1, #focusable-disabled-checkbox-2')
+  const inputs = document.currentScript.parentElement.querySelectorAll('input')
   Array.from(inputs).forEach(input => {
     input.addEventListener('click', (ev) => {
       ev.preventDefault()
@@ -182,32 +196,14 @@ If the `indeterminate` attribute is present on the `ld-checkbox` component, the 
 {% example '{ "background": "light" }' %}
 <ld-checkbox indeterminate></ld-checkbox>
 
-<ld-checkbox indeterminate disabled></ld-checkbox>
+<!-- React component -->
+
+<LdCheckbox indeterminate />
 
 <!-- CSS component -->
 
-<div id="example-indeterminate-1" class="ld-checkbox">
+<div class="ld-checkbox">
   <input type="checkbox">
-  <svg
-    class="ld-checkbox__check"
-    width="14"
-    height="14"
-    fill="none"
-    viewBox="0 0 14 14"
-  >
-    <path
-      d="M12 4L5.40795 10L2 6.63964"
-      stroke="currentColor"
-      stroke-width="3"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-    />
-  </svg>
-  <div class="ld-checkbox__box"></div>
-</div>
-
-<div id="example-indeterminate-2" class="ld-checkbox">
-  <input type="checkbox" disabled>
   <svg
     class="ld-checkbox__check"
     width="14"
@@ -227,8 +223,8 @@ If the `indeterminate` attribute is present on the `ld-checkbox` component, the 
 </div>
 
 <script>
-document.querySelectorAll('#example-indeterminate-1 input, #example-indeterminate-2 input')
-  .forEach(input => input.indeterminate = true)
+document.currentScript.previousElementSibling.querySelector('input')
+  .indeterminate = true
 </script>
 
 {% endexample %}
@@ -242,32 +238,14 @@ document.querySelectorAll('#example-indeterminate-1 input, #example-indeterminat
 {% example '{ "background": "light" }' %}
 <ld-checkbox tone="dark"></ld-checkbox>
 
-<ld-checkbox tone="dark" disabled></ld-checkbox>
+<!-- React component -->
+
+<LdCheckbox tone="dark" />
 
 <!-- CSS component -->
 
 <div class="ld-checkbox ld-checkbox--dark">
   <input type="checkbox">
-  <svg
-    class="ld-checkbox__check"
-    width="14"
-    height="14"
-    fill="none"
-    viewBox="0 0 14 14"
-  >
-    <path
-      d="M12 4L5.40795 10L2 6.63964"
-      stroke="currentColor"
-      stroke-width="3"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-    />
-  </svg>
-  <div class="ld-checkbox__box"></div>
-</div>
-
-<div class="ld-checkbox ld-checkbox--dark">
-  <input type="checkbox" disabled>
   <svg
     class="ld-checkbox__check"
     width="14"
@@ -292,32 +270,14 @@ document.querySelectorAll('#example-indeterminate-1 input, #example-indeterminat
 {% example %}
 <ld-checkbox mode="highlight"></ld-checkbox>
 
-<ld-checkbox mode="highlight" disabled></ld-checkbox>
+<!-- React component -->
+
+<LdCheckbox mode="highlight" />
 
 <!-- CSS component -->
 
 <div class="ld-checkbox ld-checkbox--highlight">
   <input type="checkbox">
-  <svg
-    class="ld-checkbox__check"
-    width="14"
-    height="14"
-    fill="none"
-    viewBox="0 0 14 14"
-  >
-    <path
-      d="M12 4L5.40795 10L2 6.63964"
-      stroke="currentColor"
-      stroke-width="3"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-    />
-  </svg>
-  <div class="ld-checkbox__box"></div>
-</div>
-
-<div class="ld-checkbox ld-checkbox--highlight">
-  <input type="checkbox" disabled>
   <svg
     class="ld-checkbox__check"
     width="14"
@@ -342,32 +302,14 @@ document.querySelectorAll('#example-indeterminate-1 input, #example-indeterminat
 {% example %}
 <ld-checkbox invalid></ld-checkbox>
 
-<ld-checkbox invalid disabled></ld-checkbox>
+<!-- React component -->
+
+<LdCheckbox invalid />
 
 <!-- CSS component -->
 
 <div class="ld-checkbox ld-checkbox--invalid">
   <input type="checkbox">
-  <svg
-    class="ld-checkbox__check"
-    width="14"
-    height="14"
-    fill="none"
-    viewBox="0 0 14 14"
-  >
-    <path
-      d="M12 4L5.40795 10L2 6.63964"
-      stroke="currentColor"
-      stroke-width="3"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-    />
-  </svg>
-  <div class="ld-checkbox__box"></div>
-</div>
-
-<div class="ld-checkbox ld-checkbox--invalid">
-  <input type="checkbox" disabled>
   <svg
     class="ld-checkbox__check"
     width="14"
@@ -394,32 +336,14 @@ The checkbox in mode "danger" looks and behaves the same as a checkbox with the 
 {% example %}
 <ld-checkbox mode="danger"></ld-checkbox>
 
-<ld-checkbox mode="danger" disabled></ld-checkbox>
+<!-- React component -->
+
+<LdCheckbox mode="danger" />
 
 <!-- CSS component -->
 
 <div class="ld-checkbox ld-checkbox--danger">
   <input type="checkbox">
-  <svg
-    class="ld-checkbox__check"
-    width="14"
-    height="14"
-    fill="none"
-    viewBox="0 0 14 14"
-  >
-    <path
-      d="M12 4L5.40795 10L2 6.63964"
-      stroke="currentColor"
-      stroke-width="3"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-    />
-  </svg>
-  <div class="ld-checkbox__box"></div>
-</div>
-
-<div class="ld-checkbox ld-checkbox--danger">
-  <input type="checkbox" disabled>
   <svg
     class="ld-checkbox__check"
     width="14"
@@ -446,6 +370,13 @@ The checkbox in mode "danger" looks and behaves the same as a checkbox with the 
   I have read the terms of service.*
   <ld-checkbox></ld-checkbox>
 </ld-label>
+
+<!-- React component -->
+
+<LdLabel position="right" size="m">
+  I have read the terms of service.*
+  <LdCheckbox />
+</LdLabel>
 
 <!-- CSS component -->
 
@@ -490,6 +421,33 @@ Please reffer to the [ld-label](components/ld-label/) docs for more information 
     <ld-checkbox></ld-checkbox>
     <ld-input-message mode="info">You may unsubscribe at any given time.</ld-input-message>
   </ld-label>
+</div>
+
+<!-- React component -->
+
+<div
+  style={ {
+    display: 'grid',
+    gap: '2rem',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(12rem, 1fr))',
+    width: '100%',
+  } }
+>
+  <LdLabel position="right" size="m">
+    I have read the terms of service.*
+    <LdCheckbox invalid required />
+    <LdInputMessage>
+      To proceed, you must except the terms of service.
+    </LdInputMessage>
+  </LdLabel>
+
+  <LdLabel position="right" size="m">
+    I'd like to receive a weekly newsletter.
+    <LdCheckbox />
+    <LdInputMessage mode="info">
+      You may unsubscribe at any given time.
+    </LdInputMessage>
+  </LdLabel>
 </div>
 
 <!-- CSS component -->

--- a/src/liquid/components/ld-circular-progress/ld-circular-progress.css
+++ b/src/liquid/components/ld-circular-progress/ld-circular-progress.css
@@ -43,6 +43,7 @@
   );
 
   align-items: center;
+  box-sizing: content-box !important;
   display: inline-flex;
   flex-direction: column;
   gap: var(--ld-sp-4);

--- a/src/liquid/components/ld-circular-progress/readme.md
+++ b/src/liquid/components/ld-circular-progress/readme.md
@@ -32,6 +32,14 @@ The `ld-circular-progress` component can be used to display measurements or cert
   <ld-typo variant="label-s">complete</ld-typo>
 </ld-circular-progress>
 
+<!-- React component -->
+
+<LdSrOnly id="progress-label">Progress</LdSrOnly>
+<LdCircularProgress aria-labelledby="progress-label" aria-valuenow={25}>
+  <LdTypo variant="b6">25%</LdTypo>
+  <LdTypo variant="label-s">complete</LdTypo>
+</LdCircularProgress>
+
 <!-- CSS component -->
 
 <span class="ld-sr-only" id="progress-label-css">Progress</span>
@@ -74,6 +82,37 @@ Interactive example:
   }()
 </script>
 
+<!-- React component -->
+
+const App = () => {
+  const [val, setVal] = useState(25)
+  return (
+    <>
+      <LdSrOnly id="progress-label">Progress</LdSrOnly>
+      <LdCircularProgress aria-labelledby="progress-label" aria-valuenow={val}>
+        <LdTypo
+          variant="b6"
+          style={ {
+            color: `var(--ld-thm-${val > 100 ? 'error' : 'primary'})`,
+          } }
+        >
+          {val}%
+        </LdTypo>
+        <LdTypo variant="label-s">complete</LdTypo>
+      </LdCircularProgress>
+
+      <LdSlider
+        onLdchange={(ev) => {
+          setVal(ev.detail[0])
+        }}
+        value={val}
+        max={200}
+        width="14rem"
+      />
+    </>
+  )
+}
+
 <!-- CSS component -->
 
 <span class="ld-sr-only" id="progress-label-css">Progress</span>
@@ -111,17 +150,37 @@ Interactive example:
 ## With custom min and max values
 
 {% example %}
-<ld-circular-progress aria-valuemax="360"
-             aria-valuemin="0"
-             aria-valuenow="90">
+<ld-circular-progress
+  aria-valuemax="360"
+  aria-valuemin="0"
+  aria-valuenow="90"
+>
   <ld-typo variant="b6">90°</ld-typo>
 </ld-circular-progress>
 
-<ld-circular-progress aria-valuemax="4"
-                      aria-valuenow="1">
-  <ld-typo variant="h4" style="color: var(--ld-thm-primary)">Step</ld-typo>
+<ld-circular-progress aria-valuemax="4" aria-valuenow="1">
+  <ld-typo variant="h4" style="color: var(--ld-thm-primary)">
+    Step
+  </ld-typo>
   <ld-typo variant="label-s">1 of 4</ld-typo>
 </ld-circular-progress>
+
+<!-- React component -->
+
+<LdCircularProgress
+  aria-valuemax={360}
+  aria-valuemin={0}
+  aria-valuenow={90}
+>
+  <LdTypo variant="b6">90°</LdTypo>
+</LdCircularProgress>
+
+<LdCircularProgress aria-valuemax={4} aria-valuenow={1}>
+  <LdTypo variant="h4" style={ { color: 'var(--ld-thm-primary)' } }>
+    Step
+  </LdTypo>
+  <LdTypo variant="label-s">1 of 4</LdTypo>
+</LdCircularProgress>
 
 <!-- CSS component -->
 
@@ -170,7 +229,23 @@ The component can visualize an overflow value up to 200% of the maximum progress
   <ld-typo variant="label-s">complete</ld-typo>
 </ld-circular-progress>
 
+<!-- React component -->
+
+<LdCircularProgress aria-valuenow={125}>
+  <LdTypo variant="b6" style={ { color: 'var(--ld-thm-error)' } }>125%</LdTypo>
+  <LdTypo variant="label-s">complete</LdTypo>
+</LdCircularProgress>
+<LdCircularProgress aria-valuenow={175}>
+  <LdTypo variant="b6" style={ { color: 'var(--ld-thm-error)' } }>175%</LdTypo>
+  <LdTypo variant="label-s">complete</LdTypo>
+</LdCircularProgress>
+<LdCircularProgress aria-valuenow={225}>
+  <LdTypo variant="b6" style={ { color: 'var(--ld-thm-error)' } }>225%</LdTypo>
+  <LdTypo variant="label-s">complete</LdTypo>
+</LdCircularProgress>
+
 <!-- CSS component -->
+
 <div class="ld-circular-progress ld-circular-progress--overflow"
      aria-valuenow="125"
      role="progressbar"
@@ -213,6 +288,16 @@ The component can visualize an overflow value up to 200% of the maximum progress
   <ld-typo variant="b6">25%</ld-typo>
   <ld-typo variant="label-s">complete</ld-typo>
 </ld-circular-progress>
+
+<!-- React component -->
+
+<LdCircularProgress
+  aria-valuenow={25}
+  style={ { '--ld-circular-progress-bar-col': 'var(--ld-thm-secondary)' } }
+>
+  <LdTypo variant="b6">25%</LdTypo>
+  <LdTypo variant="label-s">complete</LdTypo>
+</LdCircularProgress>
 
 <!-- CSS component -->
 
@@ -271,6 +356,91 @@ You can change the size of the circular progress bar. However, with a smaller si
     <ld-typo class="report-value" variant="b6" style="color: var(--ld-thm-success)">98</ld-typo>
   </ld-circular-progress>
   <ld-typo id="seo" variant="label-s">SEO</ld-typo>
+</div>
+
+<!-- React component -->
+
+<style>{`
+  .report {
+    display: grid;
+    place-items: center;
+    gap: var(--ld-sp-4);
+  }
+  .report ld-circular-progress {
+    --ld-circular-progress-size: 4rem;
+  }
+  .report-value {
+    transform: scale(0.8);
+  }
+`}</style>
+
+<div className="report">
+  <LdCircularProgress
+    aria-valuenow={75}
+    aria-labeledby="performance"
+    style={ { '--ld-circular-progress-bar-col': 'var(--ld-thm-warning)' } }
+  >
+    <LdTypo className="report-value" variant="b6">
+      75
+    </LdTypo>
+  </LdCircularProgress>
+  <LdTypo id="performance" variant="label-s">
+    Performance
+  </LdTypo>
+</div>
+<div className="report">
+  <LdCircularProgress
+    aria-valuenow={75}
+    aria-labeledby="accessibility"
+    style={ { '--ld-circular-progress-bar-col': 'var(--ld-thm-warning)' } }
+  >
+    <LdTypo className="report-value" variant="b6">
+      75
+    </LdTypo>
+  </LdCircularProgress>
+  <LdTypo id="accessibility" variant="label-s">
+    Accessibility
+  </LdTypo>
+</div>
+<div className="report">
+  <LdCircularProgress
+    aria-valuenow={100}
+    aria-labeledby="best-practices"
+    style={ {
+      '--ld-circular-progress-bar-col': 'var(--ld-thm-ocean-success)',
+    } }
+  >
+    <LdTypo
+      className="report-value"
+      variant="b6"
+      style={ { color: 'var(--ld-thm-success)' } }
+    >
+      100
+    </LdTypo>
+  </LdCircularProgress>
+  <LdTypo id="best-practices" variant="label-s">
+    Best Practices
+  </LdTypo>
+</div>
+<div className="report">
+  <LdCircularProgress
+    aria-valuenow={98}
+    aria-labeledby="seo"
+    style={ {
+      '--ld-circular-progress-bar-col': 'var(--ld-thm-ocean-success)',
+    } }
+  >
+    <LdTypo
+      className="report-value"
+      variant="b6"
+      style={ { color: 'var(--ld-thm-success)' } }
+    >
+      98
+    </LdTypo>
+  </LdCircularProgress>
+  <LdTypo id="seo" variant="label-s">
+    SEO
+  </LdTypo>
 </div>
 
 <!-- CSS component -->
@@ -352,22 +522,65 @@ You can change the size of the circular progress bar. However, with a smaller si
 Use this mode on backgrounds with brand color.
 
 {% example '{ "background": "brand", "hasBorder": false }' %}
-<ld-circular-progress brand-color
-                      aria-valuemax="360"
-                      aria-valuenow="90">
-  <ld-typo variant="b6" style="color: var(--ld-col-wht)">90°</ld-typo>
+<ld-circular-progress
+  brand-color
+  aria-valuemax="360"
+  aria-valuenow="90"
+>
+  <ld-typo variant="b6" style="color: var(--ld-col-wht)">
+    90°
+  </ld-typo>
 </ld-circular-progress>
-<ld-circular-progress brand-color
-                      aria-valuemax="360"
-                      aria-valuenow="350"
-                      style="--ld-circular-progress-bar-col: var(--ld-thm-warning)">
-  <ld-typo variant="b6" style="color: var(--ld-thm-warning)">350°</ld-typo>
+<ld-circular-progress
+  brand-color
+  aria-valuemax="360"
+  aria-valuenow="350"
+  style="--ld-circular-progress-bar-col: var(--ld-thm-warning)"
+>
+  <ld-typo variant="b6" style="color: var(--ld-thm-warning)">
+    350°
+  </ld-typo>
 </ld-circular-progress>
-<ld-circular-progress brand-color
-                      aria-valuemax="360"
-                      aria-valuenow="450">
-  <ld-typo variant="b6" style="color: var(--ld-thm-warning)">450°</ld-typo>
+<ld-circular-progress
+  brand-color
+  aria-valuemax="360"
+  aria-valuenow="450"
+>
+  <ld-typo variant="b6" style="color: var(--ld-thm-warning)">
+    450°
+  </ld-typo>
 </ld-circular-progress>
+
+<!-- React component -->
+
+<LdCircularProgress
+  brand-color
+  aria-valuemax={360}
+  aria-valuenow={90}
+>
+  <LdTypo variant="b6" style={ { color: 'var(--ld-col-wht)' } }>
+    90°
+  </LdTypo>
+</LdCircularProgress>
+<LdCircularProgress
+  brand-color
+  aria-valuemax={360}
+  aria-valuenow={350}
+  style={ { '--ld-circular-progress-bar-col': 'var(--ld-thm-warning)' } }
+>
+  <LdTypo variant="b6" style={ { color: 'var(--ld-thm-warning)' } }>
+    350°
+  </LdTypo>
+</LdCircularProgress>
+<LdCircularProgress
+  brand-color
+  aria-valuemax={360}
+  aria-valuenow={450}
+>
+  <LdTypo variant="b6" style={ { color: 'var(--ld-thm-warning)' } }>
+    450°
+  </LdTypo>
+</LdCircularProgress>
 
 <!-- CSS component -->
 

--- a/src/liquid/components/ld-circular-progress/test/ld-circular-progress.e2e.ts
+++ b/src/liquid/components/ld-circular-progress/test/ld-circular-progress.e2e.ts
@@ -443,4 +443,50 @@ describe('ld-circular-progress', () => {
       expect(results).toMatchScreenshot()
     })
   })
+
+  describe('reset', () => {
+    it('renders with box-sizing reset as Web Component', async () => {
+      const page = await getPageWithContent(
+        `
+        <style>
+          *, ::before, ::after {
+            box-sizing: border-box;
+          }
+        </style>
+        <ld-circular-progress aria-valuenow="25">
+          <ld-typo variant="b6">25%</ld-typo>
+          <ld-typo variant="label-s">complete</ld-typo>
+        </ld-circular-progress>`
+      )
+
+      const results = await page.compareScreenshot()
+      expect(results).toMatchScreenshot()
+    })
+
+    it('renders with box-sizing reset as CSS component', async () => {
+      const page = await getPageWithContent(
+        `
+          <style>
+            *, ::before, ::after {
+              box-sizing: border-box;
+            }
+          </style>
+          <div class="ld-circular-progress"
+             aria-valuenow="25"
+             role="progressbar"
+             style="--ld-circular-progress-valuenow: 25">
+          <span class="ld-typo ld-typo--b6">25%</span>
+          <span class="ld-typo ld-typo--label-s">complete</span>
+          ${svg}
+        </div>`,
+        {
+          components: [LdCircularProgress, LdTypo],
+          disableAllTransitions: true,
+        }
+      )
+
+      const results = await page.compareScreenshot()
+      expect(results).toMatchScreenshot()
+    })
+  })
 })

--- a/src/liquid/components/ld-cookie-consent/readme.md
+++ b/src/liquid/components/ld-cookie-consent/readme.md
@@ -102,6 +102,94 @@ The `ld-cookie-consent` Web Component is configurable using the `settings` prop.
 <ld-button onclick="event.target.previousElementSibling.showDisclaimer()">
   Show cookie consent disclaimer
 </ld-button>
+
+<!-- React component -->
+
+const App = () => {
+  const cookieConsentRef = useRef(null)
+  const cookieConsentSettings = {
+    categories: [
+      {
+        title: 'Necessary',
+        details: {
+          description:
+            'These cookies are necessary for the website to operate. Our website cannot function without these cookies, and they can only be disabled by changing your browser preferences.',
+        },
+        toggle: {
+          value: 'necessary',
+          checked: true,
+          disabled: true,
+        },
+      },
+      {
+        title: 'Functional',
+        details: {
+          description:
+            'These cookies enable the provision of advanced functionalities and are used for personalization. The cookies are set in particular in response to your actions and depend on your specific service requests (e.g., pop-up notification choices).',
+        },
+        toggle: {
+          value: 'functional',
+          checked: true,
+        },
+      },
+      {
+        title: 'Targeting',
+        details: {
+          description:
+            'These cookies may be set to learn more about your interests and show you relevant ads on other websites. These cookies work by uniquely identifying your browser and device. By integrating these cookies, we aim to learn more about your interests and your surfing behavior and to be able to place our advertising in a targeted manner.',
+          cookieTable: {
+            headers: ['Name', 'Provider', 'Description', 'Lifespan'],
+            rows: [
+              [
+                '_ga',
+                'Google LLC',
+                'Used to distinguish unique users...',
+                '2 years',
+              ],
+              [
+                '_gat',
+                'Google LLC',
+                'Used to throttle the request rate...',
+                '1 minute',
+              ],
+            ],
+          },
+        },
+        toggle: {
+          value: 'targeting',
+          checked: true,
+        },
+        autoclear: [
+          {
+            name: '_ga',
+            domain: 'example.com',
+            path: '/',
+          },
+          {
+            name: '_gat',
+            domain: 'example.com',
+            path: '/',
+          },
+        ],
+      },
+    ],
+    privacyStatementURL: 'legal/privacy/',
+    showOnLoad: false,
+  }
+  
+  return (
+    <>
+      <LdCookieConsent
+        ref={cookieConsentRef}
+        settings={cookieConsentSettings}
+      />
+      
+      <LdButton onClick={(ev) => cookieConsentRef.current.showDisclaimer()}>
+        Show cookie consent disclaimer
+      </LdButton>
+    </>
+  )
+}
 {% endexample %}
 
 ## Modes
@@ -128,6 +216,30 @@ This is the "bare minimum" mode. All cookies can be set on page load. In other w
 <ld-button onclick="event.target.previousElementSibling.showDisclaimer()">
   Show cookie consent disclaimer
 </ld-button>
+
+<!-- React component -->
+
+const App = () => {
+  const cookieConsentRef = useRef(null)
+  const cookieConsentSettings = {
+    mode: 'notice-only',
+    privacyStatementURL: 'legal/privacy/',
+    showOnLoad: false
+  }
+
+  return (
+    <>
+      <LdCookieConsent
+        ref={cookieConsentRef}
+        settings={cookieConsentSettings}
+      />
+
+      <LdButton onClick={(ev) => cookieConsentRef.current.showDisclaimer()}>
+        Show cookie consent disclaimer
+      </LdButton>
+    </>
+  )
+}
 {% endexample %}
 
 ### Opt-out
@@ -203,6 +315,95 @@ When using this mode you must provide information about the cookie categories us
 <ld-button onclick="event.target.previousElementSibling.showDisclaimer()">
   Show cookie consent disclaimer
 </ld-button>
+
+<!-- React component -->
+
+const App = () => {
+  const cookieConsentRef = useRef(null)
+  const cookieConsentSettings = {
+    mode: 'opt-out',
+    categories: [
+      {
+        title: 'Necessary',
+        details: {
+          description:
+            'These cookies are necessary for the website to operate. Our website cannot function without these cookies, and they can only be disabled by changing your browser preferences.',
+        },
+        toggle: {
+          value: 'necessary',
+          checked: true,
+          disabled: true,
+        },
+      },
+      {
+        title: 'Functional',
+        details: {
+          description:
+            'These cookies enable the provision of advanced functionalities and are used for personalization. The cookies are set in particular in response to your actions and depend on your specific service requests (e.g., pop-up notification choices).',
+        },
+        toggle: {
+          value: 'functional',
+          checked: true,
+        },
+      },
+      {
+        title: 'Targeting',
+        details: {
+          description:
+            'These cookies may be set to learn more about your interests and show you relevant ads on other websites. These cookies work by uniquely identifying your browser and device. By integrating these cookies, we aim to learn more about your interests and your surfing behavior and to be able to place our advertising in a targeted manner.',
+          cookieTable: {
+            headers: ['Name', 'Provider', 'Description', 'Lifespan'],
+            rows: [
+              [
+                '_ga',
+                'Google LLC',
+                'Used to distinguish unique users...',
+                '2 years',
+              ],
+              [
+                '_gat',
+                'Google LLC',
+                'Used to throttle the request rate...',
+                '1 minute',
+              ],
+            ],
+          },
+        },
+        toggle: {
+          value: 'targeting',
+          checked: true,
+        },
+        autoclear: [
+          {
+            name: '_ga',
+            domain: 'example.com',
+            path: '/',
+          },
+          {
+            name: '_gat',
+            domain: 'example.com',
+            path: '/',
+          },
+        ],
+      },
+    ],
+    privacyStatementURL: 'legal/privacy/',
+    showOnLoad: false,
+  }
+
+  return (
+    <>
+      <LdCookieConsent
+        ref={cookieConsentRef}
+        settings={cookieConsentSettings}
+      />
+
+      <LdButton onClick={(ev) => cookieConsentRef.current.showDisclaimer()}>
+        Show cookie consent disclaimer
+      </LdButton>
+    </>
+  )
+}
 {% endexample %}
 
 ### Opt-in
@@ -278,6 +479,95 @@ When using this mode you must provide information about the cookie categories us
 <ld-button onclick="event.target.previousElementSibling.showDisclaimer()">
   Show cookie consent disclaimer
 </ld-button>
+
+<!-- React component -->
+
+const App = () => {
+  const cookieConsentRef = useRef(null)
+  const cookieConsentSettings = {
+    mode: 'opt-in',
+    categories: [
+      {
+        title: 'Necessary',
+        details: {
+          description:
+            'These cookies are necessary for the website to operate. Our website cannot function without these cookies, and they can only be disabled by changing your browser preferences.',
+        },
+        toggle: {
+          value: 'necessary',
+          checked: true,
+          disabled: true,
+        },
+      },
+      {
+        title: 'Functional',
+        details: {
+          description:
+            'These cookies enable the provision of advanced functionalities and are used for personalization. The cookies are set in particular in response to your actions and depend on your specific service requests (e.g., pop-up notification choices).',
+        },
+        toggle: {
+          value: 'functional',
+          checked: true,
+        },
+      },
+      {
+        title: 'Targeting',
+        details: {
+          description:
+            'These cookies may be set to learn more about your interests and show you relevant ads on other websites. These cookies work by uniquely identifying your browser and device. By integrating these cookies, we aim to learn more about your interests and your surfing behavior and to be able to place our advertising in a targeted manner.',
+          cookieTable: {
+            headers: ['Name', 'Provider', 'Description', 'Lifespan'],
+            rows: [
+              [
+                '_ga',
+                'Google LLC',
+                'Used to distinguish unique users...',
+                '2 years',
+              ],
+              [
+                '_gat',
+                'Google LLC',
+                'Used to throttle the request rate...',
+                '1 minute',
+              ],
+            ],
+          },
+        },
+        toggle: {
+          value: 'targeting',
+          checked: true,
+        },
+        autoclear: [
+          {
+            name: '_ga',
+            domain: 'example.com',
+            path: '/',
+          },
+          {
+            name: '_gat',
+            domain: 'example.com',
+            path: '/',
+          },
+        ],
+      },
+    ],
+    privacyStatementURL: 'legal/privacy/',
+    showOnLoad: false,
+  }
+
+  return (
+    <>
+      <LdCookieConsent
+        ref={cookieConsentRef}
+        settings={cookieConsentSettings}
+      />
+
+      <LdButton onClick={(ev) => cookieConsentRef.current.showDisclaimer()}>
+        Show cookie consent disclaimer
+      </LdButton>
+    </>
+  )
+}
 {% endexample %}
 
 ## Dismissable
@@ -295,6 +585,31 @@ You can allow the user to dismiss the cookie consent disclaimer in all modes. Th
 <ld-button onclick="event.target.previousElementSibling.showDisclaimer()">
   Show cookie consent disclaimer
 </ld-button>
+
+<!-- React component -->
+
+const App = () => {
+  const cookieConsentRef = useRef(null)
+  const cookieConsentSettings = {
+    dismissable: true,
+    mode: 'notice-only',
+    privacyStatementURL: 'legal/privacy/',
+    showOnLoad: false,
+  }
+
+  return (
+    <>
+      <LdCookieConsent
+        ref={cookieConsentRef}
+        settings={cookieConsentSettings}
+      />
+
+      <LdButton onClick={(ev) => cookieConsentRef.current.showDisclaimer()}>
+        Show cookie consent disclaimer
+      </LdButton>
+    </>
+  )
+}
 {% endexample %}
 
 If you want to delay the next appearance of the disclaimer, you will need to listen to the `ldCookieConsentDismiss` event, persist the timestamp of the dismissal and invoke the disclaimer as soon as needed using you own application logic.
@@ -371,6 +686,96 @@ You can allow rejecting all cookies from the disclaimer in opt-in and opt-out mo
 <ld-button onclick="event.target.previousElementSibling.showDisclaimer()">
   Show cookie consent disclaimer
 </ld-button>
+
+<!-- React component -->
+
+const App = () => {
+  const cookieConsentRef = useRef(null)
+  const cookieConsentSettings = {
+    rejectable: true,
+    mode: 'opt-in',
+    privacyStatementURL: 'legal/privacy/',
+    showOnLoad: false,
+    categories: [
+      {
+        title: 'Necessary',
+        details: {
+          description:
+            'These cookies are necessary for the website to operate. Our website cannot function without these cookies, and they can only be disabled by changing your browser preferences.',
+        },
+        toggle: {
+          value: 'necessary',
+          checked: true,
+          disabled: true,
+        },
+      },
+      {
+        title: 'Functional',
+        details: {
+          description:
+            'These cookies enable the provision of advanced functionalities and are used for personalization. The cookies are set in particular in response to your actions and depend on your specific service requests (e.g., pop-up notification choices).',
+        },
+        toggle: {
+          value: 'functional',
+          checked: true,
+        },
+      },
+      {
+        title: 'Targeting',
+        details: {
+          description:
+            'These cookies may be set to learn more about your interests and show you relevant ads on other websites. These cookies work by uniquely identifying your browser and device. By integrating these cookies, we aim to learn more about your interests and your surfing behavior and to be able to place our advertising in a targeted manner.',
+          cookieTable: {
+            headers: ['Name', 'Provider', 'Description', 'Lifespan'],
+            rows: [
+              [
+                '_ga',
+                'Google LLC',
+                'Used to distinguish unique users...',
+                '2 years',
+              ],
+              [
+                '_gat',
+                'Google LLC',
+                'Used to throttle the request rate...',
+                '1 minute',
+              ],
+            ],
+          },
+        },
+        toggle: {
+          value: 'targeting',
+          checked: true,
+        },
+        autoclear: [
+          {
+            name: '_ga',
+            domain: 'example.com',
+            path: '/',
+          },
+          {
+            name: '_gat',
+            domain: 'example.com',
+            path: '/',
+          },
+        ],
+      },
+    ],
+  }
+
+  return (
+    <>
+      <LdCookieConsent
+        ref={cookieConsentRef}
+        settings={cookieConsentSettings}
+      />
+
+      <LdButton onClick={(ev) => cookieConsentRef.current.showDisclaimer()}>
+        Show cookie consent disclaimer
+      </LdButton>
+    </>
+  )
+}
 {% endexample %}
 
 ## Listing cookie categories
@@ -430,6 +835,77 @@ Some common cookie categories are _Necessary_, _Functional_ and _Targeting_. May
 <ld-button onclick="event.target.previousElementSibling.showDisclaimer()">
   Show cookie consent disclaimer
 </ld-button>
+
+<!-- React component -->
+
+const App = () => {
+  const cookieConsentRef = useRef(null)
+  const cookieConsentSettings = {
+    mode: 'opt-out',
+    categories: [
+      {
+        title: 'Necessary',
+        details: {
+          description:
+            'These cookies are necessary for the website to operate. Our website cannot function without these cookies, and they can only be disabled by changing your browser preferences.',
+        },
+        toggle: {
+          value: 'necessary',
+          checked: true,
+          disabled: true,
+        },
+      },
+      {
+        title: 'Functional',
+        details: {
+          description:
+            'These cookies enable the provision of advanced functionalities and are used for personalization. The cookies are set in particular in response to your actions and depend on your specific service requests (e.g., pop-up notification choices).',
+        },
+        toggle: {
+          value: 'functional',
+          checked: true,
+        },
+      },
+      {
+        title: 'Targeting',
+        details: {
+          description:
+            'These cookies may be set to learn more about your interests and show you relevant ads on other websites. These cookies work by uniquely identifying your browser and device. By integrating these cookies, we aim to learn more about your interests and your surfing behavior and to be able to place our advertising in a targeted manner.',
+        },
+        toggle: {
+          value: 'targeting',
+          checked: true,
+        },
+      },
+      {
+        title: 'Sale of Personal Data',
+        details: {
+          description:
+            'Under the California Consumer Privacy Act, you have the right to opt-out of the sale of your personal information to third parties. These cookies collect information for analytics and to personalize your experience with targeted ads. You may exercise your right to opt out of the sale of personal information by using this toggle switch. If you opt out we will not be able to offer you personalised ads and will not hand over your personal information to any third parties. Additionally, you may contact our legal department for further clarification about your rights as a California consumer by using this Exercise My Rights link.',
+        },
+        toggle: {
+          value: 'sale_of_personal_data',
+          checked: true,
+        },
+      },
+    ],
+    privacyStatementURL: 'legal/privacy/',
+    showOnLoad: false,
+  }
+
+  return (
+    <>
+      <LdCookieConsent
+        ref={cookieConsentRef}
+        settings={cookieConsentSettings}
+      />
+
+      <LdButton onClick={(ev) => cookieConsentRef.current.showDisclaimer()}>
+        Show cookie consent disclaimer
+      </LdButton>
+    </>
+  )
+}
 {% endexample %}
 
 ## Loading scripts conditionally
@@ -529,6 +1005,31 @@ You can align the cookie consent disclaimer to the left or right of the screen. 
 <ld-button onclick="event.target.previousElementSibling.showDisclaimer()">
   Show cookie consent disclaimer
 </ld-button>
+
+<!-- React component -->
+
+const App = () => {
+  const cookieConsentRef = useRef(null)
+  const cookieConsentSettings = {
+    disclaimerAlignement: 'left',
+    mode: 'notice-only',
+    privacyStatementURL: 'legal/privacy/',
+    showOnLoad: false,
+  }
+
+  return (
+    <>
+      <LdCookieConsent
+        ref={cookieConsentRef}
+        settings={cookieConsentSettings}
+      />
+
+      <LdButton onClick={(ev) => cookieConsentRef?.current?.showDisclaimer()}>
+        Show cookie consent disclaimer
+      </LdButton>
+    </>
+  )
+}
 {% endexample %}
 
 ### Align right
@@ -544,6 +1045,31 @@ You can align the cookie consent disclaimer to the left or right of the screen. 
 <ld-button onclick="event.target.previousElementSibling.showDisclaimer()">
   Show cookie consent disclaimer
 </ld-button>
+
+<!-- React component -->
+
+const App = () => {
+  const cookieConsentRef = useRef(null)
+  const cookieConsentSettings = {
+    disclaimerAlignement: 'right',
+    mode: 'notice-only',
+    privacyStatementURL: 'legal/privacy/',
+    showOnLoad: false,
+  }
+
+  return (
+    <>
+      <LdCookieConsent
+        ref={cookieConsentRef}
+        settings={cookieConsentSettings}
+      />
+
+      <LdButton onClick={(ev) => cookieConsentRef?.current?.showDisclaimer()}>
+        Show cookie consent disclaimer
+      </LdButton>
+    </>
+  )
+}
 {% endexample %}
 
 ## Theming
@@ -650,6 +1176,129 @@ You can theme the component using CSS custom properties and customize its conten
 <ld-button onclick="event.target.previousElementSibling.showDisclaimer()">
   Show cookie consent disclaimer
 </ld-button>
+
+<!-- React component -->
+
+const App = () => {
+  const cookieConsentRef = useRef(null)
+  const cookieConsentSettings = {
+    categories: [
+      {
+        title: 'Necessary',
+        details: {
+          description:
+            'These cookies are necessary for the website to operate. Our website cannot function without these cookies, and they can only be disabled by changing your browser preferences.',
+        },
+        toggle: {
+          value: 'necessary',
+          checked: true,
+          disabled: true,
+        },
+      },
+      {
+        title: 'Functional',
+        details: {
+          description:
+            'These cookies enable the provision of advanced functionalities and are used for personalization. The cookies are set in particular in response to your actions and depend on your specific service requests (e.g., pop-up notification choices).',
+        },
+        toggle: {
+          value: 'functional',
+          checked: true,
+        },
+      },
+      {
+        title: 'Targeting',
+        details: {
+          description:
+            'These cookies may be set to learn more about your interests and show you relevant ads on other websites. These cookies work by uniquely identifying your browser and device. By integrating these cookies, we aim to learn more about your interests and your surfing behavior and to be able to place our advertising in a targeted manner.',
+          cookieTable: {
+            headers: ['Name', 'Provider', 'Description', 'Lifespan'],
+            rows: [
+              [
+                '_ga',
+                'Google LLC',
+                'Used to distinguish unique users...',
+                '2 years',
+              ],
+              [
+                '_gat',
+                'Google LLC',
+                'Used to throttle the request rate...',
+                '1 minute',
+              ],
+            ],
+          },
+        },
+        toggle: {
+          value: 'targeting',
+          checked: true,
+        },
+        autoclear: [
+          {
+            name: '_ga',
+            domain: 'example.com',
+            path: '/',
+          },
+          {
+            name: '_gat',
+            domain: 'example.com',
+            path: '/',
+          },
+        ],
+      },
+    ],
+    privacyStatementURL: 'legal/privacy/',
+    showOnLoad: false,
+  }
+
+  return (
+    <>
+      <LdCookieConsent
+        ref={cookieConsentRef}
+        settings={cookieConsentSettings}
+        style={ {
+          /* font */
+          '--ld-cookie-consent-font-body': "'Source Sans Pro', sans-serif'",
+          /* colors */
+          '--ld-cookie-consent-col-wht': '#fff',
+          '--ld-cookie-consent-br-s': '0px',
+          '--ld-cookie-consent-br-m': '0px',
+          '--ld-cookie-consent-br-l': '0px',
+          '--ld-cookie-consent-col-neutral-010': '#fafafd',
+          '--ld-cookie-consent-col-neutral-050': '#8b919b',
+          '--ld-cookie-consent-col-neutral-100': '#b9bdc3',
+          '--ld-cookie-consent-col-neutral-600': '#0b182d',
+          '--ld-cookie-consent-col-neutral-900': '#000',
+          '--ld-cookie-consent-thm-primary': 'hsl(260deg, 40%, 54%)',
+          '--ld-cookie-consent-thm-primary-active': 'hsl(260deg, 40%, 34%)',
+          '--ld-cookie-consent-thm-primary-alpha-low':
+            'hsl(260deg, 40%, 54%, 0.2)',
+          '--ld-cookie-consent-thm-primary-alpha-lowest':
+            'hsl(260deg, 40%, 54%, 0.1)',
+          '--ld-cookie-consent-thm-primary-focus': 'hsl(260deg, 40%, 64%)',
+          '--ld-cookie-consent-thm-primary-highlight':
+            'hsl(260deg, 40%, 54%, 0.1)',
+          '--ld-cookie-consent-thm-primary-hover': 'hsl(260deg, 40%, 44%)',
+          '--ld-cookie-consent-thm-secondary': 'hsl(348deg, 73%, 69%)',
+          '--ld-cookie-consent-thm-secondary-active': 'hsl(348deg, 73%, 49%)',
+          '--ld-cookie-consent-thm-secondary-focus': 'hsl(348deg, 73%, 79%)',
+          '--ld-cookie-consent-thm-secondary-highlight':
+            'hsl(348deg, 73%, 69%, 0.1)',
+          '--ld-cookie-consent-thm-secondary-hover': 'hsl(348deg, 73%, 59%)',
+          /* layout */
+          '--ld-cookie-consent-max-inline-size': '44rem',
+        } }
+      >
+        <svg {...{slot: 'disclaimer-logo'}} width="901" height="870" viewBox="0 0 901 870" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M461 174.8c133.6 0 244.8 97.4 263.5 224.8h176C881.9 176.1 692 0 461 0v174.8Zm221-70c-1.2 0-1.2 0 0 0Z" fill="#5F82FF"/><path d="M461 694.8c133.6 0 244.8-97.4 263.5-224.8h176C881.9 693.5 692 869.6 461 869.6V694.8Zm221 70c-1.2 0-1.2 0 0 0Z" fill="#EA788E"/><path d="M0 434.7c-.4 110 41 216 115.8 296.8A436 436 0 0 0 403 870V697.1A265 265 0 0 1 173 435a264.1 264.1 0 0 1 230-262.1V0a436 436 0 0 0-287 138.3A434.7 434.7 0 0 0 0 434.7Z" fill="#7959B8"/></svg>
+        <svg {...{slot: 'preferences-logo'}} width="901" height="870" viewBox="0 0 901 870" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M461 174.8c133.6 0 244.8 97.4 263.5 224.8h176C881.9 176.1 692 0 461 0v174.8Zm221-70c-1.2 0-1.2 0 0 0Z" fill="#5F82FF"/><path d="M461 694.8c133.6 0 244.8-97.4 263.5-224.8h176C881.9 693.5 692 869.6 461 869.6V694.8Zm221 70c-1.2 0-1.2 0 0 0Z" fill="#EA788E"/><path d="M0 434.7c-.4 110 41 216 115.8 296.8A436 436 0 0 0 403 870V697.1A265 265 0 0 1 173 435a264.1 264.1 0 0 1 230-262.1V0a436 436 0 0 0-287 138.3A434.7 434.7 0 0 0 0 434.7Z" fill="#7959B8"/></svg>
+      </LdCookieConsent>
+
+      <LdButton onClick={(ev) => cookieConsentRef?.current?.showDisclaimer()}>
+        Show cookie consent disclaimer
+      </LdButton>
+    </>
+  )
+}
 {% endexample %}
 
 ## CSS Variables

--- a/src/liquid/components/ld-header/ld-header.css
+++ b/src/liquid/components/ld-header/ld-header.css
@@ -16,9 +16,9 @@
     box-shadow: var(--ld-header-box-shadow);
     color: var(--ld-header-col);
     display: flex;
-    justify-content: center;
     width: 100%;
     transition: transform 100ms ease-in-out;
+    overflow-x: auto;
   }
 
   :host(&.ld-header--sticky),
@@ -38,24 +38,20 @@
   align-items: center;
   box-sizing: border-box;
   display: flex;
+  gap: var(--ld-sp-16);
   height: var(--ld-header-height);
   max-width: var(--ld-header-max-width);
   padding-left: var(--ld-sp-16);
-  width: 100%;
-}
-
-*:not([mode='ghost']):not(.ld-button--ghost):not(.ld-header__logo):not(.ld-header__logo-wrapper) {
-  ::slotted(&),
-  .ld-header__container > & {
-    margin-right: var(--ld-sp-16);
-  }
+  padding-right: var(--ld-sp-16);
+  flex-grow: 1;
+  flex-shrink: 0;
 }
 
 [mode='ghost'],
 .ld-button--ghost {
   ::slotted(&),
   .ld-header__container > & {
-    margin: 0 var(--ld-sp-12) 0 calc(var(--ld-sp-4) * -1);
+    margin: 0 calc(var(--ld-sp-4) * -1);
   }
 }
 
@@ -73,7 +69,6 @@
   color: var(--ld-thm-warning);
   display: block;
   margin: -0.2rem;
-  margin-right: calc(var(--ld-sp-16) - 0.2rem);
 }
 
 .ld-header_site-name {
@@ -81,9 +76,11 @@
 }
 
 .ld-header__grow {
-  flex: 1 0 auto;
+  flex-grow: 1;
+}
 
-  :host & {
-    margin: 0;
+:host(.ld-header) {
+  .ld-header__grow {
+    margin-right: calc(var(--ld-sp-16) * -1);
   }
 }

--- a/src/liquid/components/ld-header/readme.md
+++ b/src/liquid/components/ld-header/readme.md
@@ -30,11 +30,15 @@ You can easily make the header sticky and make it hide when the user is scrollin
 {% example %}
 <ld-header site-name="Liquid Oxygen"></ld-header>
 
+<!-- React component -->
+
+<LdHeader siteName="Liquid Oxygen" />
+
 <!-- CSS component -->
 
 <header class="ld-header">
   <div class="ld-header__container">
-    <svg aria-label="Merck KGaA, Darmstadt, Germany" class="ld-header__logo ld-icon" viewBox="0 0 24 24" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M20.5921 7H19.1a.2882.2882 0 0 0-.1926.076l-2.9895 2.7586c-1.0241.9456-2.4024 1.4765-3.9177 1.4765-1.5796 0-3.0088-.5797-4.0444-1.5964 0 0-2.199-2.0294-2.2179-2.0477A2.5535 2.5535 0 0 0 4.0665 7h-1.785C2.126 7 2 7.1239 2 7.2766v7.7509c0 .765.6301 1.3843 1.4083 1.3843h.9133c.1564 0 .2831-.1249.2831-.2783l.0007-2.7582c0-.7208.5987-1.3155 1.3204-1.3155 1.3434 0 2.3067 1.1309 3.177 1.8863 1.0661.9254 1.8871 1.8169 2.8974 1.8169 1.0092 0 1.8306-.8915 2.8966-1.8169.8707-.7554 1.834-1.8863 3.1767-1.8863.718 0 1.3137.5887 1.3208 1.3039v1.6638c0 .765.6305 1.3829 1.4089 1.3829h.6079c.1588 0 .3061.0014.3061.0014.1561 0 .2828-.1249.2828-.2779V8.3842C22 7.6196 21.3692 7 20.5921 7Z" fill="currentcolor"/></svg>
+    <svg aria-label="Merck KGaA, Darmstadt, Germany" class="ld-header__logo ld-icon" viewBox="0 0 24 24" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M20.5921 7.5H19.1a.2955.2955 0 0 0-.1926.0727l-2.9895 2.6378c-1.0241.9043-2.4024 1.412-3.9177 1.412-1.5796 0-3.0088-.5544-4.0444-1.5266 0 0-2.199-1.9406-2.2179-1.958-.422-.369-1.0028-.624-1.6714-.6379h-1.785C2.126 7.5 2 7.6184 2 7.7645v7.4118c0 .7316.6301 1.3237 1.4083 1.3237h.9133c.1564 0 .2831-.1194.2831-.2661l.0007-2.6375c0-.6893.5987-1.2579 1.3204-1.2579 1.3434 0 2.3067 1.0814 3.177 1.8037 1.0661.8849 1.8871 1.7374 2.8974 1.7374 1.0092 0 1.8306-.8525 2.8966-1.7374.8707-.7223 1.834-1.8037 3.1767-1.8037.718 0 1.3137.5629 1.3208 1.2468v1.591c0 .7316.6305 1.3224 1.4089 1.3224h.6079c.1588 0 .3061.0013.3061.0013.1561 0 .2828-.1194.2828-.2658V8.8237C22 8.0925 21.3692 7.5 20.5921 7.5Z" fill="currentcolor"/></svg>
     <div class="ld-header_site-name ld-typo--h5">Liquid Oxygen</div>
   </div>
 </header>
@@ -45,12 +49,16 @@ You can easily make the header sticky and make it hide when the user is scrollin
 {% example %}
 <ld-header site-name="Liquid Oxygen" logo-title="Home" logo-url="#"></ld-header>
 
+<!-- React component -->
+
+<LdHeader siteName="Liquid Oxygen" logoTitle="Home" logoUrl="#" />
+
 <!-- CSS component -->
 
 <header class="ld-header">
   <div class="ld-header__container">
     <a aria-label="Home" class="ld-header__logo-wrapper" href="#">
-      <svg class="ld-header__logo ld-icon" viewBox="0 0 24 24" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M20.5921 7H19.1a.2882.2882 0 0 0-.1926.076l-2.9895 2.7586c-1.0241.9456-2.4024 1.4765-3.9177 1.4765-1.5796 0-3.0088-.5797-4.0444-1.5964 0 0-2.199-2.0294-2.2179-2.0477A2.5535 2.5535 0 0 0 4.0665 7h-1.785C2.126 7 2 7.1239 2 7.2766v7.7509c0 .765.6301 1.3843 1.4083 1.3843h.9133c.1564 0 .2831-.1249.2831-.2783l.0007-2.7582c0-.7208.5987-1.3155 1.3204-1.3155 1.3434 0 2.3067 1.1309 3.177 1.8863 1.0661.9254 1.8871 1.8169 2.8974 1.8169 1.0092 0 1.8306-.8915 2.8966-1.8169.8707-.7554 1.834-1.8863 3.1767-1.8863.718 0 1.3137.5887 1.3208 1.3039v1.6638c0 .765.6305 1.3829 1.4089 1.3829h.6079c.1588 0 .3061.0014.3061.0014.1561 0 .2828-.1249.2828-.2779V8.3842C22 7.6196 21.3692 7 20.5921 7Z" fill="currentcolor"/></svg>
+      <svg class="ld-header__logo ld-icon" viewBox="0 0 24 24" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M20.5921 7.5H19.1a.2955.2955 0 0 0-.1926.0727l-2.9895 2.6378c-1.0241.9043-2.4024 1.412-3.9177 1.412-1.5796 0-3.0088-.5544-4.0444-1.5266 0 0-2.199-1.9406-2.2179-1.958-.422-.369-1.0028-.624-1.6714-.6379h-1.785C2.126 7.5 2 7.6184 2 7.7645v7.4118c0 .7316.6301 1.3237 1.4083 1.3237h.9133c.1564 0 .2831-.1194.2831-.2661l.0007-2.6375c0-.6893.5987-1.2579 1.3204-1.2579 1.3434 0 2.3067 1.0814 3.177 1.8037 1.0661.8849 1.8871 1.7374 2.8974 1.7374 1.0092 0 1.8306-.8525 2.8966-1.7374.8707-.7223 1.834-1.8037 3.1767-1.8037.718 0 1.3137.5629 1.3208 1.2468v1.591c0 .7316.6305 1.3224 1.4089 1.3224h.6079c.1588 0 .3061.0013.3061.0013.1561 0 .2828-.1194.2828-.2658V8.8237C22 8.0925 21.3692 7.5 20.5921 7.5Z" fill="currentcolor"/></svg>
     </a>
     <div class="ld-header_site-name ld-typo--h5">Liquid Oxygen</div>
   </div>
@@ -63,6 +71,12 @@ You can easily make the header sticky and make it hide when the user is scrollin
 <ld-header logo-title="Rocket Inc." site-name="Rocket Science">
   <ld-icon name="rocket" size="lg" slot="logo"></ld-icon>
 </ld-header>
+
+<!-- React component -->
+
+<LdHeader siteName="Liquid Oxygen" logoTitle="Home" logoUrl="#">
+  <LdIcon name="rocket" size="lg" slot="logo" />
+</LdHeader>
 
 <!-- CSS component -->
 
@@ -77,71 +91,114 @@ You can easily make the header sticky and make it hide when the user is scrollin
 ### With buttons
 
 {% example %}
-<ld-header>
+<ld-header class="header-container">
   <ld-typo tag="div" variant="h5">
     Liquid<span class="hide-on-sm"> Oxygen</span>
   </ld-typo>
-  <ld-button id="register" slot="end" type="button">
+  <ld-button slot="end" type="button">
     <ld-icon name="pen" size="sm"></ld-icon>
     Register
   </ld-button>
-  <ld-button id="login-sm" mode="ghost" slot="end" title="Login" type="button">
+  <ld-button
+    class="hide-on-lg"
+    mode="ghost"
+    slot="end"
+    title="Login"
+    type="button"
+  >
     <ld-icon aria-label="Login" name="user" size="lg"></ld-icon>
   </ld-button>
-  <ld-button id="login-lg" mode="secondary" slot="end" type="button">
+  <ld-button
+    class="hide-on-sm"
+    mode="secondary"
+    slot="end"
+    type="button"
+  >
     <ld-icon name="user" size="sm"></ld-icon>
     Login
   </ld-button>
 </ld-header>
 
 <style>
-  .hide-on-sm {
-    display: none;
+  .header-container {
+    container-type: inline-size;
+    container-name: header;
   }
-
-  #register ld-icon {
-    display: none;
-  }
-
-  #login-lg {
-    display: none;
-  }
-
-  @media (min-width: 52rem) {
-    .hide-on-sm {
-      display: inline;
-    }
-
-    #register ld-icon {
-      display: block;
-    }
-
-    #login-sm {
+  @container header (min-width: 32rem) {
+    .hide-on-lg {
       display: none;
     }
-
-    #login-lg {
-      display: block;
+  }
+  @container header (max-width: calc(32rem - 1px)) {
+    .hide-on-sm {
+      display: none;
     }
   }
 </style>
 
+<!-- React component -->
+
+<LdHeader className="header-container">
+  <LdTypo tag="div" variant="h5">
+    Liquid<span className="hide-on-sm"> Oxygen</span>
+  </LdTypo>
+  <LdButton slot="end" type="button">
+    <LdIcon name="pen" size="sm"></LdIcon>
+    Register
+  </LdButton>
+  <LdButton
+    className="hide-on-lg"
+    mode="ghost"
+    slot="end"
+    title="Login"
+    type="button"
+  >
+    <LdIcon aria-label="Login" name="user" size="lg"></LdIcon>
+  </LdButton>
+  <LdButton
+    className="hide-on-sm"
+    mode="secondary"
+    slot="end"
+    type="button"
+  >
+    <LdIcon name="user" size="sm"></LdIcon>
+    Login
+  </LdButton>
+</LdHeader>
+
+<style>{`
+  .header-container {
+    container-type: inline-size;
+    container-name: header;
+  }
+  @container header (min-width: 32rem) {
+    .hide-on-lg {
+      display: none;
+    }
+  }
+  @container header (max-width: calc(32rem - 1px)) {
+    .hide-on-sm {
+      display: none;
+    }
+  }
+`}</style>
+
 <!-- CSS component -->
 
-<header class="ld-header">
+<header class="ld-header header-container">
   <div class="ld-header__container">
-    <svg aria-label="Merck KGaA, Darmstadt, Germany" class="ld-header__logo ld-icon" viewBox="0 0 24 24" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M20.5921 7H19.1a.2882.2882 0 0 0-.1926.076l-2.9895 2.7586c-1.0241.9456-2.4024 1.4765-3.9177 1.4765-1.5796 0-3.0088-.5797-4.0444-1.5964 0 0-2.199-2.0294-2.2179-2.0477A2.5535 2.5535 0 0 0 4.0665 7h-1.785C2.126 7 2 7.1239 2 7.2766v7.7509c0 .765.6301 1.3843 1.4083 1.3843h.9133c.1564 0 .2831-.1249.2831-.2783l.0007-2.7582c0-.7208.5987-1.3155 1.3204-1.3155 1.3434 0 2.3067 1.1309 3.177 1.8863 1.0661.9254 1.8871 1.8169 2.8974 1.8169 1.0092 0 1.8306-.8915 2.8966-1.8169.8707-.7554 1.834-1.8863 3.1767-1.8863.718 0 1.3137.5887 1.3208 1.3039v1.6638c0 .765.6305 1.3829 1.4089 1.3829h.6079c.1588 0 .3061.0014.3061.0014.1561 0 .2828-.1249.2828-.2779V8.3842C22 7.6196 21.3692 7 20.5921 7Z" fill="currentcolor"/></svg>
+    <svg aria-label="Merck KGaA, Darmstadt, Germany" class="ld-header__logo ld-icon" viewBox="0 0 24 24" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M20.5921 7.5H19.1a.2955.2955 0 0 0-.1926.0727l-2.9895 2.6378c-1.0241.9043-2.4024 1.412-3.9177 1.412-1.5796 0-3.0088-.5544-4.0444-1.5266 0 0-2.199-1.9406-2.2179-1.958-.422-.369-1.0028-.624-1.6714-.6379h-1.785C2.126 7.5 2 7.6184 2 7.7645v7.4118c0 .7316.6301 1.3237 1.4083 1.3237h.9133c.1564 0 .2831-.1194.2831-.2661l.0007-2.6375c0-.6893.5987-1.2579 1.3204-1.2579 1.3434 0 2.3067 1.0814 3.177 1.8037 1.0661.8849 1.8871 1.7374 2.8974 1.7374 1.0092 0 1.8306-.8525 2.8966-1.7374.8707-.7223 1.834-1.8037 3.1767-1.8037.718 0 1.3137.5629 1.3208 1.2468v1.591c0 .7316.6305 1.3224 1.4089 1.3224h.6079c.1588 0 .3061.0013.3061.0013.1561 0 .2828-.1194.2828-.2658V8.8237C22 8.0925 21.3692 7.5 20.5921 7.5Z" fill="currentcolor"/></svg>
     <div class="ld-header_site-name ld-header__grow ld-typo--h5">
       Liquid<span class="hide-on-sm"> Oxygen</span>
     </div>
-    <button class="ld-button ld-button--brand-color ld-button--sm" id="register" type="button">
+    <button class="ld-button ld-button--brand-color ld-button--sm" type="button">
       <svg class="ld-icon ld-icon--sm" role="none" viewBox="0 0 24 24" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M5.6192 15.1453a3.806 3.806 0 0 1 1.5674.3358c.4564.2056 1.0133.1824 1.3673-.1716L19.4353 4.4282c.4358-.4358.3698-1.1738-.227-1.3275A3.1966 3.1966 0 0 0 18.4098 3c-.5539 0-1.074.2154-1.4654.6068L5.5567 14.9944c-.0557.0557-.0163.1509.0625.1509zm.3803 1.3126H5.154a.5.5 0 0 0-.485.3787l-.639 2.5557c-.0894.3571.0277.6916.2536.9168.2252.2259.5597.3428.916.2536l2.5565-.639a.5.5 0 0 0 .3787-.4851v-.8455c0-1.1772-.958-2.1352-2.1354-2.1352zM21.5923 6.1824c0 .5542-.2154 1.0744-.6068 1.4658L9.5979 19.036c-.0557.0556-.1508.0162-.1508-.0625a3.806 3.806 0 0 0-.3358-1.5673c-.2057-.4565-.1826-1.0135.1715-1.3675L20.1635 5.1582c.4362-.4362 1.1748-.3697 1.3285.2276a3.194 3.194 0 0 1 .1003.7966z" fill="currentcolor"/></svg>
       Register
     </button>
-    <button class="ld-button ld-button--brand-color ld-button--ghost ld-button--sm ld-button--icon-only" id="login-sm" title="Login" type="button">
+    <button class="hide-on-lg ld-button ld-button--brand-color ld-button--ghost ld-button--sm ld-button--icon-only" title="Login" type="button">
       <svg aria-label="Login" class="ld-icon ld-icon--lg" viewBox="0 0 24 24" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M11.9315 2C9.4767 2 7.455 3.6606 7.455 6.8376c0 2.0938.9386 4.1877 2.2383 5.4873.4332 1.1552-.4332 1.8051-.5776 1.8773-2.5993.9386-5.6318 2.6714-5.6318 4.3321v.6498c0 2.2383 4.4043 2.7437 8.4476 2.8159 4.1156-.0722 8.5199-.5776 8.5199-2.8159v-.6498c0-1.6607-3.0325-3.3935-5.6318-4.3321-.2166-.0722-1.083-.7221-.5776-1.8773 1.2996-1.2996 2.2383-3.3935 2.2383-5.4873C16.4803 3.6606 14.3864 2 11.9315 2z" fill="currentcolor"/></svg>
     </button>
-    <button class="ld-button ld-button--brand-color ld-button--secondary ld-button--sm" id="login-lg" type="button">
+    <button class="hide-on-sm ld-button ld-button--brand-color ld-button--secondary ld-button--sm" id="login-lg" type="button">
       <svg class="ld-icon ld-icon--sm" role="none" viewBox="0 0 24 24" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M11.9315 2C9.4767 2 7.455 3.6606 7.455 6.8376c0 2.0938.9386 4.1877 2.2383 5.4873.4332 1.1552-.4332 1.8051-.5776 1.8773-2.5993.9386-5.6318 2.6714-5.6318 4.3321v.6498c0 2.2383 4.4043 2.7437 8.4476 2.8159 4.1156-.0722 8.5199-.5776 8.5199-2.8159v-.6498c0-1.6607-3.0325-3.3935-5.6318-4.3321-.2166-.0722-1.083-.7221-.5776-1.8773 1.2996-1.2996 2.2383-3.3935 2.2383-5.4873C16.4803 3.6606 14.3864 2 11.9315 2z" fill="currentcolor"/></svg>
       Login
     </button>
@@ -149,33 +206,18 @@ You can easily make the header sticky and make it hide when the user is scrollin
 </header>
 
 <style>
-  .hide-on-sm {
-    display: none;
+  .header-container {
+    container-type: inline-size;
+    container-name: header;
   }
-
-  #register .ld-icon {
-    display: none;
-  }
-
-  #login-lg {
-    display: none;
-  }
-
-  @media (min-width: 52rem) {
-    .hide-on-sm {
-      display: inline;
-    }
-
-    #register .ld-icon {
-      display: block;
-    }
-
-    #login-sm {
+  @container header (min-width: 32rem) {
+    .hide-on-lg {
       display: none;
     }
-
-    #login-lg {
-      display: grid;
+  }
+  @container header (max-width: calc(32rem - 1px)) {
+    .hide-on-sm {
+      display: none;
     }
   }
 </style>
@@ -190,6 +232,14 @@ You can easily make the header sticky and make it hide when the user is scrollin
   </ld-button>
 </ld-header>
 
+<!-- React component -->
+
+<LdHeader siteName="Liquid Oxygen">
+  <LdButton mode="ghost" slot="start" title="Open menu" type="button">
+    <LdIcon aria-label="Open menu" name="burger-menu" size="lg" />
+  </LdButton>
+</LdHeader>
+
 <!-- CSS component -->
 
 <header class="ld-header">
@@ -197,7 +247,7 @@ You can easily make the header sticky and make it hide when the user is scrollin
     <button class="ld-button ld-button--brand-color ld-button--ghost ld-button--sm ld-button--icon-only" title="Open menu" type="button">
       <svg aria-label="Open menu" class="ld-icon ld-icon--lg" viewBox="0 0 24 24" fill="none"><rect x="5" y="6" width="14" height="2" rx="1" fill="currentcolor"/><rect x="5" y="11" width="14" height="2" rx="1" fill="currentcolor"/><rect x="5" y="16" width="14" height="2" rx="1" fill="currentcolor"/></svg>
     </button>
-    <svg aria-label="Merck KGaA, Darmstadt, Germany" class="ld-header__logo ld-icon" viewBox="0 0 24 24" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M20.5921 7H19.1a.2882.2882 0 0 0-.1926.076l-2.9895 2.7586c-1.0241.9456-2.4024 1.4765-3.9177 1.4765-1.5796 0-3.0088-.5797-4.0444-1.5964 0 0-2.199-2.0294-2.2179-2.0477A2.5535 2.5535 0 0 0 4.0665 7h-1.785C2.126 7 2 7.1239 2 7.2766v7.7509c0 .765.6301 1.3843 1.4083 1.3843h.9133c.1564 0 .2831-.1249.2831-.2783l.0007-2.7582c0-.7208.5987-1.3155 1.3204-1.3155 1.3434 0 2.3067 1.1309 3.177 1.8863 1.0661.9254 1.8871 1.8169 2.8974 1.8169 1.0092 0 1.8306-.8915 2.8966-1.8169.8707-.7554 1.834-1.8863 3.1767-1.8863.718 0 1.3137.5887 1.3208 1.3039v1.6638c0 .765.6305 1.3829 1.4089 1.3829h.6079c.1588 0 .3061.0014.3061.0014.1561 0 .2828-.1249.2828-.2779V8.3842C22 7.6196 21.3692 7 20.5921 7Z" fill="currentcolor"/></svg>
+    <svg aria-label="Merck KGaA, Darmstadt, Germany" class="ld-header__logo ld-icon" viewBox="0 0 24 24" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M20.5921 7.5H19.1a.2955.2955 0 0 0-.1926.0727l-2.9895 2.6378c-1.0241.9043-2.4024 1.412-3.9177 1.412-1.5796 0-3.0088-.5544-4.0444-1.5266 0 0-2.199-1.9406-2.2179-1.958-.422-.369-1.0028-.624-1.6714-.6379h-1.785C2.126 7.5 2 7.6184 2 7.7645v7.4118c0 .7316.6301 1.3237 1.4083 1.3237h.9133c.1564 0 .2831-.1194.2831-.2661l.0007-2.6375c0-.6893.5987-1.2579 1.3204-1.2579 1.3434 0 2.3067 1.0814 3.177 1.8037 1.0661.8849 1.8871 1.7374 2.8974 1.7374 1.0092 0 1.8306-.8525 2.8966-1.7374.8707-.7223 1.834-1.8037 3.1767-1.8037.718 0 1.3137.5629 1.3208 1.2468v1.591c0 .7316.6305 1.3224 1.4089 1.3224h.6079c.1588 0 .3061.0013.3061.0013.1561 0 .2828-.1194.2828-.2658V8.8237C22 8.0925 21.3692 7.5 20.5921 7.5Z" fill="currentcolor"/></svg>
     <div class="ld-header_site-name ld-typo--h5">Liquid Oxygen</div>
   </div>
 </header>
@@ -210,19 +260,23 @@ You can add the `sticky` property to the `ld-header` web component, to make the 
 {% example %}
 <ld-header site-name="Liquid Oxygen" sticky></ld-header>
 
+<!-- React component -->
+
+<LdHeader siteName="Liquid Oxygen" sticky />
+
 <!-- CSS component -->
 
 <!-- Add the class `ld-header--hidden` to hide the sticky header. -->
 <header class="ld-header ld-header--sticky">
   <div class="ld-header__container">
-    <svg aria-label="Merck KGaA, Darmstadt, Germany" class="ld-header__logo ld-icon" viewBox="0 0 24 24" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M20.5921 7H19.1a.2882.2882 0 0 0-.1926.076l-2.9895 2.7586c-1.0241.9456-2.4024 1.4765-3.9177 1.4765-1.5796 0-3.0088-.5797-4.0444-1.5964 0 0-2.199-2.0294-2.2179-2.0477A2.5535 2.5535 0 0 0 4.0665 7h-1.785C2.126 7 2 7.1239 2 7.2766v7.7509c0 .765.6301 1.3843 1.4083 1.3843h.9133c.1564 0 .2831-.1249.2831-.2783l.0007-2.7582c0-.7208.5987-1.3155 1.3204-1.3155 1.3434 0 2.3067 1.1309 3.177 1.8863 1.0661.9254 1.8871 1.8169 2.8974 1.8169 1.0092 0 1.8306-.8915 2.8966-1.8169.8707-.7554 1.834-1.8863 3.1767-1.8863.718 0 1.3137.5887 1.3208 1.3039v1.6638c0 .765.6305 1.3829 1.4089 1.3829h.6079c.1588 0 .3061.0014.3061.0014.1561 0 .2828-.1249.2828-.2779V8.3842C22 7.6196 21.3692 7 20.5921 7Z" fill="currentcolor"/></svg>
+    <svg aria-label="Merck KGaA, Darmstadt, Germany" class="ld-header__logo ld-icon" viewBox="0 0 24 24" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M20.5921 7.5H19.1a.2955.2955 0 0 0-.1926.0727l-2.9895 2.6378c-1.0241.9043-2.4024 1.412-3.9177 1.412-1.5796 0-3.0088-.5544-4.0444-1.5266 0 0-2.199-1.9406-2.2179-1.958-.422-.369-1.0028-.624-1.6714-.6379h-1.785C2.126 7.5 2 7.6184 2 7.7645v7.4118c0 .7316.6301 1.3237 1.4083 1.3237h.9133c.1564 0 .2831-.1194.2831-.2661l.0007-2.6375c0-.6893.5987-1.2579 1.3204-1.2579 1.3434 0 2.3067 1.0814 3.177 1.8037 1.0661.8849 1.8871 1.7374 2.8974 1.7374 1.0092 0 1.8306-.8525 2.8966-1.7374.8707-.7223 1.834-1.8037 3.1767-1.8037.718 0 1.3137.5629 1.3208 1.2468v1.591c0 .7316.6305 1.3224 1.4089 1.3224h.6079c.1588 0 .3061.0013.3061.0013.1561 0 .2828-.1194.2828-.2658V8.8237C22 8.0925 21.3692 7.5 20.5921 7.5Z" fill="currentcolor"/></svg>
     <div class="ld-header_site-name ld-typo--h5">Liquid Oxygen</div>
   </div>
 </header>
 {% endexample %}
 
 <ld-notice mode="warning">
-  As the CSS property <code>position: sticky;</code> is used here to achieve this behavior, the <code>ld-header</code> "sticks" to its nearest ancestor that has a "scrolling mechanism" (created when overflow is hidden, scroll, auto, or overlay), even if that ancestor isn't the nearest actually scrolling ancestor. So you need to take care of where you place the <code>ld-header</code> in the DOM.
+  As the CSS property <code>position: sticky;</code> is used here to achieve this behavior, the <code>ld-header</code> "sticks" to its nearest ancestor that has a "scrolling mechanism" (created when <code>overflow</code> is set to <code>hidden</code>, <code>scroll</code>, <code>auto</code> or <code>overlay</code>), even if that ancestor isn't the nearest actually scrolling ancestor. So you need to be aware of where you place the <code>ld-header</code> in the DOM.
 </ld-notice>
 
 ### Hide on scroll

--- a/src/liquid/components/ld-slider/ld-slider.tsx
+++ b/src/liquid/components/ld-slider/ld-slider.tsx
@@ -94,7 +94,9 @@ export class LdSlider implements InnerFocusable {
   /** Adds custom stop points to the slider (instead of steps) */
   @Prop() unit?: string
   /** Specifies the default value */
-  @Prop({ mutable: true, reflect: true }) value?: string = String(this.min)
+  @Prop({ mutable: true, reflect: true }) value?: string | number = String(
+    this.min
+  )
   /** Width of the slider */
   @Prop() width? = '100%'
 
@@ -304,7 +306,7 @@ export class LdSlider implements InnerFocusable {
   }
 
   updateValues = (autoCorrectValues = false) => {
-    const values = this.value
+    const values = String(this.value)
       .split(',')
       .map((value) => Number.parseInt(value, 10))
 

--- a/src/liquid/components/ld-slider/readme.md
+++ b/src/liquid/components/ld-slider/readme.md
@@ -241,31 +241,31 @@ By default, the `ld-slider` applies a width of `100%`. You can set it to any fix
 
 ## Properties
 
-| Property          | Attribute           | Description                                                  | Type               | Default            |
-| ----------------- | ------------------- | ------------------------------------------------------------ | ------------------ | ------------------ |
-| `ariaDisabled`    | `aria-disabled`     | Alternative disabled state that keeps element focusable      | `string`           | `undefined`        |
-| `disabled`        | `disabled`          | Disabled state of the slider                                 | `boolean`          | `false`            |
-| `hideStopLabels`  | `hide-stop-labels`  | Prevents rendering of the stop labels below the slider       | `boolean`          | `false`            |
-| `hideValueLabels` | `hide-value-labels` | Prevents rendering of the value labels below the slider      | `boolean`          | `false`            |
-| `hideValues`      | `hide-values`       | Makes the current values only visible on interaction         | `boolean`          | `false`            |
-| `indicators`      | `indicators`        | Specifies the legal number intervals                         | `boolean`          | `false`            |
-| `key`             | `key`               | for tracking the node's identity when working with lists     | `string \| number` | `undefined`        |
-| `labelFrom`       | `label-from`        | "From" value label (when exactly 2 values are given)         | `string`           | `'From'`           |
-| `labelTo`         | `label-to`          | "To" value label (when exactly 2 values are given)           | `string`           | `'To'`             |
-| `labelValue`      | `label-value`       | "Value" label (when exactly 2 values are given)              | `string`           | `'Value'`          |
-| `ldTabindex`      | `ld-tabindex`       | Tab index of the input(s).                                   | `number`           | `undefined`        |
-| `max`             | `max`               | Specifies the maximum value allowed                          | `number`           | `100`              |
-| `min`             | `min`               | Specifies the minimum value allowed                          | `number`           | `0`                |
-| `negative`        | `negative`          | Swap which areas are being marked as selected and deselected | `boolean`          | `false`            |
-| `ref`             | `ref`               | reference to component                                       | `any`              | `undefined`        |
-| `size`            | `size`              | Size of the thumb(s).                                        | `"lg" \| "sm"`     | `undefined`        |
-| `snapOffset`      | `snap-offset`       | Offset inside which a thumb snaps to a stop point            | `number`           | `undefined`        |
-| `step`            | `step`              | Specifies the legal number intervals                         | `number`           | `undefined`        |
-| `stops`           | `stops`             | Adds custom stop points to the slider (instead of steps)     | `string`           | `undefined`        |
-| `swappable`       | `swappable`         | Allows swapping of thumbs                                    | `boolean`          | `false`            |
-| `unit`            | `unit`              | Adds custom stop points to the slider (instead of steps)     | `string`           | `undefined`        |
-| `value`           | `value`             | Specifies the default value                                  | `string`           | `String(this.min)` |
-| `width`           | `width`             | Width of the slider                                          | `string`           | `'100%'`           |
+| Property          | Attribute           | Description                                                  | Type               | Default                    |
+| ----------------- | ------------------- | ------------------------------------------------------------ | ------------------ | -------------------------- |
+| `ariaDisabled`    | `aria-disabled`     | Alternative disabled state that keeps element focusable      | `string`           | `undefined`                |
+| `disabled`        | `disabled`          | Disabled state of the slider                                 | `boolean`          | `false`                    |
+| `hideStopLabels`  | `hide-stop-labels`  | Prevents rendering of the stop labels below the slider       | `boolean`          | `false`                    |
+| `hideValueLabels` | `hide-value-labels` | Prevents rendering of the value labels below the slider      | `boolean`          | `false`                    |
+| `hideValues`      | `hide-values`       | Makes the current values only visible on interaction         | `boolean`          | `false`                    |
+| `indicators`      | `indicators`        | Specifies the legal number intervals                         | `boolean`          | `false`                    |
+| `key`             | `key`               | for tracking the node's identity when working with lists     | `string \| number` | `undefined`                |
+| `labelFrom`       | `label-from`        | "From" value label (when exactly 2 values are given)         | `string`           | `'From'`                   |
+| `labelTo`         | `label-to`          | "To" value label (when exactly 2 values are given)           | `string`           | `'To'`                     |
+| `labelValue`      | `label-value`       | "Value" label (when exactly 2 values are given)              | `string`           | `'Value'`                  |
+| `ldTabindex`      | `ld-tabindex`       | Tab index of the input(s).                                   | `number`           | `undefined`                |
+| `max`             | `max`               | Specifies the maximum value allowed                          | `number`           | `100`                      |
+| `min`             | `min`               | Specifies the minimum value allowed                          | `number`           | `0`                        |
+| `negative`        | `negative`          | Swap which areas are being marked as selected and deselected | `boolean`          | `false`                    |
+| `ref`             | `ref`               | reference to component                                       | `any`              | `undefined`                |
+| `size`            | `size`              | Size of the thumb(s).                                        | `"lg" \| "sm"`     | `undefined`                |
+| `snapOffset`      | `snap-offset`       | Offset inside which a thumb snaps to a stop point            | `number`           | `undefined`                |
+| `step`            | `step`              | Specifies the legal number intervals                         | `number`           | `undefined`                |
+| `stops`           | `stops`             | Adds custom stop points to the slider (instead of steps)     | `string`           | `undefined`                |
+| `swappable`       | `swappable`         | Allows swapping of thumbs                                    | `boolean`          | `false`                    |
+| `unit`            | `unit`              | Adds custom stop points to the slider (instead of steps)     | `string`           | `undefined`                |
+| `value`           | `value`             | Specifies the default value                                  | `number \| string` | `String(     this.min   )` |
+| `width`           | `width`             | Width of the slider                                          | `string`           | `'100%'`                   |
 
 
 ## Events


### PR DESCRIPTION
# Description

This PR ensures that the `ld-header` component works consistently as a CSS and as a Web Component and stays flexible in each view port: it now has an `overflow-x` set to `auto` on its inner container. Here are some screenshots of issues I encountered when testing the component:

<img width="389" alt="Screenshot 2023-01-24 at 16 13 10" src="https://user-images.githubusercontent.com/527049/214332621-1e12dd55-1433-461e-8f04-4bbe8efb21e1.png">

<img width="379" alt="Screenshot 2023-01-24 at 16 13 27" src="https://user-images.githubusercontent.com/527049/214332647-2f9533b3-bc67-4051-8199-0267a698de1a.png">

These issues should be fixed now. Please check the component examples in the [preview environment](https://liquid-git-fix-ld-header-uxsd.vercel.app/components/ld-header/).

This PR also includes React examples for the `ld-header` component.

## Type of change

Please delete options that are not relevant.

- [x] Bugfix
- [x] Documentation content changes

## Is it a breaking change?

- [x] No

# How Has This Been Tested?

- [x] e2e tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes
