### PR TITLE
fix: add patch to fully specify resolve path in stencil output targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,8 @@ log.txt
 .vscode/
 .sass-cache/
 .versions/
-.yarn/
+.yarn/*
+!.yarn/patches
 node_modules/
 coverage/
 tmp/

--- a/.yarn/patches/@stencil-react-output-target-npm-0.3.1-4da13663f2.patch
+++ b/.yarn/patches/@stencil-react-output-target-npm-0.3.1-4da13663f2.patch
@@ -1,0 +1,482 @@
+diff --git a/dist/index.cjs.js b/dist/index.cjs.js
+index ed803c547b18555f83d05c0f6b8880207ed34bb5..9013c7e3552e3e297eee3102dbe158a089060176 100644
+--- a/dist/index.cjs.js
++++ b/dist/index.cjs.js
+@@ -161,7 +161,7 @@ function generateProxies(config, components, pkgData, outputTarget, rootDir) {
+     const imports = `/* eslint-disable */
+ /* tslint:disable */
+ /* auto-generated react proxies */
+-import { createReactComponent } from './react-component-lib';\n`;
++import { createReactComponent } from './react-component-lib/index.js';\n`;
+     /**
+      * Generate JSX import type from correct location.
+      * When using custom elements build, we need to import from
+@@ -170,7 +170,9 @@ import { createReactComponent } from './react-component-lib';\n`;
+      */
+     const generateTypeImports = () => {
+         if (outputTarget.componentCorePackage !== undefined) {
+-            const dirPath = outputTarget.includeImportCustomElements ? `/${outputTarget.customElementsDir || 'components'}` : '';
++            const dirPath = outputTarget.includeImportCustomElements
++                ? `/${outputTarget.customElementsDir || 'components'}`
++                : '';
+             return `import type { ${IMPORT_TYPES} } from '${normalizePath(outputTarget.componentCorePackage)}${dirPath}';\n`;
+         }
+         return `import type { ${IMPORT_TYPES} } from '${normalizePath(componentsTypeFile)}';\n`;
+@@ -184,10 +186,9 @@ import { createReactComponent } from './react-component-lib';\n`;
+      * Component that takes in the Web Component as a parameter.
+      */
+     if (outputTarget.includeImportCustomElements && outputTarget.componentCorePackage !== undefined) {
+-        const cmpImports = components.map(component => {
++        const cmpImports = components.map((component) => {
+             const pascalImport = dashToPascalCase(component.tagName);
+-            return `import { defineCustomElement as define${pascalImport} } from '${normalizePath(outputTarget.componentCorePackage)}/${outputTarget.customElementsDir ||
+-                'components'}/${component.tagName}.js';`;
++            return `import { defineCustomElement as define${pascalImport} } from '${normalizePath(outputTarget.componentCorePackage)}/${outputTarget.customElementsDir || 'components'}/${component.tagName}.js';`;
+         });
+         sourceImports = cmpImports.join('\n');
+     }
+@@ -204,7 +205,9 @@ import { createReactComponent } from './react-component-lib';\n`;
+         typeImports,
+         sourceImports,
+         registerCustomElements,
+-        components.map(cmpMeta => createComponentDefinition(cmpMeta, outputTarget.includeImportCustomElements)).join('\n'),
++        components
++            .map((cmpMeta) => createComponentDefinition(cmpMeta, outputTarget.includeImportCustomElements))
++            .join('\n'),
+     ];
+     return final.join('\n') + '\n';
+ }
+@@ -222,9 +225,7 @@ function createComponentDefinition(cmpMeta, includeCustomElement = false) {
+         template += `, undefined, undefined, define${tagNameAsPascal}`;
+     }
+     template += `);`;
+-    return [
+-        template
+-    ];
++    return [template];
+ }
+ /**
+  * Copy resources used to generate the Stencil-React bindings. The resources copied here are not specific a project's
+@@ -261,9 +262,7 @@ function getPathToCorePackageLoader(config, outputTarget) {
+     const distAbsEsmLoaderPath = (distOutputTarget === null || distOutputTarget === void 0 ? void 0 : distOutputTarget.esmLoaderPath) && path__default['default'].isAbsolute(distOutputTarget.esmLoaderPath)
+         ? distOutputTarget.esmLoaderPath
+         : null;
+-    const distRelEsmLoaderPath = config.rootDir && distAbsEsmLoaderPath
+-        ? path__default['default'].relative(config.rootDir, distAbsEsmLoaderPath)
+-        : null;
++    const distRelEsmLoaderPath = config.rootDir && distAbsEsmLoaderPath ? path__default['default'].relative(config.rootDir, distAbsEsmLoaderPath) : null;
+     const loaderDir = outputTarget.loaderDir || distRelEsmLoaderPath || DEFAULT_LOADER_DIR;
+     return normalizePath(path__default['default'].join(basePkg, loaderDir));
+ }
+diff --git a/dist/index.d.ts b/dist/index.d.ts
+index f4fce6b403df1f833bf216c50e19fd52568e6f02..9a76ec911ab4b6400a282abb21555d12e7758af6 100644
+--- a/dist/index.d.ts
++++ b/dist/index.d.ts
+@@ -1,2 +1,2 @@
+-export { reactOutputTarget } from './plugin';
++export { reactOutputTarget } from './plugin.js';
+ export type { OutputTargetReact } from './types';
+diff --git a/dist/index.js b/dist/index.js
+index 280cba2bee732cbc879a9001e4cb376d1d6bc2a7..c5b221e94cad5b3adddf5cc2843f87b91218f106 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -152,7 +152,7 @@ function generateProxies(config, components, pkgData, outputTarget, rootDir) {
+     const imports = `/* eslint-disable */
+ /* tslint:disable */
+ /* auto-generated react proxies */
+-import { createReactComponent } from './react-component-lib';\n`;
++import { createReactComponent } from './react-component-lib/index.js';\n`;
+     /**
+      * Generate JSX import type from correct location.
+      * When using custom elements build, we need to import from
+@@ -161,7 +161,9 @@ import { createReactComponent } from './react-component-lib';\n`;
+      */
+     const generateTypeImports = () => {
+         if (outputTarget.componentCorePackage !== undefined) {
+-            const dirPath = outputTarget.includeImportCustomElements ? `/${outputTarget.customElementsDir || 'components'}` : '';
++            const dirPath = outputTarget.includeImportCustomElements
++                ? `/${outputTarget.customElementsDir || 'components'}`
++                : '';
+             return `import type { ${IMPORT_TYPES} } from '${normalizePath(outputTarget.componentCorePackage)}${dirPath}';\n`;
+         }
+         return `import type { ${IMPORT_TYPES} } from '${normalizePath(componentsTypeFile)}';\n`;
+@@ -175,10 +177,9 @@ import { createReactComponent } from './react-component-lib';\n`;
+      * Component that takes in the Web Component as a parameter.
+      */
+     if (outputTarget.includeImportCustomElements && outputTarget.componentCorePackage !== undefined) {
+-        const cmpImports = components.map(component => {
++        const cmpImports = components.map((component) => {
+             const pascalImport = dashToPascalCase(component.tagName);
+-            return `import { defineCustomElement as define${pascalImport} } from '${normalizePath(outputTarget.componentCorePackage)}/${outputTarget.customElementsDir ||
+-                'components'}/${component.tagName}.js';`;
++            return `import { defineCustomElement as define${pascalImport} } from '${normalizePath(outputTarget.componentCorePackage)}/${outputTarget.customElementsDir || 'components'}/${component.tagName}.js';`;
+         });
+         sourceImports = cmpImports.join('\n');
+     }
+@@ -195,7 +196,9 @@ import { createReactComponent } from './react-component-lib';\n`;
+         typeImports,
+         sourceImports,
+         registerCustomElements,
+-        components.map(cmpMeta => createComponentDefinition(cmpMeta, outputTarget.includeImportCustomElements)).join('\n'),
++        components
++            .map((cmpMeta) => createComponentDefinition(cmpMeta, outputTarget.includeImportCustomElements))
++            .join('\n'),
+     ];
+     return final.join('\n') + '\n';
+ }
+@@ -213,9 +216,7 @@ function createComponentDefinition(cmpMeta, includeCustomElement = false) {
+         template += `, undefined, undefined, define${tagNameAsPascal}`;
+     }
+     template += `);`;
+-    return [
+-        template
+-    ];
++    return [template];
+ }
+ /**
+  * Copy resources used to generate the Stencil-React bindings. The resources copied here are not specific a project's
+@@ -252,9 +253,7 @@ function getPathToCorePackageLoader(config, outputTarget) {
+     const distAbsEsmLoaderPath = (distOutputTarget === null || distOutputTarget === void 0 ? void 0 : distOutputTarget.esmLoaderPath) && path.isAbsolute(distOutputTarget.esmLoaderPath)
+         ? distOutputTarget.esmLoaderPath
+         : null;
+-    const distRelEsmLoaderPath = config.rootDir && distAbsEsmLoaderPath
+-        ? path.relative(config.rootDir, distAbsEsmLoaderPath)
+-        : null;
++    const distRelEsmLoaderPath = config.rootDir && distAbsEsmLoaderPath ? path.relative(config.rootDir, distAbsEsmLoaderPath) : null;
+     const loaderDir = outputTarget.loaderDir || distRelEsmLoaderPath || DEFAULT_LOADER_DIR;
+     return normalizePath(path.join(basePkg, loaderDir));
+ }
+diff --git a/dist/output-react.js b/dist/output-react.js
+index 43284218127e75e9dd599aabf313eed04a3bb46a..8c39e0b81deead89abee3a77e03d055022ecf39b 100644
+--- a/dist/output-react.js
++++ b/dist/output-react.js
+@@ -1,5 +1,5 @@
+ import path from 'path';
+-import { dashToPascalCase, normalizePath, readPackageJson, relativeImport, sortBy } from './utils';
++import { dashToPascalCase, normalizePath, readPackageJson, relativeImport, sortBy } from './utils.js';
+ /**
+  * Generate and write the Stencil-React bindings to disc
+  * @param config the Stencil configuration associated with the project
+@@ -41,7 +41,7 @@ export function generateProxies(config, components, pkgData, outputTarget, rootD
+     const imports = `/* eslint-disable */
+ /* tslint:disable */
+ /* auto-generated react proxies */
+-import { createReactComponent } from './react-component-lib';\n`;
++import { createReactComponent } from './react-component-lib/index.js';\n`;
+     /**
+      * Generate JSX import type from correct location.
+      * When using custom elements build, we need to import from
+@@ -50,7 +50,9 @@ import { createReactComponent } from './react-component-lib';\n`;
+      */
+     const generateTypeImports = () => {
+         if (outputTarget.componentCorePackage !== undefined) {
+-            const dirPath = outputTarget.includeImportCustomElements ? `/${outputTarget.customElementsDir || 'components'}` : '';
++            const dirPath = outputTarget.includeImportCustomElements
++                ? `/${outputTarget.customElementsDir || 'components'}`
++                : '';
+             return `import type { ${IMPORT_TYPES} } from '${normalizePath(outputTarget.componentCorePackage)}${dirPath}';\n`;
+         }
+         return `import type { ${IMPORT_TYPES} } from '${normalizePath(componentsTypeFile)}';\n`;
+@@ -64,10 +66,9 @@ import { createReactComponent } from './react-component-lib';\n`;
+      * Component that takes in the Web Component as a parameter.
+      */
+     if (outputTarget.includeImportCustomElements && outputTarget.componentCorePackage !== undefined) {
+-        const cmpImports = components.map(component => {
++        const cmpImports = components.map((component) => {
+             const pascalImport = dashToPascalCase(component.tagName);
+-            return `import { defineCustomElement as define${pascalImport} } from '${normalizePath(outputTarget.componentCorePackage)}/${outputTarget.customElementsDir ||
+-                'components'}/${component.tagName}.js';`;
++            return `import { defineCustomElement as define${pascalImport} } from '${normalizePath(outputTarget.componentCorePackage)}/${outputTarget.customElementsDir || 'components'}/${component.tagName}.js';`;
+         });
+         sourceImports = cmpImports.join('\n');
+     }
+@@ -84,7 +85,9 @@ import { createReactComponent } from './react-component-lib';\n`;
+         typeImports,
+         sourceImports,
+         registerCustomElements,
+-        components.map(cmpMeta => createComponentDefinition(cmpMeta, outputTarget.includeImportCustomElements)).join('\n'),
++        components
++            .map((cmpMeta) => createComponentDefinition(cmpMeta, outputTarget.includeImportCustomElements))
++            .join('\n'),
+     ];
+     return final.join('\n') + '\n';
+ }
+@@ -102,9 +105,7 @@ export function createComponentDefinition(cmpMeta, includeCustomElement = false)
+         template += `, undefined, undefined, define${tagNameAsPascal}`;
+     }
+     template += `);`;
+-    return [
+-        template
+-    ];
++    return [template];
+ }
+ /**
+  * Copy resources used to generate the Stencil-React bindings. The resources copied here are not specific a project's
+@@ -141,9 +142,7 @@ export function getPathToCorePackageLoader(config, outputTarget) {
+     const distAbsEsmLoaderPath = (distOutputTarget === null || distOutputTarget === void 0 ? void 0 : distOutputTarget.esmLoaderPath) && path.isAbsolute(distOutputTarget.esmLoaderPath)
+         ? distOutputTarget.esmLoaderPath
+         : null;
+-    const distRelEsmLoaderPath = config.rootDir && distAbsEsmLoaderPath
+-        ? path.relative(config.rootDir, distAbsEsmLoaderPath)
+-        : null;
++    const distRelEsmLoaderPath = config.rootDir && distAbsEsmLoaderPath ? path.relative(config.rootDir, distAbsEsmLoaderPath) : null;
+     const loaderDir = outputTarget.loaderDir || distRelEsmLoaderPath || DEFAULT_LOADER_DIR;
+     return normalizePath(path.join(basePkg, loaderDir));
+ }
+diff --git a/dist/plugin.js b/dist/plugin.js
+index dea591d26435b314e486b298069bb6bded38e235..50c1bae5c1317fdbed359fc4798975b64d91e708 100644
+--- a/dist/plugin.js
++++ b/dist/plugin.js
+@@ -1,5 +1,5 @@
+-import { normalizePath } from './utils';
+-import { reactProxyOutput } from './output-react';
++import { normalizePath } from './utils.js';
++import { reactProxyOutput } from './output-react.js';
+ import path from 'path';
+ /**
+  * Creates an output target for binding Stencil components to be used in a React context
+diff --git a/dist/utils.d.ts b/dist/utils.d.ts
+index a6e82ac4ace09226744dc46284b3196fc748552d..67abef52069beda8794790dd23e2b660e535ec8b 100644
+--- a/dist/utils.d.ts
++++ b/dist/utils.d.ts
+@@ -11,12 +11,6 @@ export declare const toLowerCase: (str: string) => string;
+  * @returns the PascalCased string
+  */
+ export declare const dashToPascalCase: (str: string) => string;
+-/**
+- * Flattens a two-dimensional array into a one dimensional array
+- * @param array the array to flatten
+- * @returns the flattened array
+- */
+-export declare function flatOne<T>(array: T[][]): T[];
+ /**
+  * Sorts a provided array by a property belonging to an item that exists on each item in the array
+  * @param array the array to sort
+diff --git a/dist/utils.js b/dist/utils.js
+index 6ebe086777f44235e60a9e75aebcde515a7ef862..8460721dd7d391bb0cf1b5dcc0c9204154eaf314 100644
+--- a/dist/utils.js
++++ b/dist/utils.js
+@@ -17,21 +17,6 @@ export const dashToPascalCase = (str) => toLowerCase(str)
+     .split('-')
+     .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+     .join('');
+-// TODO(STENCIL-356): Investigate removing this unused function
+-/**
+- * Flattens a two-dimensional array into a one dimensional array
+- * @param array the array to flatten
+- * @returns the flattened array
+- */
+-export function flatOne(array) {
+-    if (array.flat) {
+-        return array.flat(1);
+-    }
+-    return array.reduce((result, item) => {
+-        result.push(...item);
+-        return result;
+-    }, []);
+-}
+ /**
+  * Sorts a provided array by a property belonging to an item that exists on each item in the array
+  * @param array the array to sort
+diff --git a/react-component-lib/createComponent.tsx b/react-component-lib/createComponent.tsx
+index 723baa9f74247872379c35c0364cc78b6764aa05..7e1d1ef7dbbe2d2ffdc4be351053998b7bbd8252 100644
+--- a/react-component-lib/createComponent.tsx
++++ b/react-component-lib/createComponent.tsx
+@@ -1,13 +1,6 @@
+ import React, { createElement } from 'react';
+ 
+-import {
+-  attachProps,
+-  camelToDashCase,
+-  createForwardRef,
+-  dashToPascalCase,
+-  isCoveredByReact,
+-  mergeRefs,
+-} from './utils';
++import { attachProps, camelToDashCase, createForwardRef, dashToPascalCase, isCoveredByReact, mergeRefs } from './utils/index.js';
+ 
+ export interface HTMLStencilElement extends HTMLElement {
+   componentOnReady(): Promise<this>;
+@@ -28,9 +21,9 @@ export const createReactComponent = <
+   ReactComponentContext?: React.Context<ContextStateType>,
+   manipulatePropsFunction?: (
+     originalProps: StencilReactInternalProps<ElementType>,
+-    propsToPass: any,
++    propsToPass: any
+   ) => ExpandedPropsTypes,
+-  defineCustomElement?: () => void,
++  defineCustomElement?: () => void
+ ) => {
+   if (defineCustomElement !== undefined) {
+     defineCustomElement();
+@@ -77,7 +70,7 @@ export const createReactComponent = <
+           }
+         }
+         return acc;
+-      }, {});
++      }, {} as ExpandedPropsTypes);
+ 
+       if (manipulatePropsFunction) {
+         propsToPass = manipulatePropsFunction(this.props, propsToPass);
+diff --git a/react-component-lib/createOverlayComponent.tsx b/react-component-lib/createOverlayComponent.tsx
+index 3203c0deaf02cee90ff9c4616a8929fd144c547a..8a96c0303cbdb028bac149cc09cb3091ee5cd3a3 100644
+--- a/react-component-lib/createOverlayComponent.tsx
++++ b/react-component-lib/createOverlayComponent.tsx
+@@ -2,13 +2,7 @@ import React from 'react';
+ import ReactDOM from 'react-dom';
+ 
+ import { OverlayEventDetail } from './interfaces';
+-import {
+-  StencilReactForwardedRef,
+-  attachProps,
+-  dashToPascalCase,
+-  defineCustomElement,
+-  setRef,
+-} from './utils';
++import { StencilReactForwardedRef, attachProps, dashToPascalCase, defineCustomElement, setRef } from './utils/index.js';
+ 
+ interface OverlayElement extends HTMLElement {
+   present: () => Promise<void>;
+@@ -24,10 +18,7 @@ export interface ReactOverlayProps {
+   onWillPresent?: (event: CustomEvent<OverlayEventDetail>) => void;
+ }
+ 
+-export const createOverlayComponent = <
+-  OverlayComponent extends object,
+-  OverlayType extends OverlayElement
+->(
++export const createOverlayComponent = <OverlayComponent extends object, OverlayType extends OverlayElement>(
+   tagName: string,
+   controller: { create: (options: any) => Promise<OverlayType> },
+   customElement?: any
+@@ -79,7 +70,7 @@ export const createOverlayComponent = <
+       if (this.props.onDidDismiss) {
+         this.props.onDidDismiss(event);
+       }
+-      setRef(this.props.forwardedRef, null)
++      setRef(this.props.forwardedRef, null);
+     }
+ 
+     shouldComponentUpdate(nextProps: Props) {
+@@ -113,25 +104,14 @@ export const createOverlayComponent = <
+     }
+ 
+     async present(prevProps?: Props) {
+-      const {
+-        children,
+-        isOpen,
+-        onDidDismiss,
+-        onDidPresent,
+-        onWillDismiss,
+-        onWillPresent,
+-        ...cProps
+-      } = this.props;
++      const { children, isOpen, onDidDismiss, onDidPresent, onWillDismiss, onWillPresent, ...cProps } = this.props;
+       const elementProps = {
+         ...cProps,
+         ref: this.props.forwardedRef,
+         [didDismissEventName]: this.handleDismiss,
+-        [didPresentEventName]: (e: CustomEvent) =>
+-          this.props.onDidPresent && this.props.onDidPresent(e),
+-        [willDismissEventName]: (e: CustomEvent) =>
+-          this.props.onWillDismiss && this.props.onWillDismiss(e),
+-        [willPresentEventName]: (e: CustomEvent) =>
+-          this.props.onWillPresent && this.props.onWillPresent(e),
++        [didPresentEventName]: (e: CustomEvent) => this.props.onDidPresent && this.props.onDidPresent(e),
++        [willDismissEventName]: (e: CustomEvent) => this.props.onWillDismiss && this.props.onWillDismiss(e),
++        [willPresentEventName]: (e: CustomEvent) => this.props.onWillPresent && this.props.onWillPresent(e),
+       };
+ 
+       this.overlay = await controller.create({
+diff --git a/react-component-lib/index.ts b/react-component-lib/index.ts
+index 85e81ad196c6d8c5dd7076a3b57bc3afbb434b0d..611f53c9483eedc6672f03d6ee43d4b705bff381 100644
+--- a/react-component-lib/index.ts
++++ b/react-component-lib/index.ts
+@@ -1,2 +1,2 @@
+-export { createReactComponent } from './createComponent';
+-export { createOverlayComponent } from './createOverlayComponent';
++export { createReactComponent } from './createComponent.js';
++export { createOverlayComponent } from './createOverlayComponent.js';
+diff --git a/react-component-lib/utils/attachProps.ts b/react-component-lib/utils/attachProps.ts
+index de2cc499b200f76ea3f4aef1474f5c567631e7c2..26edcbe308b3b3c81b387db9154af7b2940b2057 100644
+--- a/react-component-lib/utils/attachProps.ts
++++ b/react-component-lib/utils/attachProps.ts
+@@ -1,4 +1,4 @@
+-import { camelToDashCase } from './case';
++import { camelToDashCase } from './case.js';
+ 
+ export const attachProps = (node: HTMLElement, newProps: any, oldProps: any = {}) => {
+   // some test frameworks don't render DOM elements, so we test here to make sure we are dealing with DOM first
+diff --git a/react-component-lib/utils/case.ts b/react-component-lib/utils/case.ts
+index 047704f13dff4a2d4a1f3674c84bfa7972950fcd..786689dc984f3ea0959fe3499ff795410b02b117 100644
+--- a/react-component-lib/utils/case.ts
++++ b/react-component-lib/utils/case.ts
+@@ -4,5 +4,4 @@ export const dashToPascalCase = (str: string) =>
+     .split('-')
+     .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+     .join('');
+-export const camelToDashCase = (str: string) =>
+-  str.replace(/([A-Z])/g, (m: string) => `-${m[0].toLowerCase()}`);
++export const camelToDashCase = (str: string) => str.replace(/([A-Z])/g, (m: string) => `-${m[0].toLowerCase()}`);
+diff --git a/react-component-lib/utils/index.tsx b/react-component-lib/utils/index.tsx
+index 821d067433c36569bcb7dd057ef00f11ed49236f..428ca59138cac669043443e845136c945904ab3b 100644
+--- a/react-component-lib/utils/index.tsx
++++ b/react-component-lib/utils/index.tsx
+@@ -11,10 +11,10 @@ export type StencilReactForwardedRef<T> = ((instance: T | null) => void) | React
+ 
+ export const setRef = (ref: StencilReactForwardedRef<any> | React.Ref<any> | undefined, value: any) => {
+   if (typeof ref === 'function') {
+-    ref(value)
++    ref(value);
+   } else if (ref != null) {
+     // Cast as a MutableRef so we can assign current
+-    (ref as React.MutableRefObject<any>).current = value
++    (ref as React.MutableRefObject<any>).current = value;
+   }
+ };
+ 
+@@ -22,19 +22,16 @@ export const mergeRefs = (
+   ...refs: (StencilReactForwardedRef<any> | React.Ref<any> | undefined)[]
+ ): React.RefCallback<any> => {
+   return (value: any) => {
+-    refs.forEach(ref => {
+-      setRef(ref, value)
+-    })
+-  }
++    refs.forEach((ref) => {
++      setRef(ref, value);
++    });
++  };
+ };
+ 
+-export const createForwardRef = <PropType, ElementType>(
+-  ReactComponent: any,
+-  displayName: string,
+-) => {
++export const createForwardRef = <PropType, ElementType>(ReactComponent: any, displayName: string) => {
+   const forwardRef = (
+     props: StencilReactExternalProps<PropType, ElementType>,
+-    ref: StencilReactForwardedRef<ElementType>,
++    ref: StencilReactForwardedRef<ElementType>
+   ) => {
+     return <ReactComponent {...props} forwardedRef={ref} />;
+   };
+@@ -44,14 +41,10 @@ export const createForwardRef = <PropType, ElementType>(
+ };
+ 
+ export const defineCustomElement = (tagName: string, customElement: any) => {
+-  if (
+-    customElement !== undefined &&
+-    typeof customElements !== 'undefined' &&
+-    !customElements.get(tagName)
+-  ) {
++  if (customElement !== undefined && typeof customElements !== 'undefined' && !customElements.get(tagName)) {
+     customElements.define(tagName, customElement);
+   }
+-}
++};
+ 
+-export * from './attachProps';
+-export * from './case';
++export * from './attachProps.js';
++export * from './case.js';

--- a/.yarn/patches/@stencil-vue-output-target-npm-0.6.2-a9b3828cb9.patch
+++ b/.yarn/patches/@stencil-vue-output-target-npm-0.6.2-a9b3828cb9.patch
@@ -1,0 +1,273 @@
+diff --git a/dist/generate-vue-component.js b/dist/generate-vue-component.js
+index f92d53a2caa5d462194440120a551bd3d6f24f22..370c840d054f66d1c56f3303efe10ac8bf3c4f77 100644
+--- a/dist/generate-vue-component.js
++++ b/dist/generate-vue-component.js
+@@ -1,20 +1,17 @@
+-import { dashToPascalCase } from './utils';
++import { dashToPascalCase } from './utils.js';
+ export const createComponentDefinition = (importTypes, componentModelConfig, includeCustomElement = false) => (cmpMeta) => {
+     const tagNameAsPascal = dashToPascalCase(cmpMeta.tagName);
+-    const importAs = (includeCustomElement) ? 'define' + tagNameAsPascal : 'undefined';
++    const importAs = includeCustomElement ? 'define' + tagNameAsPascal : 'undefined';
+     let props = [];
+     if (Array.isArray(cmpMeta.properties) && cmpMeta.properties.length > 0) {
+         props = cmpMeta.properties.map((prop) => `'${prop.name}'`);
+     }
+     if (Array.isArray(cmpMeta.events) && cmpMeta.events.length > 0) {
+-        props = [
+-            ...props,
+-            ...cmpMeta.events.map((event) => `'${event.name}'`)
+-        ];
++        props = [...props, ...cmpMeta.events.map((event) => `'${event.name}'`)];
+     }
+     let templateString = `
+ export const ${tagNameAsPascal} = /*@__PURE__*/ defineContainer<${importTypes}.${tagNameAsPascal}>('${cmpMeta.tagName}', ${importAs}`;
+-    const findModel = componentModelConfig && componentModelConfig.find(config => config.elements.includes(cmpMeta.tagName));
++    const findModel = componentModelConfig && componentModelConfig.find((config) => config.elements.includes(cmpMeta.tagName));
+     if (props.length > 0) {
+         templateString += `, [
+   ${props.length > 0 ? props.join(',\n  ') : ''}
+diff --git a/dist/index.cjs.js b/dist/index.cjs.js
+index ce0fad05e3bfe0e6bec389a96060e00617daf410..7a7cfaaa65070251d9c26de47d918c7818152e21 100644
+--- a/dist/index.cjs.js
++++ b/dist/index.cjs.js
+@@ -89,20 +89,17 @@ const SLASH_REGEX = /\\/g;
+ 
+ const createComponentDefinition = (importTypes, componentModelConfig, includeCustomElement = false) => (cmpMeta) => {
+     const tagNameAsPascal = dashToPascalCase(cmpMeta.tagName);
+-    const importAs = (includeCustomElement) ? 'define' + tagNameAsPascal : 'undefined';
++    const importAs = includeCustomElement ? 'define' + tagNameAsPascal : 'undefined';
+     let props = [];
+     if (Array.isArray(cmpMeta.properties) && cmpMeta.properties.length > 0) {
+         props = cmpMeta.properties.map((prop) => `'${prop.name}'`);
+     }
+     if (Array.isArray(cmpMeta.events) && cmpMeta.events.length > 0) {
+-        props = [
+-            ...props,
+-            ...cmpMeta.events.map((event) => `'${event.name}'`)
+-        ];
++        props = [...props, ...cmpMeta.events.map((event) => `'${event.name}'`)];
+     }
+     let templateString = `
+ export const ${tagNameAsPascal} = /*@__PURE__*/ defineContainer<${importTypes}.${tagNameAsPascal}>('${cmpMeta.tagName}', ${importAs}`;
+-    const findModel = componentModelConfig && componentModelConfig.find(config => config.elements.includes(cmpMeta.tagName));
++    const findModel = componentModelConfig && componentModelConfig.find((config) => config.elements.includes(cmpMeta.tagName));
+     if (props.length > 0) {
+         templateString += `, [
+   ${props.length > 0 ? props.join(',\n  ') : ''}
+@@ -161,22 +158,23 @@ function generateProxies(config, components, pkgData, outputTarget, rootDir) {
+     const imports = `/* eslint-disable */
+ /* tslint:disable */
+ /* auto-generated vue proxies */
+-import { defineContainer } from './vue-component-lib/utils';\n`;
++import { defineContainer } from './vue-component-lib/utils.js';\n`;
+     const generateTypeImports = () => {
+         if (outputTarget.componentCorePackage !== undefined) {
+-            const dirPath = outputTarget.includeImportCustomElements ? `/${outputTarget.customElementsDir || 'components'}` : '';
++            const dirPath = outputTarget.includeImportCustomElements
++                ? `/${outputTarget.customElementsDir || 'components'}`
++                : '';
+             return `import type { ${IMPORT_TYPES} } from '${normalizePath(outputTarget.componentCorePackage)}${dirPath}';\n`;
+         }
+-        return `import type { ${IMPORT_TYPES} } from '${normalizePath(componentsTypeFile)}';\n`;
++        return `import type { ${IMPORT_TYPES} } from '${normalizePath(componentsTypeFile)}.js';\n`;
+     };
+     const typeImports = generateTypeImports();
+     let sourceImports = '';
+     let registerCustomElements = '';
+     if (outputTarget.includeImportCustomElements && outputTarget.componentCorePackage !== undefined) {
+-        const cmpImports = components.map(component => {
++        const cmpImports = components.map((component) => {
+             const pascalImport = dashToPascalCase(component.tagName);
+-            return `import { defineCustomElement as define${pascalImport} } from '${normalizePath(outputTarget.componentCorePackage)}/${outputTarget.customElementsDir ||
+-                'components'}/${component.tagName}.js';`;
++            return `import { defineCustomElement as define${pascalImport} } from '${normalizePath(outputTarget.componentCorePackage)}/${outputTarget.customElementsDir || 'components'}/${component.tagName}.js';`;
+         });
+         sourceImports = cmpImports.join('\n');
+     }
+@@ -221,9 +219,7 @@ function getPathToCorePackageLoader(config, outputTarget) {
+     const distAbsEsmLoaderPath = (distOutputTarget === null || distOutputTarget === void 0 ? void 0 : distOutputTarget.esmLoaderPath) && path__default['default'].isAbsolute(distOutputTarget.esmLoaderPath)
+         ? distOutputTarget.esmLoaderPath
+         : null;
+-    const distRelEsmLoaderPath = config.rootDir && distAbsEsmLoaderPath
+-        ? path__default['default'].relative(config.rootDir, distAbsEsmLoaderPath)
+-        : null;
++    const distRelEsmLoaderPath = config.rootDir && distAbsEsmLoaderPath ? path__default['default'].relative(config.rootDir, distAbsEsmLoaderPath) : null;
+     const loaderDir = outputTarget.loaderDir || distRelEsmLoaderPath || DEFAULT_LOADER_DIR;
+     return normalizePath(path__default['default'].join(basePkg, loaderDir));
+ }
+diff --git a/dist/index.d.ts b/dist/index.d.ts
+index 26cb893e90a3fc9a0a2ea3ce598196d7f99ffc59..535829157b12216bd0f2651ab209549ad923c1c8 100644
+--- a/dist/index.d.ts
++++ b/dist/index.d.ts
+@@ -1,2 +1,2 @@
+-export { vueOutputTarget } from './plugin';
++export { vueOutputTarget } from './plugin.js';
+ export type { OutputTargetVue, ComponentModelConfig } from './types';
+diff --git a/dist/index.js b/dist/index.js
+index aa686db09e35a595b65bee010034c3f4f7517001..bec938e6e85923f00c83d24d02260012cc294cd4 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -80,20 +80,17 @@ const SLASH_REGEX = /\\/g;
+ 
+ const createComponentDefinition = (importTypes, componentModelConfig, includeCustomElement = false) => (cmpMeta) => {
+     const tagNameAsPascal = dashToPascalCase(cmpMeta.tagName);
+-    const importAs = (includeCustomElement) ? 'define' + tagNameAsPascal : 'undefined';
++    const importAs = includeCustomElement ? 'define' + tagNameAsPascal : 'undefined';
+     let props = [];
+     if (Array.isArray(cmpMeta.properties) && cmpMeta.properties.length > 0) {
+         props = cmpMeta.properties.map((prop) => `'${prop.name}'`);
+     }
+     if (Array.isArray(cmpMeta.events) && cmpMeta.events.length > 0) {
+-        props = [
+-            ...props,
+-            ...cmpMeta.events.map((event) => `'${event.name}'`)
+-        ];
++        props = [...props, ...cmpMeta.events.map((event) => `'${event.name}'`)];
+     }
+     let templateString = `
+ export const ${tagNameAsPascal} = /*@__PURE__*/ defineContainer<${importTypes}.${tagNameAsPascal}>('${cmpMeta.tagName}', ${importAs}`;
+-    const findModel = componentModelConfig && componentModelConfig.find(config => config.elements.includes(cmpMeta.tagName));
++    const findModel = componentModelConfig && componentModelConfig.find((config) => config.elements.includes(cmpMeta.tagName));
+     if (props.length > 0) {
+         templateString += `, [
+   ${props.length > 0 ? props.join(',\n  ') : ''}
+@@ -152,22 +149,23 @@ function generateProxies(config, components, pkgData, outputTarget, rootDir) {
+     const imports = `/* eslint-disable */
+ /* tslint:disable */
+ /* auto-generated vue proxies */
+-import { defineContainer } from './vue-component-lib/utils';\n`;
++import { defineContainer } from './vue-component-lib/utils.js';\n`;
+     const generateTypeImports = () => {
+         if (outputTarget.componentCorePackage !== undefined) {
+-            const dirPath = outputTarget.includeImportCustomElements ? `/${outputTarget.customElementsDir || 'components'}` : '';
++            const dirPath = outputTarget.includeImportCustomElements
++                ? `/${outputTarget.customElementsDir || 'components'}`
++                : '';
+             return `import type { ${IMPORT_TYPES} } from '${normalizePath(outputTarget.componentCorePackage)}${dirPath}';\n`;
+         }
+-        return `import type { ${IMPORT_TYPES} } from '${normalizePath(componentsTypeFile)}';\n`;
++        return `import type { ${IMPORT_TYPES} } from '${normalizePath(componentsTypeFile)}.js';\n`;
+     };
+     const typeImports = generateTypeImports();
+     let sourceImports = '';
+     let registerCustomElements = '';
+     if (outputTarget.includeImportCustomElements && outputTarget.componentCorePackage !== undefined) {
+-        const cmpImports = components.map(component => {
++        const cmpImports = components.map((component) => {
+             const pascalImport = dashToPascalCase(component.tagName);
+-            return `import { defineCustomElement as define${pascalImport} } from '${normalizePath(outputTarget.componentCorePackage)}/${outputTarget.customElementsDir ||
+-                'components'}/${component.tagName}.js';`;
++            return `import { defineCustomElement as define${pascalImport} } from '${normalizePath(outputTarget.componentCorePackage)}/${outputTarget.customElementsDir || 'components'}/${component.tagName}.js';`;
+         });
+         sourceImports = cmpImports.join('\n');
+     }
+@@ -212,9 +210,7 @@ function getPathToCorePackageLoader(config, outputTarget) {
+     const distAbsEsmLoaderPath = (distOutputTarget === null || distOutputTarget === void 0 ? void 0 : distOutputTarget.esmLoaderPath) && path.isAbsolute(distOutputTarget.esmLoaderPath)
+         ? distOutputTarget.esmLoaderPath
+         : null;
+-    const distRelEsmLoaderPath = config.rootDir && distAbsEsmLoaderPath
+-        ? path.relative(config.rootDir, distAbsEsmLoaderPath)
+-        : null;
++    const distRelEsmLoaderPath = config.rootDir && distAbsEsmLoaderPath ? path.relative(config.rootDir, distAbsEsmLoaderPath) : null;
+     const loaderDir = outputTarget.loaderDir || distRelEsmLoaderPath || DEFAULT_LOADER_DIR;
+     return normalizePath(path.join(basePkg, loaderDir));
+ }
+diff --git a/dist/output-vue.js b/dist/output-vue.js
+index 63aff6cc9e8364ef0b64af2601590813a40583b9..50b5901fe2dd1ed29b0c8d248e97ad7050ed6fa4 100644
+--- a/dist/output-vue.js
++++ b/dist/output-vue.js
+@@ -1,6 +1,6 @@
+ import path from 'path';
+-import { createComponentDefinition } from './generate-vue-component';
+-import { normalizePath, readPackageJson, relativeImport, sortBy, dashToPascalCase } from './utils';
++import { createComponentDefinition } from './generate-vue-component.js';
++import { normalizePath, readPackageJson, relativeImport, sortBy, dashToPascalCase } from './utils.js';
+ export async function vueProxyOutput(config, compilerCtx, outputTarget, components) {
+     const filteredComponents = getFilteredComponents(outputTarget.excludeComponents, components);
+     const rootDir = config.rootDir;
+@@ -20,22 +20,23 @@ export function generateProxies(config, components, pkgData, outputTarget, rootD
+     const imports = `/* eslint-disable */
+ /* tslint:disable */
+ /* auto-generated vue proxies */
+-import { defineContainer } from './vue-component-lib/utils';\n`;
++import { defineContainer } from './vue-component-lib/utils.js';\n`;
+     const generateTypeImports = () => {
+         if (outputTarget.componentCorePackage !== undefined) {
+-            const dirPath = outputTarget.includeImportCustomElements ? `/${outputTarget.customElementsDir || 'components'}` : '';
++            const dirPath = outputTarget.includeImportCustomElements
++                ? `/${outputTarget.customElementsDir || 'components'}`
++                : '';
+             return `import type { ${IMPORT_TYPES} } from '${normalizePath(outputTarget.componentCorePackage)}${dirPath}';\n`;
+         }
+-        return `import type { ${IMPORT_TYPES} } from '${normalizePath(componentsTypeFile)}';\n`;
++        return `import type { ${IMPORT_TYPES} } from '${normalizePath(componentsTypeFile)}.js';\n`;
+     };
+     const typeImports = generateTypeImports();
+     let sourceImports = '';
+     let registerCustomElements = '';
+     if (outputTarget.includeImportCustomElements && outputTarget.componentCorePackage !== undefined) {
+-        const cmpImports = components.map(component => {
++        const cmpImports = components.map((component) => {
+             const pascalImport = dashToPascalCase(component.tagName);
+-            return `import { defineCustomElement as define${pascalImport} } from '${normalizePath(outputTarget.componentCorePackage)}/${outputTarget.customElementsDir ||
+-                'components'}/${component.tagName}.js';`;
++            return `import { defineCustomElement as define${pascalImport} } from '${normalizePath(outputTarget.componentCorePackage)}/${outputTarget.customElementsDir || 'components'}/${component.tagName}.js';`;
+         });
+         sourceImports = cmpImports.join('\n');
+     }
+@@ -80,9 +81,7 @@ export function getPathToCorePackageLoader(config, outputTarget) {
+     const distAbsEsmLoaderPath = (distOutputTarget === null || distOutputTarget === void 0 ? void 0 : distOutputTarget.esmLoaderPath) && path.isAbsolute(distOutputTarget.esmLoaderPath)
+         ? distOutputTarget.esmLoaderPath
+         : null;
+-    const distRelEsmLoaderPath = config.rootDir && distAbsEsmLoaderPath
+-        ? path.relative(config.rootDir, distAbsEsmLoaderPath)
+-        : null;
++    const distRelEsmLoaderPath = config.rootDir && distAbsEsmLoaderPath ? path.relative(config.rootDir, distAbsEsmLoaderPath) : null;
+     const loaderDir = outputTarget.loaderDir || distRelEsmLoaderPath || DEFAULT_LOADER_DIR;
+     return normalizePath(path.join(basePkg, loaderDir));
+ }
+diff --git a/dist/plugin.js b/dist/plugin.js
+index 042d0deb6faf247351aa240180050e418b56f985..a4713018139ce26104ec306b77e3292f8c7df041 100644
+--- a/dist/plugin.js
++++ b/dist/plugin.js
+@@ -1,5 +1,5 @@
+-import { normalizePath } from './utils';
+-import { vueProxyOutput } from './output-vue';
++import { normalizePath } from './utils.js';
++import { vueProxyOutput } from './output-vue.js';
+ import path from 'path';
+ export const vueOutputTarget = (outputTarget) => ({
+     type: 'custom',
+diff --git a/dist/utils.d.ts b/dist/utils.d.ts
+index 44733fee64db3d4d1ad26ef4834224aec4d9c26b..14dbcffcd2ab77ad9781b32cb15ad98a8023dd2e 100644
+--- a/dist/utils.d.ts
++++ b/dist/utils.d.ts
+@@ -1,7 +1,6 @@
+ import type { PackageJSON } from './types';
+ export declare const toLowerCase: (str: string) => string;
+ export declare const dashToPascalCase: (str: string) => string;
+-export declare function flatOne<T>(array: T[][]): T[];
+ export declare function sortBy<T>(array: T[], prop: (item: T) => string): T[];
+ export declare function normalizePath(str: string): string;
+ export declare function relativeImport(pathFrom: string, pathTo: string, ext?: string): string;
+diff --git a/dist/utils.js b/dist/utils.js
+index 3978075c26eb354fd06565ee43d423c93f3b31f0..185d4bbf29228473dbcc1590b1a3dbb8fcab5c92 100644
+--- a/dist/utils.js
++++ b/dist/utils.js
+@@ -7,15 +7,6 @@ export const dashToPascalCase = (str) => toLowerCase(str)
+     .split('-')
+     .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+     .join('');
+-export function flatOne(array) {
+-    if (array.flat) {
+-        return array.flat(1);
+-    }
+-    return array.reduce((result, item) => {
+-        result.push(...item);
+-        return result;
+-    }, []);
+-}
+ export function sortBy(array, prop) {
+     return array.slice().sort((a, b) => {
+         const nameA = prop(a);

--- a/package.json
+++ b/package.json
@@ -193,5 +193,9 @@
       "optional": true
     }
   },
-  "packageManager": "yarn@3.2.0"
+  "packageManager": "yarn@3.2.0",
+  "resolutions": {
+    "@stencil/react-output-target@^0.3.1": "patch:@stencil/react-output-target@npm:0.3.1#.yarn/patches/@stencil-react-output-target-npm-0.3.1-4da13663f2.patch",
+    "@stencil/vue-output-target@^0.6.2": "patch:@stencil/vue-output-target@npm:0.6.2#.yarn/patches/@stencil-vue-output-target-npm-0.6.2-a9b3828cb9.patch"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2384,7 +2384,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stencil/react-output-target@npm:^0.3.1":
+"@stencil/react-output-target@npm:0.3.1":
   version: 0.3.1
   resolution: "@stencil/react-output-target@npm:0.3.1"
   peerDependencies:
@@ -2393,12 +2393,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stencil/vue-output-target@npm:^0.6.2":
+"@stencil/react-output-target@patch:@stencil/react-output-target@npm:0.3.1#.yarn/patches/@stencil-react-output-target-npm-0.3.1-4da13663f2.patch::locator=%40emdgroup-liquid%2Fliquid%40workspace%3A.":
+  version: 0.3.1
+  resolution: "@stencil/react-output-target@patch:@stencil/react-output-target@npm%3A0.3.1#.yarn/patches/@stencil-react-output-target-npm-0.3.1-4da13663f2.patch::version=0.3.1&hash=da4231&locator=%40emdgroup-liquid%2Fliquid%40workspace%3A."
+  peerDependencies:
+    "@stencil/core": ^2.9.0
+  checksum: ce5eb767b1a1b8726bb23c86086cd5c8785ca27dfe0c000c6c771c76ccde08770a7fcb81fefb4c2772ebfe5dc2cb6971fc3f0ed17238028056f29d379399612b
+  languageName: node
+  linkType: hard
+
+"@stencil/vue-output-target@npm:0.6.2":
   version: 0.6.2
   resolution: "@stencil/vue-output-target@npm:0.6.2"
   peerDependencies:
     "@stencil/core": ^2.9.0
   checksum: bd25b6f88e93cce9450a90278d71b432f139d665446b77c841db7d09a644165075759c9e8dcd27e4b84fbbd0abaac8b39d11c28aaeb8cbe3156fef3e125080cc
+  languageName: node
+  linkType: hard
+
+"@stencil/vue-output-target@patch:@stencil/vue-output-target@npm:0.6.2#.yarn/patches/@stencil-vue-output-target-npm-0.6.2-a9b3828cb9.patch::locator=%40emdgroup-liquid%2Fliquid%40workspace%3A.":
+  version: 0.6.2
+  resolution: "@stencil/vue-output-target@patch:@stencil/vue-output-target@npm%3A0.6.2#.yarn/patches/@stencil-vue-output-target-npm-0.6.2-a9b3828cb9.patch::version=0.6.2&hash=acd8b2&locator=%40emdgroup-liquid%2Fliquid%40workspace%3A."
+  peerDependencies:
+    "@stencil/core": ^2.9.0
+  checksum: 397aa5851723a9793fa8ad085b365692edec5307f3536ee9fa715e66e38eb8e32fa49ff7eb246837ed19d026fbed0fbe8b028fccc14af46885e109837410cd1a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

This PR includes a patch to the Stencil Vue and React output targets, resolving an issue with relatively imported modules, which need to have the .js or /index.js extension to be added to the import path in order to resolve an actual path, when working with esm in environments, where a fully specified path is the default (such as in a create react app with webpack 5, which, if not ejected and changed, has [resolve.fullySpecified](https://webpack.js.org/configuration/module/#resolvefullyspecified) set to true).

Fixes #495

References:
- Issue https://github.com/ionic-team/stencil-ds-output-targets/issues/319
- PR https://github.com/ionic-team/stencil-ds-output-targets/pull/322

## Type of change

- [x] Bugfix

## Is it a breaking change?

- [x] No

# How Has This Been Tested?

- [x] tested manually

In order to test this, you'll need to do the following:

1. Inside the liquid project working directory, check out the branch `fix/resolve_esm`
2. Run `yarn && yarn build && npm link`
3. Clone https://github.com/emdgroup-liquid/liquid-sandbox-cra-tailwind
4. Delete `patch-package ; ` in [this line](https://github.com/emdgroup-liquid/liquid-sandbox-cra-tailwind/blob/main/package.json#L43) in the package.json file
5. Run `npm install && npm link @emdgroup-liquid/liquid && npm start`
6. Open http://localhost:3000 in your browser

You can test the Vue bindings as well, using the same procedure as above with the [Nuxt sandbox app](https://github.com/emdgroup-liquid/liquid-sandbox-nuxt-tailwind). However, Nuxt will not be able to resolve symlinks, so you will have to copy paste the vue dist folder into the project as a workaround.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes
