### PR TITLE
fix(ld-select): make focusInner use focusVisible

### DIFF
--- a/src/liquid/components/ld-select/ld-select.tsx
+++ b/src/liquid/components/ld-select/ld-select.tsx
@@ -127,7 +127,11 @@ export class LdSelect implements InnerFocusable {
   @Method()
   async focusInner() {
     if (!this.disabled) {
-      this.triggerRef.focus()
+      // Experimental feature that fixes a bug in Firefox only.
+      // See https://github.com/emdgroup-liquid/liquid/issues/486
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error
+      this.triggerRef.focus({ focusVisible: true })
     }
   }
 

--- a/src/liquid/components/ld-select/test/ld-select.spec.ts
+++ b/src/liquid/components/ld-select/test/ld-select.spec.ts
@@ -2806,6 +2806,9 @@ describe('ld-select', () => {
 
     await page.root.focusInner()
     expect(btnTrigger.focus).toHaveBeenCalledTimes(1)
+    expect(btnTrigger.focus).toHaveBeenCalledWith(
+      expect.objectContaining({ focusVisible: true })
+    )
   })
 
   it('removes popper element on disconnect', async () => {


### PR DESCRIPTION
# Description

Applies an option inside the focusInner method to fix focus behavior (Firefox only). Other browsers: The browser determines, whether to apply `focus` or `focus-visible` styles. Focusing works, even though in some cases the outline is not visible. We will not fix this behavior in all browsers, as the functionality is not affected.

Fixes #486 

## Type of change

Please delete options that are not relevant.

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Is it a breaking change?

- [ ] Yes
- [x] No

# How Has This Been Tested?

Please describe the tests that you've added and run to verify your changes. 
Provide instructions, so we can reproduce.

- [x] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes