### PR TITLE
feat(ld-input): add ldinputfile and ldchangefile events

### DIFF
--- a/src/liquid/components/ld-input/ld-input.tsx
+++ b/src/liquid/components/ld-input/ld-input.tsx
@@ -29,6 +29,7 @@ import { registerAutofocus } from '../../utils/focus'
  * Styling for `ld-icon` and `ld-button` is provided within the `ld-input` component.
  * If you choose to place something different into the slot, you will probably
  * need to adjust some styles on the slotted item in order to make it fit right.
+ * @virtualProp { FileList | undefined } files - Selected files for ld-input with type file (readonly).
  * @virtualProp ref - reference to component
  * @virtualProp {string | number} key - for tracking the node's identity when working with lists
  * @part input - Actual input/textarea element
@@ -142,14 +143,8 @@ export class LdInput implements InnerFocusable, ClonesAttributes {
   /** Emitted when the input value changed and the element loses focus. */
   @Event() ldchange: EventEmitter<string>
 
-  /** Emitted when the input files value changed and the element loses focus. */
-  @Event() ldchangefile: EventEmitter<FileList>
-
   /** Emitted when the input value changed. */
   @Event() ldinput: EventEmitter<string>
-
-  /** Emitted when the input files value changed. */
-  @Event() ldinputfile: EventEmitter<FileList>
 
   /**
    * Sets focus on the input
@@ -260,6 +255,16 @@ export class LdInput implements InnerFocusable, ClonesAttributes {
   }
 
   componentWillLoad() {
+    // Add readonly prop files.
+    Object.defineProperty(this.el, 'files', {
+      get: () => {
+        if (this.isInputTypeFile(this.input)) {
+          return this.input.files
+        }
+        return undefined
+      },
+    })
+
     this.attributesObserver = cloneAttributes.call(this, [
       'multiline',
       'autocomplete',
@@ -303,19 +308,11 @@ export class LdInput implements InnerFocusable, ClonesAttributes {
   private handleChange = (ev: InputEvent) => {
     this.el.dispatchEvent(new InputEvent('change', ev))
 
-    if (this.isInputTypeFile(this.input)) {
-      this.ldchangefile.emit(this.input.files)
-    }
-
     this.ldchange.emit(this.value)
   }
 
   private handleInput = () => {
     this.value = this.input.value
-
-    if (this.isInputTypeFile(this.input)) {
-      this.ldinputfile.emit(this.input.files)
-    }
 
     this.ldinput.emit(this.value)
   }

--- a/src/liquid/components/ld-input/readme.md
+++ b/src/liquid/components/ld-input/readme.md
@@ -207,7 +207,7 @@ Triggerts associated keyboard in supporting browsers and devices with dynamic ke
 
 If you are using the `ld-input` component within a `form` and are posting the form, there is no need to access the selected files and the underlying data, because they are submitted as part of the form data automatically.
 
-However, if you want to compose the form data yourself or want to read the files on the client side, you can do so using the `ldinputfile` or `ldchangefile` events.
+However, if you want to compose the form data yourself or want to read the files on the client side, you can do so using the _readonly_ `files` prop.
 
 {% example %}
 <ld-input
@@ -219,9 +219,9 @@ However, if you want to compose the form data yourself or want to read the files
 <script>
   ;(() => {
     const ldInput = document.currentScript.previousElementSibling
-    ldInput.addEventListener('ldchangefile', async (ev) => {
-      const files = ev.detail // as FileList
-      if (!files.length) return
+    ldInput.addEventListener('ldchange', async (ev) => {
+      const files = ev.target.files
+      if (!files || !files.length) return
 
       // Read the file on the client side.
       const fileReader = new FileReader()
@@ -259,9 +259,9 @@ However, if you want to compose the form data yourself or want to read the files
   placeholder="Your profile picture"
   type="file"
   accept="image/png, image/jpeg"
-  onLdchangefile={async (ev) => {
-    const files = ev.detail
-    if (!files.length) return
+  onLdchange={async (ev) => {
+    const files = ev.target.files
+    if (!files || !files.length) return
 
     // Read the file on the client side.
     const fileReader = new FileReader()
@@ -915,6 +915,7 @@ understanding on how they can be used together.
 | `cols`         | `cols`         | The number of columns.                                                                                                | `number`                                         | `undefined` |
 | `dirname`      | `dirname`      | Name of form field to use for sending the element's directionality in form submission.                                | `string`                                         | `undefined` |
 | `disabled`     | `disabled`     | Whether the form control is disabled.                                                                                 | `boolean`                                        | `undefined` |
+| `files`        | `files`        | Selected files for ld-input with type file (readonly).                                                                | `FileList \| undefined`                          | `undefined` |
 | `form`         | `form`         | Associates the control with a form element.                                                                           | `string`                                         | `undefined` |
 | `invalid`      | `invalid`      | Set this property to `true` in order to mark the field visually as invalid.                                           | `boolean`                                        | `undefined` |
 | `key`          | `key`          | for tracking the node's identity when working with lists                                                              | `string \| number`                               | `undefined` |
@@ -943,10 +944,10 @@ understanding on how they can be used together.
 
 ## Events
 
-| Event      | Description                                                       | Type                              |
-| ---------- | ----------------------------------------------------------------- | --------------------------------- |
-| `ldchange` | Emitted when the input value changed and the element loses focus. | `CustomEvent<FileList \| string>` |
-| `ldinput`  | Emitted when the input value changed.                             | `CustomEvent<FileList \| string>` |
+| Event      | Description                                                       | Type                  |
+| ---------- | ----------------------------------------------------------------- | --------------------- |
+| `ldchange` | Emitted when the input value changed and the element loses focus. | `CustomEvent<string>` |
+| `ldinput`  | Emitted when the input value changed.                             | `CustomEvent<string>` |
 
 
 ## Methods

--- a/src/liquid/components/ld-input/readme.md
+++ b/src/liquid/components/ld-input/readme.md
@@ -30,22 +30,30 @@ By default, the `ld-input` component is of [type `text`](https://developer.mozil
 {% example %}
 <ld-input placeholder="Placeholder"></ld-input>
 
-<ld-input value="Value"></ld-input>
-
 <!-- React component -->
 
 <LdInput placeholder="Placeholder" />
-
-<LdInput value="Value" />
 
 <!-- CSS component -->
 
 <div class="ld-input">
   <input placeholder="Placeholder">
 </div>
+{% endexample %}
+
+### With value
+
+{% example %}
+<ld-input placeholder="Placeholder" value="Hello"></ld-input>
+
+<!-- React component -->
+
+<LdInput placeholder="Placeholder" value="Hello" />
+
+<!-- CSS component -->
 
 <div class="ld-input">
-  <input placeholder="Placeholder" value="Value">
+  <input placeholder="Placeholder" value="Hello">
 </div>
 {% endexample %}
 
@@ -54,22 +62,14 @@ By default, the `ld-input` component is of [type `text`](https://developer.mozil
 {% example %}
 <ld-input placeholder="Placeholder" disabled></ld-input>
 
-<ld-input disabled value="Value"></ld-input>
-
 <!-- React component -->
 
 <LdInput placeholder="Placeholder" disabled />
-
-<LdInput disabled value="Value" />
 
 <!-- CSS component -->
 
 <div class="ld-input ld-input--disabled">
   <input placeholder="Placeholder" disabled>
-</div>
-
-<div class="ld-input ld-input--disabled">
-  <input placeholder="Placeholder" value="Value" disabled>
 </div>
 {% endexample %}
 
@@ -78,13 +78,9 @@ By default, the `ld-input` component is of [type `text`](https://developer.mozil
 {% example %}
 <ld-input placeholder="Placeholder" aria-disabled="true"></ld-input>
 
-<ld-input aria-disabled="true" value="Value"></ld-input>
-
 <!-- React component -->
 
 <LdInput placeholder="Placeholder" aria-disabled="true" />
-
-<LdInput aria-disabled="true" value="Value" />
 
 <!-- CSS component -->
 
@@ -95,23 +91,15 @@ By default, the `ld-input` component is of [type `text`](https://developer.mozil
     id="focusable-disabled-input-1">
 </div>
 
-<div class="ld-input ld-input--disabled">
-  <input
-    placeholder="Placeholder"
-    value="Value"
-    aria-disabled="true"
-    id="focusable-disabled-input-2">
-</div>
-
 <!-- Example code for input prevention on aria-disabled input elements -->
 <script>
-  const inputs = document.querySelectorAll('#focusable-disabled-input-1, #focusable-disabled-input-2')
-  Array.from(inputs).forEach(input => {
-    const initialValue = input.value
-    input.addEventListener('input', () => {
-      input.value = initialValue
-    })
+;(() => {
+  const input = document.currentScript.previousElementSibling.querySelector('input')
+  const initialValue = input.value
+  input.addEventListener('input', () => {
+    input.value = initialValue
   })
+})()
 </script>
 {% endexample %}
 
@@ -128,22 +116,14 @@ By default, the `ld-input` component is of [type `text`](https://developer.mozil
 {% example '{ "background": "light" }' %}
 <ld-input tone="dark" placeholder="Placeholder"></ld-input>
 
-<ld-input tone="dark" placeholder="Placeholder" disabled></ld-input>
-
 <!-- React component -->
 
 <LdInput tone="dark" placeholder="Placeholder" />
-
-<LdInput tone="dark" placeholder="Placeholder" disabled />
 
 <!-- CSS component -->
 
 <div class="ld-input ld-input--dark">
   <input placeholder="Placeholder">
-</div>
-
-<div class="ld-input ld-input--dark ld-input--disabled">
-  <input placeholder="Placeholder" disabled>
 </div>
 {% endexample %}
 
@@ -216,11 +196,98 @@ Triggerts associated keyboard in supporting browsers and devices with dynamic ke
 ### Type file
 
 {% example %}
-<ld-input placeholder="Your profile image" type="file" accept="image/png, image/jpeg"></ld-input>
+<ld-input placeholder="Your profile picture" type="file" accept="image/png, image/jpeg"></ld-input>
 
 <!-- React component -->
 
-<LdInput placeholder="Your profile image" type="file" accept="image/png, image/jpeg" />
+<LdInput placeholder="Your profile picture" type="file" accept="image/png, image/jpeg" />
+{% endexample %}
+
+#### Handling files
+
+If you are using the `ld-input` component within a `form` and are posting the form, there is no need to access the selected files and the underlying data, because they are submitted as part of the form data automatically.
+
+However, if you want to compose the form data yourself or want to read the files on the client side, you can do so using the `ldinputfile` or `ldchangefile` events.
+
+{% example %}
+<ld-input
+  placeholder="Your profile picture"
+  type="file"
+  accept="image/png, image/jpeg"
+></ld-input>
+
+<script>
+  ;(() => {
+    const ldInput = document.currentScript.previousElementSibling
+    ldInput.addEventListener('ldchangefile', async (ev) => {
+      const files = ev.detail // as FileList
+      if (!files.length) return
+
+      // Read the file on the client side.
+      const fileReader = new FileReader()
+      fileReader.readAsDataURL(files[0])
+      fileReader.onerror = (progressEvent) => {
+        // Handle error...
+      }
+      fileReader.onloadend = (progressEvent) => {
+        // Use file data...
+      }
+
+      // Or post the file to the server.
+      const data = new FormData()
+      data.append('userpic', files[0])
+      const requestOptions = {
+        method: 'POST',
+        body: data,
+      }
+      try {
+        await fetch('/api/user/profile/picture', {
+          method: 'POST',
+          body: data,
+        })
+        // success!
+      } catch (err) {
+        // Handle error...
+      }
+    })
+  })()
+</script>
+
+<!-- React component -->
+
+<LdInput
+  placeholder="Your profile picture"
+  type="file"
+  accept="image/png, image/jpeg"
+  onLdchangefile={async (ev) => {
+    const files = ev.detail
+    if (!files.length) return
+
+    // Read the file on the client side.
+    const fileReader = new FileReader()
+    fileReader.readAsDataURL(files[0])
+    fileReader.onerror = (progressEvent) => {
+      // Handle error...
+    }
+    fileReader.onloadend = (progressEvent) => {
+      // Use file data...
+    }
+
+    // Or post the file to the server.
+    const data = new FormData()
+    data.append('userpic', files[0])
+    const requestOptions = {
+      method: 'POST',
+      body: data,
+    }
+    try {
+      await fetch('/api/user/profile/picture', requestOptions)
+      // success!
+    } catch (err) {
+      // Handle error...
+    }
+  }}
+/>
 {% endexample %}
 
 ### Type number
@@ -572,19 +639,6 @@ You can use [slots](components/ld-input/#slots) in order to add static or intera
 #### With icon
 
 {% example %}
-<ld-input placeholder="Placeholder" size="sm">
-  <ld-icon name="placeholder" slot="end"></ld-icon>
-</ld-input>
-
-<ld-input placeholder="Placeholder" size="sm">
-  <ld-icon name="placeholder" slot="start"></ld-icon>
-</ld-input>
-
-<ld-input placeholder="Placeholder" size="sm">
-  <ld-icon name="placeholder" slot="start"></ld-icon>
-  <ld-icon name="placeholder" slot="end"></ld-icon>
-</ld-input>
-
 <ld-input placeholder="Placeholder">
   <ld-icon name="placeholder" slot="end"></ld-icon>
 </ld-input>
@@ -594,38 +648,12 @@ You can use [slots](components/ld-input/#slots) in order to add static or intera
 </ld-input>
 
 <ld-input placeholder="Placeholder">
-  <ld-icon name="placeholder" slot="start"></ld-icon>
-  <ld-icon name="placeholder" slot="end"></ld-icon>
-</ld-input>
-
-<ld-input placeholder="Placeholder" size="lg">
-  <ld-icon name="placeholder" slot="end"></ld-icon>
-</ld-input>
-
-<ld-input placeholder="Placeholder" size="lg">
-  <ld-icon name="placeholder" slot="start"></ld-icon>
-</ld-input>
-
-<ld-input placeholder="Placeholder" size="lg">
   <ld-icon name="placeholder" slot="start"></ld-icon>
   <ld-icon name="placeholder" slot="end"></ld-icon>
 </ld-input>
 
 <!-- React component -->
 
-<LdInput placeholder="Placeholder" size="sm">
-  <LdIcon name="placeholder" slot="end" />
-</LdInput>
-
-<LdInput placeholder="Placeholder" size="sm">
-  <LdIcon name="placeholder" slot="start" />
-</LdInput>
-
-<LdInput placeholder="Placeholder" size="sm">
-  <LdIcon name="placeholder" slot="start" />
-  <LdIcon name="placeholder" slot="end" />
-</LdInput>
-
 <LdInput placeholder="Placeholder">
   <LdIcon name="placeholder" slot="end" />
 </LdInput>
@@ -635,65 +663,12 @@ You can use [slots](components/ld-input/#slots) in order to add static or intera
 </LdInput>
 
 <LdInput placeholder="Placeholder">
-  <LdIcon name="placeholder" slot="start" />
-  <LdIcon name="placeholder" slot="end" />
-</LdInput>
-
-<LdInput placeholder="Placeholder" size="lg">
-  <LdIcon name="placeholder" slot="end" />
-</LdInput>
-
-<LdInput placeholder="Placeholder" size="lg">
-  <LdIcon name="placeholder" slot="start" />
-</LdInput>
-
-<LdInput placeholder="Placeholder" size="lg">
   <LdIcon name="placeholder" slot="start" />
   <LdIcon name="placeholder" slot="end" />
 </LdInput>
 
 <!-- CSS component -->
 
-<div class="ld-input ld-input--sm">
-  <input placeholder="Placeholder">
-  <span class="ld-icon ld-icon--sm">
-    <svg viewBox="0 0 24 24" fill="none">
-      <title>Text</title>
-      <rect x="1.5" y="1.5" width="21" height="21" rx="4.5" stroke="currentColor" stroke-width="3"/>
-      <circle cx="12" cy="12" r="4.5" stroke="currentColor" stroke-width="3"/>
-    </svg>
-  </span>
-</div>
-
-<div class="ld-input ld-input--sm">
-  <span class="ld-icon ld-icon--sm">
-    <svg viewBox="0 0 24 24" fill="none">
-      <title>Text</title>
-      <rect x="1.5" y="1.5" width="21" height="21" rx="4.5" stroke="currentColor" stroke-width="3"/>
-      <circle cx="12" cy="12" r="4.5" stroke="currentColor" stroke-width="3"/>
-    </svg>
-  </span>
-  <input placeholder="Placeholder">
-</div>
-
-<div class="ld-input ld-input--sm">
-  <span class="ld-icon ld-icon--sm">
-    <svg viewBox="0 0 24 24" fill="none">
-      <title>Text</title>
-      <rect x="1.5" y="1.5" width="21" height="21" rx="4.5" stroke="currentColor" stroke-width="3"/>
-      <circle cx="12" cy="12" r="4.5" stroke="currentColor" stroke-width="3"/>
-    </svg>
-  </span>
-  <input placeholder="Placeholder">
-  <span class="ld-icon ld-icon--sm">
-    <svg viewBox="0 0 24 24" fill="none">
-      <title>Text</title>
-      <rect x="1.5" y="1.5" width="21" height="21" rx="4.5" stroke="currentColor" stroke-width="3"/>
-      <circle cx="12" cy="12" r="4.5" stroke="currentColor" stroke-width="3"/>
-    </svg>
-  </span>
-</div>
-
 <div class="ld-input">
   <input placeholder="Placeholder">
   <span class="ld-icon">
@@ -726,46 +701,6 @@ You can use [slots](components/ld-input/#slots) in order to add static or intera
   </span>
   <input placeholder="Placeholder">
   <span class="ld-icon">
-    <svg viewBox="0 0 24 24" fill="none">
-      <title>Text</title>
-      <rect x="1.5" y="1.5" width="21" height="21" rx="4.5" stroke="currentColor" stroke-width="3"/>
-      <circle cx="12" cy="12" r="4.5" stroke="currentColor" stroke-width="3"/>
-    </svg>
-  </span>
-</div>
-
-<div class="ld-input ld-input--lg">
-  <input placeholder="Placeholder">
-  <span class="ld-icon ld-icon--lg">
-    <svg viewBox="0 0 24 24" fill="none">
-      <title>Text</title>
-      <rect x="1.5" y="1.5" width="21" height="21" rx="4.5" stroke="currentColor" stroke-width="3"/>
-      <circle cx="12" cy="12" r="4.5" stroke="currentColor" stroke-width="3"/>
-    </svg>
-  </span>
-</div>
-
-<div class="ld-input ld-input--lg">
-  <span class="ld-icon ld-icon--lg">
-    <svg viewBox="0 0 24 24" fill="none">
-      <title>Text</title>
-      <rect x="1.5" y="1.5" width="21" height="21" rx="4.5" stroke="currentColor" stroke-width="3"/>
-      <circle cx="12" cy="12" r="4.5" stroke="currentColor" stroke-width="3"/>
-    </svg>
-  </span>
-  <input placeholder="Placeholder">
-</div>
-
-<div class="ld-input ld-input--lg">
-  <span class="ld-icon ld-icon--lg">
-    <svg viewBox="0 0 24 24" fill="none">
-      <title>Text</title>
-      <rect x="1.5" y="1.5" width="21" height="21" rx="4.5" stroke="currentColor" stroke-width="3"/>
-      <circle cx="12" cy="12" r="4.5" stroke="currentColor" stroke-width="3"/>
-    </svg>
-  </span>
-  <input placeholder="Placeholder">
-  <span class="ld-icon ld-icon--lg">
     <svg viewBox="0 0 24 24" fill="none">
       <title>Text</title>
       <rect x="1.5" y="1.5" width="21" height="21" rx="4.5" stroke="currentColor" stroke-width="3"/>
@@ -782,18 +717,6 @@ You can use [slots](components/ld-input/#slots) in order to add static or intera
 #### With button
 
 {% example %}
-<ld-input placeholder="Placeholder" size="sm">
-  <ld-button slot="end" aria-label="Submit" >
-    <ld-icon name="placeholder"></ld-icon>
-  </ld-button>
-</ld-input>
-
-<ld-input placeholder="Placeholder" size="sm">
-  <ld-button slot="end" >
-    Submit <ld-icon name="placeholder"></ld-icon>
-  </ld-button>
-</ld-input>
-
 <ld-input placeholder="Placeholder">
   <ld-button slot="end" aria-label="Submit">
     <ld-icon name="placeholder"></ld-icon>
@@ -801,18 +724,6 @@ You can use [slots](components/ld-input/#slots) in order to add static or intera
 </ld-input>
 
 <ld-input placeholder="Placeholder">
-  <ld-button slot="end">
-    Submit <ld-icon name="placeholder"></ld-icon>
-  </ld-button>
-</ld-input>
-
-<ld-input placeholder="Placeholder" size="lg">
-  <ld-button slot="end" aria-label="Submit">
-    <ld-icon name="placeholder"></ld-icon>
-  </ld-button>
-</ld-input>
-
-<ld-input placeholder="Placeholder" size="lg">
   <ld-button slot="end">
     Submit <ld-icon name="placeholder"></ld-icon>
   </ld-button>
@@ -820,18 +731,6 @@ You can use [slots](components/ld-input/#slots) in order to add static or intera
 
 <!-- React component -->
 
-<LdInput placeholder="Placeholder" size="sm">
-  <LdButton slot="end" aria-label="Submit" >
-    <LdIcon name="placeholder" />
-  </LdButton>
-</LdInput>
-
-<LdInput placeholder="Placeholder" size="sm">
-  <LdButton slot="end" >
-    Submit <LdIcon name="placeholder" />
-  </LdButton>
-</LdInput>
-
 <LdInput placeholder="Placeholder">
   <LdButton slot="end" aria-label="Submit">
     <LdIcon name="placeholder" />
@@ -839,49 +738,12 @@ You can use [slots](components/ld-input/#slots) in order to add static or intera
 </LdInput>
 
 <LdInput placeholder="Placeholder">
-  <LdButton slot="end">
-    Submit <LdIcon name="placeholder" />
-  </LdButton>
-</LdInput>
-
-<LdInput placeholder="Placeholder" size="lg">
-  <LdButton slot="end" aria-label="Submit">
-    <LdIcon name="placeholder" />
-  </LdButton>
-</LdInput>
-
-<LdInput placeholder="Placeholder" size="lg">
   <LdButton slot="end">
     Submit <LdIcon name="placeholder" />
   </LdButton>
 </LdInput>
 
 <!-- CSS component -->
-
-<div class="ld-input ld-input--sm">
-  <input placeholder="Placeholder">
-  <button class="ld-button ld-button--sm" aria-label="Submit">
-    <span class="ld-icon ld-icon--sm">
-      <svg viewBox="0 0 24 24" fill="none">
-        <rect x="1.5" y="1.5" width="21" height="21" rx="4.5" stroke="currentColor" stroke-width="3"/>
-        <circle cx="12" cy="12" r="4.5" stroke="currentColor" stroke-width="3"/>
-      </svg>
-    </span>
-  </button>
-</div>
-
-<div class="ld-input ld-input--sm">
-  <input placeholder="Placeholder">
-  <button class="ld-button ld-button--sm">
-    Submit
-    <span class="ld-icon ld-icon--sm">
-      <svg viewBox="0 0 24 24" fill="none">
-        <rect x="1.5" y="1.5" width="21" height="21" rx="4.5" stroke="currentColor" stroke-width="3"/>
-        <circle cx="12" cy="12" r="4.5" stroke="currentColor" stroke-width="3"/>
-      </svg>
-    </span>
-  </button>
-</div>
 
 <div class="ld-input">
   <input placeholder="Placeholder">
@@ -907,57 +769,11 @@ You can use [slots](components/ld-input/#slots) in order to add static or intera
     </span>
   </button>
 </div>
-
-<div class="ld-input ld-input--lg">
-  <input placeholder="Placeholder">
-  <button class="ld-button ld-button--lg" aria-label="Submit">
-    <span class="ld-icon ld-icon--lg">
-      <svg viewBox="0 0 24 24" fill="none">
-        <rect x="1.5" y="1.5" width="21" height="21" rx="4.5" stroke="currentColor" stroke-width="3"/>
-        <circle cx="12" cy="12" r="4.5" stroke="currentColor" stroke-width="3"/>
-      </svg>
-    </span>
-  </button>
-</div>
-
-<div class="ld-input ld-input--lg">
-  <input placeholder="Placeholder">
-  <button class="ld-button ld-button--lg">
-    Submit
-    <span class="ld-icon ld-icon--lg">
-      <svg viewBox="0 0 24 24" fill="none">
-        <rect x="1.5" y="1.5" width="21" height="21" rx="4.5" stroke="currentColor" stroke-width="3"/>
-        <circle cx="12" cy="12" r="4.5" stroke="currentColor" stroke-width="3"/>
-      </svg>
-    </span>
-  </button>
-</div>
 {% endexample %}
 
 #### With ghost button
 
 {% example %}
-<ld-input placeholder="Placeholder" size="sm">
-  <ld-button mode="ghost" slot="end" aria-label="Submit">
-    <ld-icon name="placeholder"></ld-icon>
-  </ld-button>
-</ld-input>
-
-<ld-input placeholder="Placeholder" size="sm">
-  <ld-button mode="ghost" slot="start" aria-label="Submit">
-    <ld-icon name="placeholder"></ld-icon>
-  </ld-button>
-</ld-input>
-
-<ld-input placeholder="Placeholder" size="sm">
-  <ld-button mode="ghost" slot="start" aria-label="Submit">
-    <ld-icon name="placeholder"></ld-icon>
-  </ld-button>
-  <ld-button mode="ghost" slot="end" aria-label="Submit">
-    <ld-icon name="placeholder"></ld-icon>
-  </ld-button>
-</ld-input>
-
 <ld-input placeholder="Placeholder">
   <ld-button mode="ghost" slot="end" aria-label="Submit">
     <ld-icon name="placeholder"></ld-icon>
@@ -971,27 +787,6 @@ You can use [slots](components/ld-input/#slots) in order to add static or intera
 </ld-input>
 
 <ld-input placeholder="Placeholder">
-  <ld-button mode="ghost" slot="start" aria-label="Submit">
-    <ld-icon name="placeholder"></ld-icon>
-  </ld-button>
-  <ld-button mode="ghost" slot="end" aria-label="Submit">
-    <ld-icon name="placeholder"></ld-icon>
-  </ld-button>
-</ld-input>
-
-<ld-input placeholder="Placeholder" size="lg">
-  <ld-button mode="ghost" slot="end" aria-label="Submit">
-    <ld-icon name="placeholder"></ld-icon>
-  </ld-button>
-</ld-input>
-
-<ld-input placeholder="Placeholder" size="lg">
-  <ld-button mode="ghost" slot="start" aria-label="Submit">
-    <ld-icon name="placeholder"></ld-icon>
-  </ld-button>
-</ld-input>
-
-<ld-input placeholder="Placeholder" size="lg">
   <ld-button mode="ghost" slot="start" aria-label="Submit">
     <ld-icon name="placeholder"></ld-icon>
   </ld-button>
@@ -1002,27 +797,6 @@ You can use [slots](components/ld-input/#slots) in order to add static or intera
 
 <!-- React component -->
 
-<LdInput placeholder="Placeholder" size="sm">
-  <LdButton mode="ghost" slot="end" aria-label="Submit">
-    <LdIcon name="placeholder" />
-  </LdButton>
-</LdInput>
-
-<LdInput placeholder="Placeholder" size="sm">
-  <LdButton mode="ghost" slot="start" aria-label="Submit">
-    <LdIcon name="placeholder" />
-  </LdButton>
-</LdInput>
-
-<LdInput placeholder="Placeholder" size="sm">
-  <LdButton mode="ghost" slot="start" aria-label="Submit">
-    <LdIcon name="placeholder" />
-  </LdButton>
-  <LdButton mode="ghost" slot="end" aria-label="Submit">
-    <LdIcon name="placeholder" />
-  </LdButton>
-</LdInput>
-
 <LdInput placeholder="Placeholder">
   <LdButton mode="ghost" slot="end" aria-label="Submit">
     <LdIcon name="placeholder" />
@@ -1036,27 +810,6 @@ You can use [slots](components/ld-input/#slots) in order to add static or intera
 </LdInput>
 
 <LdInput placeholder="Placeholder">
-  <LdButton mode="ghost" slot="start" aria-label="Submit">
-    <LdIcon name="placeholder" />
-  </LdButton>
-  <LdButton mode="ghost" slot="end" aria-label="Submit">
-    <LdIcon name="placeholder" />
-  </LdButton>
-</LdInput>
-
-<LdInput placeholder="Placeholder" size="lg">
-  <LdButton mode="ghost" slot="end" aria-label="Submit">
-    <LdIcon name="placeholder" />
-  </LdButton>
-</LdInput>
-
-<LdInput placeholder="Placeholder" size="lg">
-  <LdButton mode="ghost" slot="start" aria-label="Submit">
-    <LdIcon name="placeholder" />
-  </LdButton>
-</LdInput>
-
-<LdInput placeholder="Placeholder" size="lg">
   <LdButton mode="ghost" slot="start" aria-label="Submit">
     <LdIcon name="placeholder" />
   </LdButton>
@@ -1067,50 +820,6 @@ You can use [slots](components/ld-input/#slots) in order to add static or intera
 
 <!-- CSS component -->
 
-<div class="ld-input ld-input--sm">
-  <input placeholder="Placeholder">
-  <button class="ld-button ld-button--sm ld-button--ghost" aria-label="Submit">
-    <span class="ld-icon ld-icon--sm">
-      <svg viewBox="0 0 24 24" fill="none">
-        <rect x="1.5" y="1.5" width="21" height="21" rx="4.5" stroke="currentColor" stroke-width="3"/>
-        <circle cx="12" cy="12" r="4.5" stroke="currentColor" stroke-width="3"/>
-      </svg>
-    </span>
-  </button>
-</div>
-
-<div class="ld-input ld-input--sm">
-  <button class="ld-button ld-button--sm ld-button--ghost" aria-label="Submit">
-    <span class="ld-icon ld-icon--sm">
-      <svg viewBox="0 0 24 24" fill="none">
-        <rect x="1.5" y="1.5" width="21" height="21" rx="4.5" stroke="currentColor" stroke-width="3"/>
-        <circle cx="12" cy="12" r="4.5" stroke="currentColor" stroke-width="3"/>
-      </svg>
-    </span>
-  </button>
-  <input placeholder="Placeholder">
-</div>
-
-<div class="ld-input ld-input--sm">
-  <button class="ld-button ld-button--sm ld-button--ghost" aria-label="Submit">
-    <span class="ld-icon ld-icon--sm">
-      <svg viewBox="0 0 24 24" fill="none">
-        <rect x="1.5" y="1.5" width="21" height="21" rx="4.5" stroke="currentColor" stroke-width="3"/>
-        <circle cx="12" cy="12" r="4.5" stroke="currentColor" stroke-width="3"/>
-      </svg>
-    </span>
-  </button>
-  <input placeholder="Placeholder">
-  <button class="ld-button ld-button--sm ld-button--ghost" aria-label="Submit">
-    <span class="ld-icon ld-icon--sm">
-      <svg viewBox="0 0 24 24" fill="none">
-        <rect x="1.5" y="1.5" width="21" height="21" rx="4.5" stroke="currentColor" stroke-width="3"/>
-        <circle cx="12" cy="12" r="4.5" stroke="currentColor" stroke-width="3"/>
-      </svg>
-    </span>
-  </button>
-</div>
-
 <div class="ld-input">
   <input placeholder="Placeholder">
   <button class="ld-button ld-button--ghost" aria-label="Submit">
@@ -1147,50 +856,6 @@ You can use [slots](components/ld-input/#slots) in order to add static or intera
   <input placeholder="Placeholder">
   <button class="ld-button ld-button--ghost" aria-label="Submit">
     <span class="ld-icon">
-      <svg viewBox="0 0 24 24" fill="none">
-        <rect x="1.5" y="1.5" width="21" height="21" rx="4.5" stroke="currentColor" stroke-width="3"/>
-        <circle cx="12" cy="12" r="4.5" stroke="currentColor" stroke-width="3"/>
-      </svg>
-    </span>
-  </button>
-</div>
-
-<div class="ld-input ld-input--lg">
-  <input placeholder="Placeholder">
-  <button class="ld-button ld-button--lg ld-button--ghost" aria-label="Submit">
-    <span class="ld-icon ld-icon--lg">
-      <svg viewBox="0 0 24 24" fill="none">
-        <rect x="1.5" y="1.5" width="21" height="21" rx="4.5" stroke="currentColor" stroke-width="3"/>
-        <circle cx="12" cy="12" r="4.5" stroke="currentColor" stroke-width="3"/>
-      </svg>
-    </span>
-  </button>
-</div>
-
-<div class="ld-input ld-input--lg">
-  <button class="ld-button ld-button--lg ld-button--ghost" aria-label="Submit">
-    <span class="ld-icon ld-icon--lg">
-      <svg viewBox="0 0 24 24" fill="none">
-        <rect x="1.5" y="1.5" width="21" height="21" rx="4.5" stroke="currentColor" stroke-width="3"/>
-        <circle cx="12" cy="12" r="4.5" stroke="currentColor" stroke-width="3"/>
-      </svg>
-    </span>
-  </button>
-  <input placeholder="Placeholder">
-</div>
-
-<div class="ld-input ld-input--lg">
-  <button class="ld-button ld-button--lg ld-button--ghost" aria-label="Submit">
-    <span class="ld-icon ld-icon--lg">
-      <svg viewBox="0 0 24 24" fill="none">
-        <rect x="1.5" y="1.5" width="21" height="21" rx="4.5" stroke="currentColor" stroke-width="3"/>
-        <circle cx="12" cy="12" r="4.5" stroke="currentColor" stroke-width="3"/>
-      </svg>
-    </span>
-  </button>
-  <input placeholder="Placeholder">
-  <button class="ld-button ld-button--lg ld-button--ghost" aria-label="Submit">
-    <span class="ld-icon ld-icon--lg">
       <svg viewBox="0 0 24 24" fill="none">
         <rect x="1.5" y="1.5" width="21" height="21" rx="4.5" stroke="currentColor" stroke-width="3"/>
         <circle cx="12" cy="12" r="4.5" stroke="currentColor" stroke-width="3"/>
@@ -1278,10 +943,10 @@ understanding on how they can be used together.
 
 ## Events
 
-| Event      | Description                                                       | Type                  |
-| ---------- | ----------------------------------------------------------------- | --------------------- |
-| `ldchange` | Emitted when the input value changed and the element loses focus. | `CustomEvent<string>` |
-| `ldinput`  | Emitted when the input value changed.                             | `CustomEvent<string>` |
+| Event      | Description                                                       | Type                              |
+| ---------- | ----------------------------------------------------------------- | --------------------------------- |
+| `ldchange` | Emitted when the input value changed and the element loses focus. | `CustomEvent<FileList \| string>` |
+| `ldinput`  | Emitted when the input value changed.                             | `CustomEvent<FileList \| string>` |
 
 
 ## Methods

--- a/src/liquid/components/ld-input/test/__snapshots__/ld-input.spec.ts.snap
+++ b/src/liquid/components/ld-input/test/__snapshots__/ld-input.spec.ts.snap
@@ -244,7 +244,63 @@ exports[`ld-input renders with value 1`] = `
 </ld-input>
 `;
 
-exports[`ld-input sets size on ld-button css component 1`] = `
+exports[`ld-input sets size lg ld-icon css component 1`] = `
+<ld-input class="ld-input ld-input--lg" size="lg">
+  <mock:shadow-root>
+    <slot name="start"></slot>
+    <input part="input focusable" size="lg">
+    <slot name="end"></slot>
+  </mock:shadow-root>
+  <svg class="ld-icon ld-icon--lg" slot="start"></svg>
+  <svg class="ld-icon ld-icon--lg" slot="end"></svg>
+</ld-input>
+`;
+
+exports[`ld-input sets size lg on ld-button css component 1`] = `
+<ld-input class="ld-input ld-input--lg" size="lg">
+  <mock:shadow-root>
+    <slot name="start"></slot>
+    <input part="input focusable" size="lg">
+    <slot name="end"></slot>
+  </mock:shadow-root>
+  <button class="ld-button ld-button--lg" slot="start">
+    X
+  </button>
+  <button class="ld-button ld-button--lg" slot="end">
+    Y
+  </button>
+</ld-input>
+`;
+
+exports[`ld-input sets size lg on ld-button web component 1`] = `
+<ld-input class="ld-input ld-input--lg" size="lg">
+  <mock:shadow-root>
+    <slot name="start"></slot>
+    <input part="input focusable" size="lg">
+    <slot name="end"></slot>
+  </mock:shadow-root>
+  <ld-button size="lg" slot="start">
+    X
+  </ld-button>
+  <ld-button size="lg" slot="end">
+    Y
+  </ld-button>
+</ld-input>
+`;
+
+exports[`ld-input sets size lg on ld-icon web component 1`] = `
+<ld-input class="ld-input ld-input--lg" size="lg">
+  <mock:shadow-root>
+    <slot name="start"></slot>
+    <input part="input focusable" size="lg">
+    <slot name="end"></slot>
+  </mock:shadow-root>
+  <ld-icon name="placeholder" size="lg" slot="start"></ld-icon>
+  <ld-icon name="placeholder" size="lg" slot="end"></ld-icon>
+</ld-input>
+`;
+
+exports[`ld-input sets size sm on ld-button css component 1`] = `
 <ld-input class="ld-input ld-input--sm" size="sm">
   <mock:shadow-root>
     <slot name="start"></slot>
@@ -260,7 +316,7 @@ exports[`ld-input sets size on ld-button css component 1`] = `
 </ld-input>
 `;
 
-exports[`ld-input sets size on ld-button web component 1`] = `
+exports[`ld-input sets size sm on ld-button web component 1`] = `
 <ld-input class="ld-input ld-input--sm" size="sm">
   <mock:shadow-root>
     <slot name="start"></slot>
@@ -276,7 +332,7 @@ exports[`ld-input sets size on ld-button web component 1`] = `
 </ld-input>
 `;
 
-exports[`ld-input sets size on ld-icon css component 1`] = `
+exports[`ld-input sets size sm on ld-icon css component 1`] = `
 <ld-input class="ld-input ld-input--sm" size="sm">
   <mock:shadow-root>
     <slot name="start"></slot>
@@ -288,7 +344,7 @@ exports[`ld-input sets size on ld-icon css component 1`] = `
 </ld-input>
 `;
 
-exports[`ld-input sets size on ld-icon web component 1`] = `
+exports[`ld-input sets size sm on ld-icon web component 1`] = `
 <ld-input class="ld-input ld-input--sm" size="sm">
   <mock:shadow-root>
     <slot name="start"></slot>

--- a/src/liquid/components/ld-input/test/ld-input.spec.ts
+++ b/src/liquid/components/ld-input/test/ld-input.spec.ts
@@ -105,7 +105,7 @@ describe('ld-input', () => {
     expect(ldchangeHandler).toHaveBeenCalledTimes(1)
   })
 
-  it('emits ldchange event with file list', async () => {
+  it('allows accessing files via readonly files prop', async () => {
     const page = await newSpecPage({
       components: [LdInput],
       html: `<ld-input type="file" />`,
@@ -114,16 +114,36 @@ describe('ld-input', () => {
     const input = ldInput.shadowRoot.querySelector('input')
     input.files = ['foo', 'bar'] as unknown as FileList
 
-    const ldchangefileHandler = jest.fn()
-    ldInput.addEventListener('ldchangefile', ldchangefileHandler)
+    const ldchangeHandler = jest.fn()
+    ldInput.addEventListener('ldchange', ldchangeHandler)
 
-    input.value = 'test'
     input.dispatchEvent(new InputEvent('change', { bubbles: true }))
     await page.waitForChanges()
 
-    expect(ldchangefileHandler).toHaveBeenCalledWith(
-      expect.objectContaining({ detail: ['foo', 'bar'] })
+    expect(ldchangeHandler).toHaveBeenCalled()
+    expect(ldInput.files).toEqual(['foo', 'bar'])
+  })
+
+  it('throws when trying to alter readonly files prop', async () => {
+    const page = await newSpecPage({
+      components: [LdInput],
+      html: `<ld-input />`,
+    })
+    const ldInput = page.root
+    const fn = () => {
+      ldInput.files = []
+    }
+    expect(fn).toThrow(
+      'Cannot set property files of [object Object] which has only a getter'
     )
+  })
+
+  it('returns undefined when accassing files if input type is not file', async () => {
+    const page = await newSpecPage({
+      components: [LdInput],
+      html: `<ld-input type="file" />`,
+    })
+    expect(page.root.files).toEqual(undefined)
   })
 
   // TODO: Uncomment, as soon as Stencil's JSDom implementation
@@ -166,29 +186,6 @@ describe('ld-input', () => {
     await page.waitForChanges()
 
     expect(ldinputHandler).toHaveBeenCalledTimes(1)
-  })
-
-  it('emits ldinput event with file list', async () => {
-    const page = await newSpecPage({
-      components: [LdInput],
-      html: `<ld-input type="file" />`,
-    })
-    const ldInput = page.root
-    const input = ldInput.shadowRoot.querySelector('input')
-    input.files = ['foo', 'bar'] as unknown as FileList
-
-    const ldinputfileHandler = jest.fn()
-    ldInput.addEventListener('ldinputfile', ldinputfileHandler)
-
-    input.value = 'test'
-    input.dispatchEvent(
-      new InputEvent('input', { bubbles: true, composed: true })
-    )
-    await page.waitForChanges()
-
-    expect(ldinputfileHandler).toHaveBeenCalledWith(
-      expect.objectContaining({ detail: ['foo', 'bar'] })
-    )
   })
 
   it('renders with slot start', async () => {

--- a/src/liquid/components/ld-input/test/ld-input.spec.ts
+++ b/src/liquid/components/ld-input/test/ld-input.spec.ts
@@ -105,6 +105,27 @@ describe('ld-input', () => {
     expect(ldchangeHandler).toHaveBeenCalledTimes(1)
   })
 
+  it('emits ldchange event with file list', async () => {
+    const page = await newSpecPage({
+      components: [LdInput],
+      html: `<ld-input type="file" />`,
+    })
+    const ldInput = page.root
+    const input = ldInput.shadowRoot.querySelector('input')
+    input.files = ['foo', 'bar'] as unknown as FileList
+
+    const ldchangefileHandler = jest.fn()
+    ldInput.addEventListener('ldchangefile', ldchangefileHandler)
+
+    input.value = 'test'
+    input.dispatchEvent(new InputEvent('change', { bubbles: true }))
+    await page.waitForChanges()
+
+    expect(ldchangefileHandler).toHaveBeenCalledWith(
+      expect.objectContaining({ detail: ['foo', 'bar'] })
+    )
+  })
+
   // TODO: Uncomment, as soon as Stencil's JSDom implementation
   // supports bubbling of composed events into the light DOM.
   xit('emits input event', async () => {
@@ -145,6 +166,29 @@ describe('ld-input', () => {
     await page.waitForChanges()
 
     expect(ldinputHandler).toHaveBeenCalledTimes(1)
+  })
+
+  it('emits ldinput event with file list', async () => {
+    const page = await newSpecPage({
+      components: [LdInput],
+      html: `<ld-input type="file" />`,
+    })
+    const ldInput = page.root
+    const input = ldInput.shadowRoot.querySelector('input')
+    input.files = ['foo', 'bar'] as unknown as FileList
+
+    const ldinputfileHandler = jest.fn()
+    ldInput.addEventListener('ldinputfile', ldinputfileHandler)
+
+    input.value = 'test'
+    input.dispatchEvent(
+      new InputEvent('input', { bubbles: true, composed: true })
+    )
+    await page.waitForChanges()
+
+    expect(ldinputfileHandler).toHaveBeenCalledWith(
+      expect.objectContaining({ detail: ['foo', 'bar'] })
+    )
   })
 
   it('renders with slot start', async () => {
@@ -191,6 +235,25 @@ describe('ld-input', () => {
     const page = await newSpecPage({
       components: [LdInput],
       html: `<ld-input><span slot="end"><span id="banana">🍌</span></span></ld-input>`,
+    })
+    const ldInput = page.root
+    const banana = ldInput.querySelector('#banana') as HTMLElement
+    const input = ldInput.shadowRoot.querySelector('input')
+
+    const doc = ldInput.shadowRoot as unknown as { activeElement: Element }
+    doc.activeElement = input
+
+    input.focus = jest.fn()
+    banana.dispatchEvent(new Event('click', { bubbles: true }))
+    ldInput.dispatchEvent(new Event('click'))
+
+    expect(input.focus).not.toHaveBeenCalled()
+  })
+
+  it('does not focus the input on click of non-interactive elment inside the component if disabled', async () => {
+    const page = await newSpecPage({
+      components: [LdInput],
+      html: `<ld-input disabled><span slot="end"><span id="banana">🍌</span></span></ld-input>`,
     })
     const ldInput = page.root
     const banana = ldInput.querySelector('#banana') as HTMLElement
@@ -308,7 +371,7 @@ describe('ld-input', () => {
     expect(page.root).toMatchSnapshot()
   })
 
-  it('sets size on ld-icon web component', async () => {
+  it('sets size sm on ld-icon web component', async () => {
     const page = await newSpecPage({
       components: [LdInput],
       html: `<ld-input size="sm">
@@ -319,12 +382,34 @@ describe('ld-input', () => {
     expect(page.root).toMatchSnapshot()
   })
 
-  it('sets size on ld-icon css component', async () => {
+  it('sets size lg on ld-icon web component', async () => {
+    const page = await newSpecPage({
+      components: [LdInput],
+      html: `<ld-input size="lg">
+        <ld-icon name="placeholder" slot="start"></ld-icon>
+        <ld-icon name="placeholder" size="sm" slot="end"></ld-icon>
+      </ld-input>`,
+    })
+    expect(page.root).toMatchSnapshot()
+  })
+
+  it('sets size sm on ld-icon css component', async () => {
     const page = await newSpecPage({
       components: [LdInput],
       html: `<ld-input size="sm">
         <svg class="ld-icon" slot="start"></svg>
         <svg class="ld-icon ld-icon--lg" slot="end"></svg>
+      </ld-input>`,
+    })
+    expect(page.root).toMatchSnapshot()
+  })
+
+  it('sets size lg ld-icon css component', async () => {
+    const page = await newSpecPage({
+      components: [LdInput],
+      html: `<ld-input size="lg">
+        <svg class="ld-icon" slot="start"></svg>
+        <svg class="ld-icon ld-icon--sm" slot="end"></svg>
       </ld-input>`,
     })
     expect(page.root).toMatchSnapshot()
@@ -352,7 +437,7 @@ describe('ld-input', () => {
     expect(page.root).toMatchSnapshot()
   })
 
-  it('sets size on ld-button web component', async () => {
+  it('sets size sm on ld-button web component', async () => {
     const page = await newSpecPage({
       components: [LdInput],
       html: `<ld-input size="sm">
@@ -363,12 +448,34 @@ describe('ld-input', () => {
     expect(page.root).toMatchSnapshot()
   })
 
-  it('sets size on ld-button css component', async () => {
+  it('sets size lg on ld-button web component', async () => {
+    const page = await newSpecPage({
+      components: [LdInput],
+      html: `<ld-input size="lg">
+        <ld-button slot="start">X</ld-button>
+        <ld-button size="sm" slot="end">Y</ld-button>
+      </ld-input>`,
+    })
+    expect(page.root).toMatchSnapshot()
+  })
+
+  it('sets size sm on ld-button css component', async () => {
     const page = await newSpecPage({
       components: [LdInput],
       html: `<ld-input size="sm">
         <button class="ld-button" slot="start">X</button>
         <button class="ld-button ld-button--lg" slot="end">Y</button>
+      </ld-input>`,
+    })
+    expect(page.root).toMatchSnapshot()
+  })
+
+  it('sets size lg on ld-button css component', async () => {
+    const page = await newSpecPage({
+      components: [LdInput],
+      html: `<ld-input size="lg">
+        <button class="ld-button" slot="start">X</button>
+        <button class="ld-button ld-button--sm" slot="end">Y</button>
       </ld-input>`,
     })
     expect(page.root).toMatchSnapshot()
@@ -453,6 +560,25 @@ describe('ld-input', () => {
     expect(root).toMatchSnapshot()
   })
 
+  it('replaces hidden input field with clone of input field of type file', async () => {
+    const { root, waitForChanges } = await newSpecPage({
+      components: [LdInput],
+      html: `<ld-input type="file" name="example" form="example-form" />`,
+    })
+    const hiddenInput = root.querySelector('input')
+    hiddenInput.replaceWith = jest.fn()
+
+    const inputInShadow = root.shadowRoot.querySelector('input')
+    expect(inputInShadow.type).toEqual('file')
+    inputInShadow.value = 'foo.txt'
+    inputInShadow.files = ['foo'] as unknown as FileList
+    expect(inputInShadow.files).toEqual(['foo'])
+    inputInShadow.dispatchEvent(new Event('input'))
+    await waitForChanges()
+
+    expect(hiddenInput.replaceWith).toHaveBeenCalled()
+  })
+
   it('updates hidden input field attributes', async () => {
     const { root, waitForChanges } = await newSpecPage({
       components: [LdInput],
@@ -535,6 +661,22 @@ describe('ld-input', () => {
     )
 
     expect(form.requestSubmit).toHaveBeenCalled()
+  })
+
+  it('does not requests submit on enter with aria-disabled set to true', async () => {
+    const { body, root } = await newSpecPage({
+      components: [LdInput],
+      html: `<form><ld-input name="example" aria-disabled="true" /></form>`,
+    })
+
+    const form = body.querySelector('form')
+    form.requestSubmit = jest.fn()
+    const input = root.shadowRoot.querySelector('input')
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
+    )
+
+    expect(form.requestSubmit).not.toHaveBeenCalled()
   })
 
   it('requests submit on enter, if form attribute is given', async () => {


### PR DESCRIPTION
# Description

This pull request adds two event emitters to the `ld-input` component, emitted when the component has the `type` prop set to `'file'`. The detail property of the custom events contains the file data, which is necessary to read the files on client side via the FileReader API, or to create a FormData object and send it to a server.

## Type of change

- [x] Feature

## Is it a breaking change?

- [x] No

# How Has This Been Tested?

- [x] unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes
