### PR TITLE
feat(ssr): add dist-hydrate-script output target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ bin/
 !bin/.gitkeep
 dist/
 dist_docs/
+hydrate/
 
 *~
 *.sw[mnpcod]

--- a/config/.eslintrc.cjs
+++ b/config/.eslintrc.cjs
@@ -77,6 +77,7 @@ module.exports = {
   ignorePatterns: [
     '**/bin/**/*',
     '**/dist/**/*',
+    '**/hydrate/**/*',
     '**/dist_docs/**/*',
     '**/coverage/**/*',
     '**/components.d.ts',

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "sideEffects": false,
   "files": [
     "bin/",
-    "dist/"
+    "dist/",
+    "hydrate/"
   ],
   "scripts": {
     "apply_design_tokens": "dotenv -e .env -- ts-node scripts/applyDesignTokens.ts",

--- a/src/docs/pages/guides/server-side-rendering.md
+++ b/src/docs/pages/guides/server-side-rendering.md
@@ -6,6 +6,10 @@ eleventyNavigation:
 layout: layout.njk
 title: Server-side rendering
 permalink: guides/server-side-rendering/
+tags:
+  - SSR
+  - RSC
+  - Next.js
 ---
 
 
@@ -38,5 +42,25 @@ useEffect(()=>{
 ```
 
 For working examples check out our [sandbox apps](guides/sandbox-applications/).
+
+## Hydrate App
+
+The hydrate app is a Stencil output target which generates a module that can be used on a NodeJS server to hydrate HTML and implement server side rendering (SSR). You can import the hydrate app as follows:
+
+```js
+import { hydrateDocument } from '@emdgroup-liquid/liquid/hydrate'
+```
+
+Please refer to the [Stencil Hydrate App documentation](https://stenciljs.com/docs/hydrate-app) and our [Next.js sandbox app](https://github.com/emdgroup-liquid/liquid-sandbox-next-tailwind/) for details on how to use the hydrate app.
+
+## React Server Components
+
+[Liquid Oxygen React bindings](introduction/getting-started/react/) use client side hooks and therefore cannot be used as React Server Components (RSC). There are three ways to work around this issue:
+
+1. You can make use of Liquid Oxygen CSS components.
+2. You can wrap Liquid Oxygen React components in client side components (which use the `"use client"` directive).
+3. You can use the non-wrapped Liquid Oxygen Web Components (without React bindings) in your RSC. In this case you may want to review our docs on [type checking and intellisense](guides/type-checking-and-intellisense/).
+
+Our [Next.js sandbox app](https://github.com/emdgroup-liquid/liquid-sandbox-next-tailwind/) covers most of the options described above.
 
 <docs-page-nav prev-href="guides/type-checking-and-intellisense/" next-title="Event handling" next-href="guides/event-handling/"></docs-page-nav>

--- a/src/docs/pages/guides/type-checking-and-intellisense.md
+++ b/src/docs/pages/guides/type-checking-and-intellisense.md
@@ -33,7 +33,9 @@ type LiquidElements<T> = {
 
 declare global {
   namespace JSX {
-    interface IntrinsicElements extends LiquidElements<LocalJSX.IntrinsicElements> {}
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    interface IntrinsicElements
+      extends LiquidElements<LocalJSX.IntrinsicElements> {}
   }
 
   // Required only when using __LD_ASSET_PATH__

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -58,7 +58,12 @@ export const config: Config = {
       file: 'dist/web-components.json',
     },
     {
+      type: 'dist-hydrate-script',
+    },
+    {
       type: 'docs-custom',
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
       generator: new WebTypesGenerator({
         name: '@emdgroup-liquid/liquid',
         version: 'latest',
@@ -79,7 +84,7 @@ export const config: Config = {
         viewport: {
           width: 600,
           height: 600,
-          // A device scale factor of 2 would reduce issues with anti-aliasing.
+          // A device scale factor of 2 would reduce issues with antialiasing.
           // However, testing then takes longer and screenshot matching
           // tends to time out, especially when running all tests in one go.
           // That is why we do without the higher device scale factor, for now.


### PR DESCRIPTION
# Description

This PR adds the [hydrate-app output target](https://stenciljs.com/docs/hydrate-app) to the stencil config. It allows to render web components on server side and hydrate them on client side.

I have experimented with this using Nuxt and Next, but didn't come too far, because of different hydration errors, mostly related to mismatches between client and server rendered HTML. I haven't had the time to report this to the Stencil team yet. However, I decided to push my changes and create a draft PR so that we don't loose this topic out of sight.

## Type of change

Please delete options that are not relevant.

- [x] Build related changes

## Is it a breaking change?

- [x] No

# How Has This Been Tested?

Please describe the tests that you've added and run to verify your changes. 
Provide instructions, so we can reproduce.

- [ ] tested manually with Nuxt and Next

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes
