### PR TITLE
docs: add even more react examples

### DIFF
--- a/src/liquid/components/ld-icon/readme.md
+++ b/src/liquid/components/ld-icon/readme.md
@@ -20,6 +20,10 @@ An icon provides a visual hint for content or interactions. Combine it with text
 {% example %}
 <ld-icon name="placeholder"></ld-icon>
 
+<!-- React component -->
+
+<LdIcon name="placeholder" />
+
 <!-- CSS component -->
 
 <span class="ld-icon" role="presentation">
@@ -38,6 +42,14 @@ An icon provides a visual hint for content or interactions. Combine it with text
 <ld-icon name="placeholder"></ld-icon>
 
 <ld-icon name="placeholder" size="lg"></ld-icon>
+
+<!-- React component -->
+
+<LdIcon name="placeholder" size="sm" />
+
+<LdIcon name="placeholder" />
+
+<LdIcon name="placeholder" size="lg" />
 
 <!-- CSS component -->
 
@@ -74,6 +86,14 @@ Liquid's icons use the [`currentColor`](https://developer.mozilla.org/en-US/docs
   <ld-icon name="placeholder"></ld-icon>
 </span>
 
+<!-- React component -->
+
+<LdIcon name="placeholder" style={ { color: 'var(--ld-col-vc)' } } />
+
+<span style={ { color: 'var(--ld-col-vg)' } }>
+  <LdIcon name="placeholder" />
+</span>
+
 <!-- CSS component -->
 
 <span class="ld-icon" role="presentation" style="color: var(--ld-col-vc)">
@@ -99,6 +119,12 @@ Liquid's icons use the [`currentColor`](https://developer.mozilla.org/en-US/docs
 <ld-icon>
   <svg viewBox="0 0 24 24"><path fill="currentColor" d="M16.48 20.335a3.622 3.622 0 01-7.244 0h7.244zm2.748-6.48l2.024 1.94c.297.284.464.677.464 1.088v.801c0 .833-.675 1.51-1.508 1.51h-14.7A1.51 1.51 0 014 17.683v-.76c0-.434.188-.848.516-1.134l1.922-1.683c.328-.286.516-.7.516-1.135V8.858a5.878 5.878 0 013.498-5.37c.556-.249.931-.78.931-1.39v-.622a1.476 1.476 0 112.952 0v.622c0 .61.375 1.141.931 1.39 2.06.918 3.5 2.97 3.5 5.37v3.908c0 .411.167.805.463 1.09z" fill-rule="evenodd"/></svg>
 </ld-icon>
+
+<!-- React component -->
+
+<LdIcon>
+  <svg viewBox="0 0 24 24"><path fill="currentColor" d="M16.48 20.335a3.622 3.622 0 01-7.244 0h7.244zm2.748-6.48l2.024 1.94c.297.284.464.677.464 1.088v.801c0 .833-.675 1.51-1.508 1.51h-14.7A1.51 1.51 0 014 17.683v-.76c0-.434.188-.848.516-1.134l1.922-1.683c.328-.286.516-.7.516-1.135V8.858a5.878 5.878 0 013.498-5.37c.556-.249.931-.78.931-1.39v-.622a1.476 1.476 0 112.952 0v.622c0 .61.375 1.141.931 1.39 2.06.918 3.5 2.97 3.5 5.37v3.908c0 .411.167.805.463 1.09z" fillRule="evenodd"/></svg>
+</LdIcon>
 
 <!-- CSS component -->
 

--- a/src/liquid/components/ld-input-message/readme.md
+++ b/src/liquid/components/ld-input-message/readme.md
@@ -29,6 +29,10 @@ This component is meant to be used in conjunction with the [`ld-input`](componen
 {% example '{ "background": "light" }' %}
 <ld-input-message>This field is required.</ld-input-message>
 
+<!-- React component -->
+
+<LdInputMessage>This field is required.</LdInputMessage>
+
 <!-- CSS component -->
 
 <span class="ld-input-message ld-input-message--error">
@@ -47,6 +51,10 @@ This component is meant to be used in conjunction with the [`ld-input`](componen
 {% example '{ "background": "light" }' %}
 <ld-input-message mode="info">This field will destroy itself on form submission.</ld-input-message>
 
+<!-- React component -->
+
+<LdInputMessage mode="info">This field will destroy itself on form submission.</LdInputMessage>
+
 <!-- CSS component -->
 
 <span class="ld-input-message ld-input-message--info">
@@ -64,6 +72,10 @@ This component is meant to be used in conjunction with the [`ld-input`](componen
 
 {% example '{ "background": "light" }' %}
 <ld-input-message mode="valid">That's correct!</ld-input-message>
+
+<!-- React component -->
+
+<LdInputMessage mode="valid">That's correct!</LdInputMessage>
 
 <!-- CSS component -->
 

--- a/src/liquid/components/ld-input/readme.md
+++ b/src/liquid/components/ld-input/readme.md
@@ -32,6 +32,12 @@ By default, the `ld-input` component is of [type `text`](https://developer.mozil
 
 <ld-input value="Value"></ld-input>
 
+<!-- React component -->
+
+<LdInput placeholder="Placeholder" />
+
+<LdInput value="Value" />
+
 <!-- CSS component -->
 
 <div class="ld-input">
@@ -50,6 +56,12 @@ By default, the `ld-input` component is of [type `text`](https://developer.mozil
 
 <ld-input disabled value="Value"></ld-input>
 
+<!-- React component -->
+
+<LdInput placeholder="Placeholder" disabled />
+
+<LdInput disabled value="Value" />
+
 <!-- CSS component -->
 
 <div class="ld-input ld-input--disabled">
@@ -67,6 +79,12 @@ By default, the `ld-input` component is of [type `text`](https://developer.mozil
 <ld-input placeholder="Placeholder" aria-disabled="true"></ld-input>
 
 <ld-input aria-disabled="true" value="Value"></ld-input>
+
+<!-- React component -->
+
+<LdInput placeholder="Placeholder" aria-disabled="true" />
+
+<LdInput aria-disabled="true" value="Value" />
 
 <!-- CSS component -->
 
@@ -112,6 +130,12 @@ By default, the `ld-input` component is of [type `text`](https://developer.mozil
 
 <ld-input tone="dark" placeholder="Placeholder" disabled></ld-input>
 
+<!-- React component -->
+
+<LdInput tone="dark" placeholder="Placeholder" />
+
+<LdInput tone="dark" placeholder="Placeholder" disabled />
+
 <!-- CSS component -->
 
 <div class="ld-input ld-input--dark">
@@ -128,6 +152,10 @@ By default, the `ld-input` component is of [type `text`](https://developer.mozil
 {% example %}
 <ld-input invalid placeholder="Placeholder"></ld-input>
 
+<!-- React component -->
+
+<LdInput invalid placeholder="Placeholder" />
+
 <!-- CSS component -->
 
 <div class="ld-input ld-input--invalid">
@@ -140,6 +168,10 @@ By default, the `ld-input` component is of [type `text`](https://developer.mozil
 {% example %}
 <ld-input placeholder="Birthday" type="date" value="2017-06-01"></ld-input>
 
+<!-- React component -->
+
+<LdInput placeholder="Birthday" type="date" value="2017-06-01" />
+
 <!-- CSS component -->
 
 <div class="ld-input">
@@ -151,6 +183,10 @@ By default, the `ld-input` component is of [type `text`](https://developer.mozil
 
 {% example %}
 <ld-input placeholder="Birthday" type="datetime-local" value="2017-06-01T19:30"></ld-input>
+
+<!-- React component -->
+
+<LdInput placeholder="Birthday" type="datetime-local" value="2017-06-01T19:30" />
 
 <!-- CSS component -->
 
@@ -165,6 +201,10 @@ Triggerts associated keyboard in supporting browsers and devices with dynamic ke
 
 {% example %}
 <ld-input placeholder="Your email address" type="email"></ld-input>
+
+<!-- React component -->
+
+<LdInput placeholder="Your email address" type="email" />
 
 <!-- CSS component -->
 
@@ -184,6 +224,10 @@ Triggerts associated keyboard in supporting browsers and devices with dynamic ke
 {% example %}
 <ld-input placeholder="Your age in years" type="number" min="0"></ld-input>
 
+<!-- React component -->
+
+<LdInput placeholder="Your age in years" type="number" min="0" />
+
 <!-- CSS component -->
 
 <div class="ld-input">
@@ -196,6 +240,10 @@ Triggerts associated keyboard in supporting browsers and devices with dynamic ke
 {% example %}
 <ld-input placeholder="Password" type="password" min="0"></ld-input>
 
+<!-- React component -->
+
+<LdInput placeholder="Password" type="password" min="0" />
+
 <!-- CSS component -->
 
 <div class="ld-input">
@@ -207,6 +255,10 @@ Triggerts associated keyboard in supporting browsers and devices with dynamic ke
 
 {% example %}
 <ld-input placeholder="Search" type="search"></ld-input>
+
+<!-- React component -->
+
+<LdInput placeholder="Search" type="search" />
 
 <!-- CSS component -->
 
@@ -222,6 +274,10 @@ Triggers a telephone keypad in some devices with dynamic keypads.
 {% example %}
 <ld-input placeholder="Your phone number" type="tel"></ld-input>
 
+<!-- React component -->
+
+<LdInput placeholder="Your phone number" type="tel" />
+
 <!-- CSS component -->
 
 <div class="ld-input">
@@ -233,6 +289,10 @@ Triggers a telephone keypad in some devices with dynamic keypads.
 
 {% example %}
 <ld-input placeholder="Time of reservation" type="time" value="13:30"></ld-input>
+
+<!-- React component -->
+
+<LdInput placeholder="Time of reservation" type="time" value="13:30" />
 
 <!-- CSS component -->
 
@@ -248,6 +308,10 @@ Triggerts associated keyboard in supporting browsers and devices with dynamic ke
 {% example %}
 <ld-input placeholder="Your website URL" type="url"></ld-input>
 
+<!-- React component -->
+
+<LdInput placeholder="Your website URL" type="url" />
+
 <!-- CSS component -->
 
 <div class="ld-input">
@@ -261,6 +325,10 @@ The `multiline` attribute transforms the component to a textarea element instead
 
 {% example %}
 <ld-input placeholder="Tell us your story..." multiline rows="5" cols="33"></ld-input>
+
+<!-- React component -->
+
+<LdInput placeholder="Tell us your story..." multiline rows={5} cols={33} />
 
 <!-- CSS component -->
 
@@ -277,6 +345,12 @@ You can change the way how the multiline input element can be resized by the use
 <ld-input resize="horizontal" placeholder="Tell us your story..." multiline rows="5" cols="33"></ld-input>
 
 <ld-input resize="vertical" placeholder="Tell us your story..." multiline rows="5" cols="33"></ld-input>
+
+<!-- React component -->
+
+<LdInput resize="horizontal" placeholder="Tell us your story..." multiline rows={5} cols={33} />
+
+<LdInput resize="vertical" placeholder="Tell us your story..." multiline rows={5} cols={33} />
 
 <!-- CSS component -->
 
@@ -297,6 +371,14 @@ You can change the way how the multiline input element can be resized by the use
 <ld-input placeholder="Placeholder"></ld-input>
 
 <ld-input placeholder="Placeholder" size="lg"></ld-input>
+
+<!-- React component -->
+
+<LdInput placeholder="Placeholder" size="sm" />
+
+<LdInput placeholder="Placeholder" />
+
+<LdInput placeholder="Placeholder" size="lg" />
 
 <!-- CSS component -->
 
@@ -320,6 +402,13 @@ You can change the way how the multiline input element can be resized by the use
   Email Address
   <ld-input placeholder="jane.doe@example.com" type="email"></ld-input>
 </ld-label>
+
+<!-- React component -->
+
+<LdLabel>
+  Email Address
+  <LdInput placeholder="jane.doe@example.com" type="email" />
+</LdLabel>
 
 <!-- CSS component -->
 
@@ -348,6 +437,27 @@ Please reffer to the [ld-label](components/ld-label/) docs for more information 
     <ld-input type="password" value="asdf1234"></ld-input>
     <ld-input-message mode="info">Use at least one special character (~!@#$%^&*_-+=|\(){}[]:;<>,.?/)</ld-input-message>
   </ld-label>
+</div>
+
+<!-- React component -->
+
+<div style={ {
+  display: 'grid',
+  gap: '1rem',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(12rem, 1fr))',
+  width: '100%',
+} }>
+  <LdLabel>
+    Email Address
+    <LdInput invalid placeholder="jane.doe@example.com" value="yolo" type="email" />
+    <LdInputMessage>The email address is invalid.</LdInputMessage>
+  </LdLabel>
+
+  <LdLabel>
+    Password
+    <LdInput type="password" value="asdf1234" />
+    <LdInputMessage mode="info">Use at least one special character (~!@#$%^&*_-+=|()&#123;&#125;[]:;&lt;&gt;,.?/)</LdInputMessage>
+  </LdLabel>
 </div>
 
 <!-- CSS component -->
@@ -401,6 +511,20 @@ By default, the input field stretches to the maximum width of its wrapping label
   <ld-input placeholder="jane.doe@example.com" type="email"></ld-input>
   <ld-input-message mode="info">This info message is also extremely long, but since the label has a max width, all three components (the label, the input and itself) can take only the maximum width of the label.</ld-input-message>
 </ld-label>
+
+<!-- React component -->
+
+<LdLabel>
+  Email Address
+  <LdInput placeholder="jane.doe@example.com" type="email" />
+  <LdInputMessage mode="info">This info message is extremely long and makes all three components (the label, the input and itself) grow horizontaly.</LdInputMessage>
+</LdLabel>
+
+<LdLabel style={ { maxWidth: '20rem' } }>
+  Email Address
+  <LdInput placeholder="jane.doe@example.com" type="email" />
+  <LdInputMessage mode="info">This info message is also extremely long, but since the label has a max width, all three components (the label, the input and itself) can take only the maximum width of the label.</LdInputMessage>
+</LdLabel>
 
 <!-- CSS component -->
 
@@ -482,6 +606,47 @@ You can use [slots](components/ld-input/#slots) in order to add static or intera
   <ld-icon name="placeholder" slot="start"></ld-icon>
   <ld-icon name="placeholder" slot="end"></ld-icon>
 </ld-input>
+
+<!-- React component -->
+
+<LdInput placeholder="Placeholder" size="sm">
+  <LdIcon name="placeholder" slot="end" />
+</LdInput>
+
+<LdInput placeholder="Placeholder" size="sm">
+  <LdIcon name="placeholder" slot="start" />
+</LdInput>
+
+<LdInput placeholder="Placeholder" size="sm">
+  <LdIcon name="placeholder" slot="start" />
+  <LdIcon name="placeholder" slot="end" />
+</LdInput>
+
+<LdInput placeholder="Placeholder">
+  <LdIcon name="placeholder" slot="end" />
+</LdInput>
+
+<LdInput placeholder="Placeholder">
+  <LdIcon name="placeholder" slot="start" />
+</LdInput>
+
+<LdInput placeholder="Placeholder">
+  <LdIcon name="placeholder" slot="start" />
+  <LdIcon name="placeholder" slot="end" />
+</LdInput>
+
+<LdInput placeholder="Placeholder" size="lg">
+  <LdIcon name="placeholder" slot="end" />
+</LdInput>
+
+<LdInput placeholder="Placeholder" size="lg">
+  <LdIcon name="placeholder" slot="start" />
+</LdInput>
+
+<LdInput placeholder="Placeholder" size="lg">
+  <LdIcon name="placeholder" slot="start" />
+  <LdIcon name="placeholder" slot="end" />
+</LdInput>
 
 <!-- CSS component -->
 
@@ -649,6 +814,44 @@ You can use [slots](components/ld-input/#slots) in order to add static or intera
   </ld-button>
 </ld-input>
 
+<!-- React component -->
+
+<LdInput placeholder="Placeholder" size="sm">
+  <LdButton slot="end" aria-label="Submit" >
+    <LdIcon name="placeholder" />
+  </LdButton>
+</LdInput>
+
+<LdInput placeholder="Placeholder" size="sm">
+  <LdButton slot="end" >
+    Submit <LdIcon name="placeholder" />
+  </LdButton>
+</LdInput>
+
+<LdInput placeholder="Placeholder">
+  <LdButton slot="end" aria-label="Submit">
+    <LdIcon name="placeholder" />
+  </LdButton>
+</LdInput>
+
+<LdInput placeholder="Placeholder">
+  <LdButton slot="end">
+    Submit <LdIcon name="placeholder" />
+  </LdButton>
+</LdInput>
+
+<LdInput placeholder="Placeholder" size="lg">
+  <LdButton slot="end" aria-label="Submit">
+    <LdIcon name="placeholder" />
+  </LdButton>
+</LdInput>
+
+<LdInput placeholder="Placeholder" size="lg">
+  <LdButton slot="end">
+    Submit <LdIcon name="placeholder" />
+  </LdButton>
+</LdInput>
+
 <!-- CSS component -->
 
 <div class="ld-input ld-input--sm">
@@ -793,6 +996,71 @@ You can use [slots](components/ld-input/#slots) in order to add static or intera
   </ld-button>
 </ld-input>
 
+<!-- React component -->
+
+<LdInput placeholder="Placeholder" size="sm">
+  <LdButton mode="ghost" slot="end" aria-label="Submit">
+    <LdIcon name="placeholder" />
+  </LdButton>
+</LdInput>
+
+<LdInput placeholder="Placeholder" size="sm">
+  <LdButton mode="ghost" slot="start" aria-label="Submit">
+    <LdIcon name="placeholder" />
+  </LdButton>
+</LdInput>
+
+<LdInput placeholder="Placeholder" size="sm">
+  <LdButton mode="ghost" slot="start" aria-label="Submit">
+    <LdIcon name="placeholder" />
+  </LdButton>
+  <LdButton mode="ghost" slot="end" aria-label="Submit">
+    <LdIcon name="placeholder" />
+  </LdButton>
+</LdInput>
+
+<LdInput placeholder="Placeholder">
+  <LdButton mode="ghost" slot="end" aria-label="Submit">
+    <LdIcon name="placeholder" />
+  </LdButton>
+</LdInput>
+
+<LdInput placeholder="Placeholder">
+  <LdButton mode="ghost" slot="start" aria-label="Submit">
+    <LdIcon name="placeholder" />
+  </LdButton>
+</LdInput>
+
+<LdInput placeholder="Placeholder">
+  <LdButton mode="ghost" slot="start" aria-label="Submit">
+    <LdIcon name="placeholder" />
+  </LdButton>
+  <LdButton mode="ghost" slot="end" aria-label="Submit">
+    <LdIcon name="placeholder" />
+  </LdButton>
+</LdInput>
+
+<LdInput placeholder="Placeholder" size="lg">
+  <LdButton mode="ghost" slot="end" aria-label="Submit">
+    <LdIcon name="placeholder" />
+  </LdButton>
+</LdInput>
+
+<LdInput placeholder="Placeholder" size="lg">
+  <LdButton mode="ghost" slot="start" aria-label="Submit">
+    <LdIcon name="placeholder" />
+  </LdButton>
+</LdInput>
+
+<LdInput placeholder="Placeholder" size="lg">
+  <LdButton mode="ghost" slot="start" aria-label="Submit">
+    <LdIcon name="placeholder" />
+  </LdButton>
+  <LdButton mode="ghost" slot="end" aria-label="Submit">
+    <LdIcon name="placeholder" />
+  </LdButton>
+</LdInput>
+
 <!-- CSS component -->
 
 <div class="ld-input ld-input--sm">
@@ -934,6 +1202,12 @@ You can use [slots](components/ld-input/#slots) in order to add static or intera
 <ld-input placeholder="Placeholder">
   <span slot="end">🤓</span>
 </ld-input>
+
+<!-- React component -->
+
+<LdInput placeholder="Placeholder">
+  <span slot="end">🤓</span>
+</LdInput>
 
 <!-- CSS component -->
 

--- a/src/liquid/components/ld-label/readme.md
+++ b/src/liquid/components/ld-label/readme.md
@@ -23,6 +23,10 @@ This component is meant to be used in conjunction with form input components, su
 {% example %}
 <ld-label>Email Address</ld-label>
 
+<!-- React component -->
+
+<LdLabel>Email Address</LdLabel>
+
 <!-- CSS component -->
 
 <label class="ld-label">Email Address</label>
@@ -36,6 +40,12 @@ The default size is small. You can use a slightly bigger label (size medium) by 
 <ld-label size="m">
   Email Address
 </ld-label>
+
+<!-- React component -->
+
+<LdLabel size="m">
+  Email Address
+</LdLabel>
 
 <!-- CSS component -->
 
@@ -67,6 +77,25 @@ How the label positions its child elements depends both on its `position` prop a
   <ld-toggle></ld-toggle>
   <ld-input-message mode="info">Recommended.</ld-input-message>
 </ld-label>
+
+<!-- React component -->
+
+<LdLabel>
+  Email Address
+  <LdInput placeholder="jane.doe@example.com" type="email" />
+</LdLabel>
+
+<LdLabel>
+  Email Address
+  <LdInput invalid placeholder="jane.doe@example.com" type="email" />
+  <LdInputMessage>This field is required.</LdInputMessage>
+</LdLabel>
+
+<LdLabel>
+  Auto-update
+  <LdToggle />
+  <LdInputMessage mode="info">Recommended.</LdInputMessage>
+</LdLabel>
 
 <!-- CSS component -->
 
@@ -129,6 +158,25 @@ How the label positions its child elements depends both on its `position` prop a
   <ld-input-message mode="info">Recommended.</ld-input-message>
 </ld-label>
 
+<!-- React component -->
+
+<LdLabel position="left" size="m">
+  Email Address
+  <LdInput placeholder="jane.doe@example.com" type="email" />
+</LdLabel>
+
+<LdLabel position="left" size="m" alignMessage>
+  Email Address
+  <LdInput invalid placeholder="jane.doe@example.com" type="email" />
+  <LdInputMessage>This field is required.</LdInputMessage>
+</LdLabel>
+
+<LdLabel position="left" size="m">
+  Auto-update
+  <LdToggle />
+  <LdInputMessage mode="info">Recommended.</LdInputMessage>
+</LdLabel>
+
 <!-- CSS component -->
 
 <label class="ld-label ld-label--left ld-label--m">
@@ -189,6 +237,25 @@ How the label positions its child elements depends both on its `position` prop a
   <ld-toggle></ld-toggle>
   <ld-input-message mode="info">Recommended.</ld-input-message>
 </ld-label>
+
+<!-- React component -->
+
+<LdLabel position="right" size="m">
+  Email Address
+  <LdInput placeholder="jane.doe@example.com" type="email" />
+</LdLabel>
+
+<LdLabel position="right" size="m" alignMessage>
+  Email Address
+  <LdInput invalid placeholder="jane.doe@example.com" type="email" />
+  <LdInputMessage>This field is required.</LdInputMessage>
+</LdLabel>
+
+<LdLabel position="right" size="m">
+  Auto-update
+  <LdToggle />
+  <LdInputMessage mode="info">Recommended.</LdInputMessage>
+</LdLabel>
 
 <!-- CSS component -->
 
@@ -254,6 +321,28 @@ When positioning the label left or right, you may want to position the `ld-input
   <ld-input-message>I never grow underneath the label, even though I am very long.</ld-input-message>
 </ld-label>
 
+<!-- React component -->
+
+<LdLabel position="left" size="m">
+  Email Address
+  <LdInput invalid placeholder="jane.doe@example.com" type="email" />
+  <LdInputMessage>I do not align with the input.</LdInputMessage>
+</LdLabel>
+
+<LdLabel position="left" size="m" alignMessage>
+  Email Address
+  <LdInput invalid placeholder="jane.doe@example.com" type="email" />
+  <LdInputMessage>I align with the input.</LdInputMessage>
+</LdLabel>
+
+<LdLabel position="right" size="m" alignMessage>
+  Email Address
+  <LdInput invalid placeholder="jane.doe@example.com" type="email" />
+  <LdInputMessage>
+    I never grow underneath the label, even though I am very long.
+  </LdInputMessage>
+</LdLabel>
+
 <!-- CSS component -->
 
 <label class="ld-label ld-label--left ld-label--m">
@@ -317,6 +406,19 @@ HTML content describing the labeled element should be wrapped in a single HTML e
   <ld-checkbox invalid></ld-checkbox>
   <ld-input-message>Please confirm that you love to code.</ld-input-message>
 </ld-label>
+
+<!-- React component -->
+
+<LdLabel position="right">
+  <span>I love to <code style={ { lineHeight: 0 } }>code</code>.</span>
+  <LdCheckbox />
+</LdLabel>
+
+<LdLabel position="right">
+  <span>I love to <code style={ { lineHeight: 0 } }>code</code>.</span>
+  <LdCheckbox invalid />
+  <LdInputMessage>Please confirm that you love to code.</LdInputMessage>
+</LdLabel>
 
 <!-- CSS component -->
 

--- a/src/liquid/components/ld-link/readme.md
+++ b/src/liquid/components/ld-link/readme.md
@@ -22,6 +22,10 @@ This component is meant to be used in conjunction with the [`ld-icon`](component
 {% example %}
 <ld-link>Link</ld-link>
 
+<!-- React component -->
+
+<LdLink>Link</LdLink>
+
 <!-- CSS component -->
 
 <a class="ld-link">Link</a>
@@ -43,6 +47,20 @@ The `ld-link` component inherits its font-size and line-height.
 <ld-typo variant="body-m">
   <b>M</b>: Lorem ipsum <ld-link>dolor sit amet</ld-link>, consectetur adipiscing elit.
 </ld-typo>
+
+<!-- React component -->
+
+<LdTypo variant="body-xs">
+  <b>XS</b>: Lorem ipsum <LdLink>dolor sit amet</LdLink>, consectetur adipiscing elit.
+</LdTypo>
+
+<LdTypo variant="body-s">
+  <b>S</b>: Lorem ipsum <LdLink>dolor sit amet</LdLink>, consectetur adipiscing elit.
+</LdTypo>
+
+<LdTypo variant="body-m">
+  <b>M</b>: Lorem ipsum <LdLink>dolor sit amet</LdLink>, consectetur adipiscing elit.
+</LdTypo>
 
 <!-- CSS component -->
 
@@ -66,6 +84,10 @@ There are several ways to disable a link. The simplest one is by not using a `hr
 {% example %}
 <ld-link href="#" disabled>Link</ld-link>
 
+<!-- React component -->
+
+<LdLink href="#" disabled>Link</LdLink>
+
 <!-- CSS component -->
 
 <a id="disabled-link" class="ld-link" href="#" aria-disabled="true">Link</a>
@@ -88,6 +110,12 @@ There are several ways to disable a link. The simplest one is by not using a `hr
   Link which opens in a new tab
 </ld-link>
 
+<!-- React component -->
+
+<LdLink href="#" target="_blank">
+  Link which opens in a new tab
+</LdLink>
+
 <!-- CSS component -->
 
 <a class="ld-link" href="#" target="_blank" rel="noreferrer noopener">
@@ -100,6 +128,11 @@ There are several ways to disable a link. The simplest one is by not using a `hr
 {% example %}
 <ld-link chevron="start">Link</ld-link>
 <ld-link chevron="end">Link</ld-link>
+
+<!-- React component -->
+
+<LdLink chevron="start">Link</LdLink>
+<LdLink chevron="end">Link</LdLink>
 
 <!-- CSS component -->
 

--- a/src/liquid/components/ld-loading/readme.md
+++ b/src/liquid/components/ld-loading/readme.md
@@ -18,6 +18,10 @@ Use the `ld-loading` component to indicate that the user should wait for a proce
 {% example %}
 <ld-loading></ld-loading>
 
+<!-- React component -->
+
+<LdLoading />
+
 <!-- CSS component -->
 
 <svg class="ld-loading" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid meet">
@@ -44,6 +48,10 @@ Use the `ld-loading` component to indicate that the user should wait for a proce
 
 {% example %}
 <ld-loading neutral></ld-loading>
+
+<!-- React component -->
+
+<LdLoading neutral />
 
 <!-- CSS component -->
 

--- a/src/liquid/components/ld-modal/readme.md
+++ b/src/liquid/components/ld-modal/readme.md
@@ -36,6 +36,22 @@ Here is a minimalistic example of a modal dialog:
 
 <ld-button onclick="event.target.previousElementSibling.showModal()">Open Modal</ld-button>
 
+<!-- React component -->
+
+const modalRef = useRef(null)
+
+return (
+  <>
+    <LdModal ref={modalRef}>
+      <LdTypo style={ { textAlign: 'center' } }>I'm a modal dialog.</LdTypo>
+    </LdModal>
+
+    <LdButton onClick={() => modalRef.current.showModal()}>
+      Open Modal
+    </LdButton>
+  </>
+)
+
 <!-- CSS component -->
 
 <dialog class="ld-modal">
@@ -71,6 +87,38 @@ You have two additional slots to your disposal for altering the modal header and
 </ld-modal>
 
 <ld-button onclick="event.target.previousElementSibling.showModal()">Open Modal</ld-button>
+
+<!-- React component -->
+
+const modalRef = useRef(null)
+
+return (
+  <>
+    <LdModal ref={modalRef}>
+      <LdTypo slot="header">Hello</LdTypo>
+      <LdTypo style={ { textAlign: 'center' } }>I'm a modal dialog.</LdTypo>
+      <LdButton
+        slot="footer"
+        style={ { width: '8rem' } }
+        mode="ghost"
+        onClick={() => modalRef.current.close()}
+      >
+        Cancel
+      </LdButton>
+      <LdButton
+        slot="footer"
+        style={ { width: '8rem' } }
+        onClick={() => modalRef.current.close()}
+      >
+        Submit
+      </LdButton>
+    </LdModal>
+
+    <LdButton onClick={() => modalRef.current.showModal()}>
+      Open Modal
+    </LdButton>
+  </>
+)
 
 <!-- CSS component -->
 
@@ -110,6 +158,30 @@ You have two additional slots to your disposal for altering the modal header and
 
 <ld-button onclick="event.target.previousElementSibling.showModal()">Open Modal</ld-button>
 
+<!-- React component -->
+
+const modalRef = useRef(null)
+
+return (
+  <>
+    <LdModal cancelable="false" ref={modalRef}>
+      <LdTypo slot="header">Hello</LdTypo>
+      <LdTypo style={ { textAlign: 'center' } }>I'm a modal dialog.</LdTypo>
+      <LdButton
+        slot="footer"
+        style={ { width: '8rem' } }
+        onClick={() => modalRef.current.close()}
+      >
+        Submit
+      </LdButton>
+    </LdModal>
+
+    <LdButton onClick={() => modalRef.current.showModal()}>
+      Open Modal
+    </LdButton>
+  </>
+)
+
 <!-- CSS component -->
 
 <dialog class="ld-modal" oncancel="event.preventDefault()">
@@ -139,6 +211,22 @@ You have two additional slots to your disposal for altering the modal header and
 </ld-modal>
 
 <ld-button onclick="event.target.previousElementSibling.showModal()">Open Modal</ld-button>
+
+<!-- React component -->
+
+const modalRef = useRef(null)
+
+return (
+  <>
+    <LdModal blurryBackdrop ref={modalRef}>
+      <LdTypo style={ { textAlign: 'center' } }>I'm a modal dialog.</LdTypo>
+    </LdModal>
+
+    <LdButton onClick={() => modalRef.current.showModal()}>
+      Open Modal
+    </LdButton>
+  </>
+)
 
 <!-- CSS component -->
 

--- a/src/liquid/components/ld-notice/readme.md
+++ b/src/liquid/components/ld-notice/readme.md
@@ -22,7 +22,23 @@ This component is meant to be used in conjunction with the [`ld-input`](componen
 ### As success message
 
 {% example %}
-<ld-notice headline="Success message" mode="success">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Metus pellentesque facilisi nunc iaculis. Laoreet eget eu lacus cursus odio quam ut elementum. Faucibus cursus in placerat enim non senectus. In molestie volutpat at sem bibendum ac id. Suspendisse erat malesuada vulputate et congue blandit in erat ornare. Rhoncus interdum.</ld-notice>
+<ld-notice headline="Success message" mode="success">
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Metus
+  pellentesque facilisi nunc iaculis. Laoreet eget eu lacus cursus odio
+  quam ut elementum. Faucibus cursus in placerat enim non senectus. In
+  molestie volutpat at sem bibendum ac id. Suspendisse erat malesuada
+  vulputate et congue blandit in erat ornare. Rhoncus interdum.
+</ld-notice>
+
+<!-- React component -->
+
+<LdNotice headline="Success message" mode="success">
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Metus
+  pellentesque facilisi nunc iaculis. Laoreet eget eu lacus cursus odio
+  quam ut elementum. Faucibus cursus in placerat enim non senectus. In
+  molestie volutpat at sem bibendum ac id. Suspendisse erat malesuada
+  vulputate et congue blandit in erat ornare. Rhoncus interdum.
+</LdNotice>
 
 <!-- CSS component -->
 
@@ -33,14 +49,34 @@ This component is meant to be used in conjunction with the [`ld-input`](componen
     <path d="M16.898 9.56123L10.4404 15.4388L7.10205 12.147" stroke="var(--ld-icon-secondary-col)" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
   </svg>
   <p class="ld-notice__headline ld-typo--h4">Success message</p>
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Metus pellentesque facilisi nunc iaculis. Laoreet eget eu lacus cursus odio quam ut elementum. Faucibus cursus in placerat enim non senectus. In molestie volutpat at sem bibendum ac id. Suspendisse erat malesuada vulputate et congue blandit in erat ornare. Rhoncus interdum.
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Metus
+  pellentesque facilisi nunc iaculis. Laoreet eget eu lacus cursus odio
+  quam ut elementum. Faucibus cursus in placerat enim non senectus. In
+  molestie volutpat at sem bibendum ac id. Suspendisse erat malesuada
+  vulputate et congue blandit in erat ornare. Rhoncus interdum.
 </div>
 {% endexample %}
 
 ### As error message
 
 {% example %}
-<ld-notice headline="An error occurred" mode="error">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Metus pellentesque facilisi nunc iaculis. Laoreet eget eu lacus cursus odio quam ut elementum. Faucibus cursus in placerat enim non senectus. In molestie volutpat at sem bibendum ac id. Suspendisse erat malesuada vulputate et congue blandit in erat ornare. Rhoncus interdum.</ld-notice>
+<ld-notice headline="An error occurred" mode="error">
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Metus
+  pellentesque facilisi nunc iaculis. Laoreet eget eu lacus cursus odio
+  quam ut elementum. Faucibus cursus in placerat enim non senectus. In
+  molestie volutpat at sem bibendum ac id. Suspendisse erat malesuada
+  vulputate et congue blandit in erat ornare. Rhoncus interdum.
+</ld-notice>
+
+<!-- React component -->
+
+<LdNotice headline="An error occurred" mode="error">
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Metus
+  pellentesque facilisi nunc iaculis. Laoreet eget eu lacus cursus odio
+  quam ut elementum. Faucibus cursus in placerat enim non senectus. In
+  molestie volutpat at sem bibendum ac id. Suspendisse erat malesuada
+  vulputate et congue blandit in erat ornare. Rhoncus interdum.
+</LdNotice>
 
 <!-- CSS component -->
 
@@ -52,14 +88,34 @@ This component is meant to be used in conjunction with the [`ld-input`](componen
     <ellipse cx="6.99977" cy="3.80007" rx="1.06667" ry="1.06667" fill="var(--ld-icon-secondary-col)"/>
   </svg>
   <p class="ld-notice__headline ld-typo--h4">An error occurred</p>
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Metus pellentesque facilisi nunc iaculis. Laoreet eget eu lacus cursus odio quam ut elementum. Faucibus cursus in placerat enim non senectus. In molestie volutpat at sem bibendum ac id. Suspendisse erat malesuada vulputate et congue blandit in erat ornare. Rhoncus interdum.
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Metus
+  pellentesque facilisi nunc iaculis. Laoreet eget eu lacus cursus odio
+  quam ut elementum. Faucibus cursus in placerat enim non senectus. In
+  molestie volutpat at sem bibendum ac id. Suspendisse erat malesuada
+  vulputate et congue blandit in erat ornare. Rhoncus interdum.
 </div>
 {% endexample %}
 
 ### As info message
 
 {% example %}
-<ld-notice headline="Information">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Metus pellentesque facilisi nunc iaculis. Laoreet eget eu lacus cursus odio quam ut elementum. Faucibus cursus in placerat enim non senectus. In molestie volutpat at sem bibendum ac id. Suspendisse erat malesuada vulputate et congue blandit in erat ornare. Rhoncus interdum.</ld-notice>
+<ld-notice headline="Information">
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Metus
+  pellentesque facilisi nunc iaculis. Laoreet eget eu lacus cursus odio
+  quam ut elementum. Faucibus cursus in placerat enim non senectus. In
+  molestie volutpat at sem bibendum ac id. Suspendisse erat malesuada
+  vulputate et congue blandit in erat ornare. Rhoncus interdum.
+</ld-notice>
+
+<!-- React component -->
+
+<LdNotice headline="Information">
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Metus
+  pellentesque facilisi nunc iaculis. Laoreet eget eu lacus cursus odio
+  quam ut elementum. Faucibus cursus in placerat enim non senectus. In
+  molestie volutpat at sem bibendum ac id. Suspendisse erat malesuada
+  vulputate et congue blandit in erat ornare. Rhoncus interdum.
+</LdNotice>
 
 <!-- CSS component -->
 
@@ -71,14 +127,34 @@ This component is meant to be used in conjunction with the [`ld-input`](componen
     <ellipse cx="6.99977" cy="3.80007" rx="1.06667" ry="1.06667" fill="var(--ld-icon-secondary-col)"/>
   </svg>
   <p class="ld-notice__headline ld-typo--h4">Information</p>
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Metus pellentesque facilisi nunc iaculis. Laoreet eget eu lacus cursus odio quam ut elementum. Faucibus cursus in placerat enim non senectus. In molestie volutpat at sem bibendum ac id. Suspendisse erat malesuada vulputate et congue blandit in erat ornare. Rhoncus interdum.
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Metus
+  pellentesque facilisi nunc iaculis. Laoreet eget eu lacus cursus odio
+  quam ut elementum. Faucibus cursus in placerat enim non senectus. In
+  molestie volutpat at sem bibendum ac id. Suspendisse erat malesuada
+  vulputate et congue blandit in erat ornare. Rhoncus interdum.
 </div>
 {% endexample %}
 
 ### As warning message
 
 {% example %}
-<ld-notice headline="Warning!" mode="warning">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Metus pellentesque facilisi nunc iaculis. Laoreet eget eu lacus cursus odio quam ut elementum. Faucibus cursus in placerat enim non senectus. In molestie volutpat at sem bibendum ac id. Suspendisse erat malesuada vulputate et congue blandit in erat ornare. Rhoncus interdum.</ld-notice>
+<ld-notice headline="Warning!" mode="warning">
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Metus
+  pellentesque facilisi nunc iaculis. Laoreet eget eu lacus cursus odio
+  quam ut elementum. Faucibus cursus in placerat enim non senectus. In
+  molestie volutpat at sem bibendum ac id. Suspendisse erat malesuada
+  vulputate et congue blandit in erat ornare. Rhoncus interdum.
+</ld-notice>
+
+<!-- React component -->
+
+<LdNotice headline="Warning!" mode="warning">
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Metus
+  pellentesque facilisi nunc iaculis. Laoreet eget eu lacus cursus odio
+  quam ut elementum. Faucibus cursus in placerat enim non senectus. In
+  molestie volutpat at sem bibendum ac id. Suspendisse erat malesuada
+  vulputate et congue blandit in erat ornare. Rhoncus interdum.
+</LdNotice>
 
 <!-- CSS component -->
 
@@ -90,7 +166,11 @@ This component is meant to be used in conjunction with the [`ld-input`](componen
     <ellipse cx="6.99977" cy="3.80007" rx="1.06667" ry="1.06667" fill="var(--ld-icon-secondary-col)"/>
   </svg>
   <p class="ld-notice__headline ld-typo--h4">Warning!</p>
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Metus pellentesque facilisi nunc iaculis. Laoreet eget eu lacus cursus odio quam ut elementum. Faucibus cursus in placerat enim non senectus. In molestie volutpat at sem bibendum ac id. Suspendisse erat malesuada vulputate et congue blandit in erat ornare. Rhoncus interdum.
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Metus
+  pellentesque facilisi nunc iaculis. Laoreet eget eu lacus cursus odio
+  quam ut elementum. Faucibus cursus in placerat enim non senectus. In
+  molestie volutpat at sem bibendum ac id. Suspendisse erat malesuada
+  vulputate et congue blandit in erat ornare. Rhoncus interdum.
 </div>
 {% endexample %}
 
@@ -99,8 +179,23 @@ This component is meant to be used in conjunction with the [`ld-input`](componen
 {% example %}
 <ld-notice headline="With custom icon" mode="success">
   <ld-icon slot="custom-icon" name="placeholder" size="lg"></ld-icon>
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Metus pellentesque facilisi nunc iaculis. Laoreet eget eu lacus cursus odio quam ut elementum. Faucibus cursus in placerat enim non senectus. In molestie volutpat at sem bibendum ac id. Suspendisse erat malesuada vulputate et congue blandit in erat ornare. Rhoncus interdum.
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Metus
+  pellentesque facilisi nunc iaculis. Laoreet eget eu lacus cursus odio
+  quam ut elementum. Faucibus cursus in placerat enim non senectus. In
+  molestie volutpat at sem bibendum ac id. Suspendisse erat malesuada
+  vulputate et congue blandit in erat ornare. Rhoncus interdum.
 </ld-notice>
+
+<!-- React component -->
+
+<LdNotice headline="With custom icon" mode="success">
+  <LdIcon slot="custom-icon" name="placeholder" size="lg" />
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Metus
+  pellentesque facilisi nunc iaculis. Laoreet eget eu lacus cursus odio
+  quam ut elementum. Faucibus cursus in placerat enim non senectus. In
+  molestie volutpat at sem bibendum ac id. Suspendisse erat malesuada
+  vulputate et congue blandit in erat ornare. Rhoncus interdum.
+</LdNotice>
 
 <!-- CSS component -->
 
@@ -108,7 +203,11 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Metus pellentesque faci
   <!-- Note that you can use an img element with the class ld-notice__icon here, as well. -->
   <svg class="ld-notice__icon ld-icon ld-icon--lg" viewBox="0 0 16 16" fill="none"><rect x="1" y="1" width="14" height="14" rx="3" stroke="currentcolor" stroke-width="2"/><circle cx="8" cy="8" r="3" stroke="currentColor" stroke-width="2"/></svg>
   <p class="ld-notice__headline ld-typo--h4">With custom icon</p>
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Metus pellentesque facilisi nunc iaculis. Laoreet eget eu lacus cursus odio quam ut elementum. Faucibus cursus in placerat enim non senectus. In molestie volutpat at sem bibendum ac id. Suspendisse erat malesuada vulputate et congue blandit in erat ornare. Rhoncus interdum.
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Metus
+  pellentesque facilisi nunc iaculis. Laoreet eget eu lacus cursus odio
+  quam ut elementum. Faucibus cursus in placerat enim non senectus. In
+  molestie volutpat at sem bibendum ac id. Suspendisse erat malesuada
+  vulputate et congue blandit in erat ornare. Rhoncus interdum.
 </div>
 {% endexample %}
 

--- a/src/liquid/components/ld-notification/readme.md
+++ b/src/liquid/components/ld-notification/readme.md
@@ -143,7 +143,7 @@ The examples below illustrate how you can trigger notifications using different 
 <form class="notification-form" id="form-info">
   <ld-label>
     Info message
-    <ld-input id="input-info" value="I have an info for you."></ld-input>
+    <ld-input name="message" value="I have an info for you."></ld-input>
   </ld-label>
   <ld-button type="submit">Submit</ld-button>
 </form>
@@ -151,7 +151,7 @@ The examples below illustrate how you can trigger notifications using different 
 <form class="notification-form" id="form-warn">
   <ld-label>
     Warning
-    <ld-input id="input-warn" value="I warn you!"></ld-input>
+    <ld-input name="message" value="I warn you!"></ld-input>
   </ld-label>
   <ld-button type="submit">Submit</ld-button>
 </form>
@@ -159,7 +159,7 @@ The examples below illustrate how you can trigger notifications using different 
 <form class="notification-form" id="form-info-custom-timeout">
   <ld-label>
     Info message which times out after 10 seconds
-    <ld-input id="input-info-custom-timeout" value="I'll take my time."></ld-input>
+    <ld-input name="message" value="I'll take my time."></ld-input>
   </ld-label>
   <ld-button type="submit">Submit</ld-button>
 </form>
@@ -167,7 +167,7 @@ The examples below illustrate how you can trigger notifications using different 
 <form class="notification-form" id="form-info-no-timeout">
   <ld-label>
     Info message which doesn't time out
-    <ld-input id="input-info-no-timeout" value="I'm here to stay!"></ld-input>
+    <ld-input name="message" value="I'm here to stay!"></ld-input>
   </ld-label>
   <ld-button type="submit">Submit</ld-button>
 </form>
@@ -175,51 +175,44 @@ The examples below illustrate how you can trigger notifications using different 
 <form class="notification-form" id="form-alert">
   <ld-label>
     alert message
-    <ld-input id="input-alert" value="Ooops."></ld-input>
+    <ld-input name="message" value="Ooops."></ld-input>
   </ld-label>
   <ld-button type="submit">Submit</ld-button>
 </form>
 
-<form id="form-dismiss">
-  <ld-button type="submit">Dismiss current notification</ld-button>
-</form>
+<ld-button id="button-dismiss" type="button">Dismiss current notification</ld-button>
 
-<form id="form-clear">
-  <ld-button type="submit">Clear all notifications</ld-button>
-</form>
+<ld-button id="button-clear" type="button">Clear all notifications</ld-button>
 
 <script>
 const formInfo = document.getElementById('form-info')
-const inputInfo = document.getElementById('input-info')
 formInfo.addEventListener('submit', ev => {
   ev.preventDefault()
   dispatchEvent(new CustomEvent('ldNotificationAdd', {
     detail: {
-      content: inputInfo.value || '',
+      content: ev.currentTarget.message.value || '',
       type: 'info',
     }
   }))
 })
 
 const formWarn = document.getElementById('form-warn')
-const inputWarn = document.getElementById('input-warn')
 formWarn.addEventListener('submit', ev => {
   ev.preventDefault()
   dispatchEvent(new CustomEvent('ldNotificationAdd', {
     detail: {
-      content: inputWarn.value || '',
+      content: ev.currentTarget.message.value || '',
       type: 'warn',
     }
   }))
 })
 
 const formInfoCustomTimeout = document.getElementById('form-info-custom-timeout')
-const inputInfoCustomTimeout = document.getElementById('input-info-custom-timeout')
 formInfoCustomTimeout.addEventListener('submit', ev => {
   ev.preventDefault()
   dispatchEvent(new CustomEvent('ldNotificationAdd', {
     detail: {
-      content: inputInfoCustomTimeout.value || '',
+      content: ev.currentTarget.message.value || '',
       type: 'info',
       timeout: 10000,
     }
@@ -227,12 +220,11 @@ formInfoCustomTimeout.addEventListener('submit', ev => {
 })
 
 const formInfoNoTimeout = document.getElementById('form-info-no-timeout')
-const inputInfoNoTimeout = document.getElementById('input-info-no-timeout')
 formInfoNoTimeout.addEventListener('submit', ev => {
   ev.preventDefault()
   dispatchEvent(new CustomEvent('ldNotificationAdd', {
     detail: {
-      content: inputInfoNoTimeout.value || '',
+      content: ev.currentTarget.message.value || '',
       type: 'info',
       timeout: 0,
     }
@@ -240,29 +232,171 @@ formInfoNoTimeout.addEventListener('submit', ev => {
 })
 
 const formAlert = document.getElementById('form-alert')
-const inputAlert = document.getElementById('input-alert')
 formAlert.addEventListener('submit', ev => {
   ev.preventDefault()
   dispatchEvent(new CustomEvent('ldNotificationAdd', {
     detail: {
-      content: inputAlert.value || '',
+      content: ev.currentTarget.message.value || '',
       type: 'alert',
     }
   }))
 })
 
-const formDismiss = document.getElementById('form-dismiss')
-formDismiss.addEventListener('submit', ev => {
+const buttonDismiss = document.getElementById('button-dismiss')
+buttonDismiss.addEventListener('click', ev => {
   ev.preventDefault()
   dispatchEvent(new CustomEvent('ldNotificationDismiss'))
 })
 
-const formClear = document.getElementById('form-clear')
-formClear.addEventListener('submit', ev => {
+const buttonClear = document.getElementById('button-clear')
+buttonClear.addEventListener('click', ev => {
   ev.preventDefault()
   dispatchEvent(new CustomEvent('ldNotificationClear'))
 })
 </script>
+
+<!-- React component -->
+
+const notificationFormStyles = {
+  display: 'grid',
+  gridTemplateColumns: '1fr auto',
+  alignItems: 'flex-end',
+  gridGap: '1rem',
+  width: 'calc(100% - 2 * var(--ld-sp-24))',
+}
+
+return (
+  <>
+    <LdNotification placement="bottom" />
+
+    <form
+      onSubmit={(ev) => {
+        ev.preventDefault()
+        dispatchEvent(
+          new CustomEvent('ldNotificationAdd', {
+            detail: {
+              content: ev.currentTarget.message.value || '',
+              type: 'info',
+            },
+          })
+        )
+      }}
+      style={notificationFormStyles}
+    >
+      <LdLabel>
+        Info message
+        <LdInput name="message" value="I have an info for you." />
+      </LdLabel>
+      <LdButton type="submit">Submit</LdButton>
+    </form>
+
+    <form
+      onSubmit={(ev) => {
+        ev.preventDefault()
+        dispatchEvent(
+          new CustomEvent('ldNotificationAdd', {
+            detail: {
+              content: ev.currentTarget.message.value || '',
+              type: 'warn',
+            },
+          })
+        )
+      }}
+      style={notificationFormStyles}
+    >
+      <LdLabel>
+        Warning
+        <LdInput name="message" value="I warn you!" />
+      </LdLabel>
+      <LdButton type="submit">Submit</LdButton>
+    </form>
+
+    <form
+      onSubmit={(ev) => {
+        ev.preventDefault()
+        dispatchEvent(
+          new CustomEvent('ldNotificationAdd', {
+            detail: {
+              content: ev.currentTarget.message.value || '',
+              type: 'info',
+              timeout: 10000,
+            },
+          })
+        )
+      }}
+      style={notificationFormStyles}
+    >
+      <LdLabel>
+        Info message which times out after 10 seconds
+        <LdInput name="message" value="I'll take my time." />
+      </LdLabel>
+      <LdButton type="submit">Submit</LdButton>
+    </form>
+
+    <form
+      onSubmit={(ev) => {
+        ev.preventDefault()
+        dispatchEvent(
+          new CustomEvent('ldNotificationAdd', {
+            detail: {
+              content: ev.currentTarget.message.value || '',
+              type: 'info',
+              timeout: 0,
+            },
+          })
+        )
+      }}
+      style={notificationFormStyles}
+    >
+      <LdLabel>
+        Info message which doesn't time out
+        <LdInput name="message" value="I'm here to stay!" />
+      </LdLabel>
+      <LdButton type="submit">Submit</LdButton>
+    </form>
+
+    <form
+      onSubmit={(ev) => {
+        ev.preventDefault()
+        dispatchEvent(
+          new CustomEvent('ldNotificationAdd', {
+            detail: {
+              content: ev.currentTarget.message.value || '',
+              type: 'alert',
+            },
+          })
+        )
+      }}
+      style={notificationFormStyles}
+    >
+      <LdLabel>
+        alert message
+        <LdInput name="message" value="Ooops." />
+      </LdLabel>
+      <LdButton type="submit">Submit</LdButton>
+    </form>
+
+    <LdButton
+      onClick={(ev) => {
+        ev.preventDefault()
+        dispatchEvent(new CustomEvent('ldNotificationDismiss'))
+      }}
+      type="button"
+    >
+      Dismiss current notification
+    </LdButton>
+
+    <LdButton
+      onClick={(ev) => {
+        ev.preventDefault()
+        dispatchEvent(new CustomEvent('ldNotificationClear'))
+      }}
+      type="button"
+    >
+      Clear all notifications
+    </LdButton>
+  </>
+)
 {% endexample %}
 
 <!-- Auto Generated Below -->


### PR DESCRIPTION
# Description

Adds React examples for the following components:

- ld-icon
- ld-input
- ld-input-message
- ld-label
- ld-link
- ld-loading
- ld-modal
- ld-notice
- ld-notification

Fixes a CSS issue for `ld-progress`.

## Type of change

Please delete options that are not relevant.

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## Is it a breaking change?

- [ ] Yes
- [x] No

# How Has This Been Tested?

Please describe the tests that you've added and run to verify your changes. 
Provide instructions, so we can reproduce.

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes