### PR TITLE
feat: autoDefineCustomComponents for React and Vue

### DIFF
--- a/.yarn/patches/@stencil-react-output-target-npm-0.3.1-4da13663f2.patch
+++ b/.yarn/patches/@stencil-react-output-target-npm-0.3.1-4da13663f2.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/index.cjs.js b/dist/index.cjs.js
-index ed803c547b18555f83d05c0f6b8880207ed34bb5..9013c7e3552e3e297eee3102dbe158a089060176 100644
+index ed803c547b18555f83d05c0f6b8880207ed34bb5..3ec06e61885a9c7e76068abd6c5c8c10d29921bf 100644
 --- a/dist/index.cjs.js
 +++ b/dist/index.cjs.js
 @@ -161,7 +161,7 @@ function generateProxies(config, components, pkgData, outputTarget, rootDir) {
@@ -22,7 +22,7 @@ index ed803c547b18555f83d05c0f6b8880207ed34bb5..9013c7e3552e3e297eee3102dbe158a0
              return `import type { ${IMPORT_TYPES} } from '${normalizePath(outputTarget.componentCorePackage)}${dirPath}';\n`;
          }
          return `import type { ${IMPORT_TYPES} } from '${normalizePath(componentsTypeFile)}';\n`;
-@@ -184,10 +186,9 @@ import { createReactComponent } from './react-component-lib';\n`;
+@@ -184,19 +186,18 @@ import { createReactComponent } from './react-component-lib';\n`;
       * Component that takes in the Web Component as a parameter.
       */
      if (outputTarget.includeImportCustomElements && outputTarget.componentCorePackage !== undefined) {
@@ -35,6 +35,17 @@ index ed803c547b18555f83d05c0f6b8880207ed34bb5..9013c7e3552e3e297eee3102dbe158a0
          });
          sourceImports = cmpImports.join('\n');
      }
+     else if (outputTarget.includePolyfills && outputTarget.includeDefineCustomElements) {
+-        sourceImports = `import { ${APPLY_POLYFILLS}, ${REGISTER_CUSTOM_ELEMENTS} } from '${pathToCorePackageLoader}';\n`;
++        sourceImports = `import { ${APPLY_POLYFILLS}, ${REGISTER_CUSTOM_ELEMENTS} } from '${pathToCorePackageLoader}/index.js';\n`;
+         registerCustomElements = `${APPLY_POLYFILLS}().then(() => ${REGISTER_CUSTOM_ELEMENTS}());`;
+     }
+     else if (!outputTarget.includePolyfills && outputTarget.includeDefineCustomElements) {
+-        sourceImports = `import { ${REGISTER_CUSTOM_ELEMENTS} } from '${pathToCorePackageLoader}';\n`;
++        sourceImports = `import { ${REGISTER_CUSTOM_ELEMENTS} } from '${pathToCorePackageLoader}/index.js';\n`;
+         registerCustomElements = `${REGISTER_CUSTOM_ELEMENTS}();`;
+     }
+     const final = [
 @@ -204,7 +205,9 @@ import { createReactComponent } from './react-component-lib';\n`;
          typeImports,
          sourceImports,
@@ -77,7 +88,7 @@ index f4fce6b403df1f833bf216c50e19fd52568e6f02..9a76ec911ab4b6400a282abb21555d12
 +export { reactOutputTarget } from './plugin.js';
  export type { OutputTargetReact } from './types';
 diff --git a/dist/index.js b/dist/index.js
-index 280cba2bee732cbc879a9001e4cb376d1d6bc2a7..c5b221e94cad5b3adddf5cc2843f87b91218f106 100644
+index 280cba2bee732cbc879a9001e4cb376d1d6bc2a7..e540feb50efe72f6d18c520447d999650910320e 100644
 --- a/dist/index.js
 +++ b/dist/index.js
 @@ -152,7 +152,7 @@ function generateProxies(config, components, pkgData, outputTarget, rootDir) {
@@ -100,7 +111,7 @@ index 280cba2bee732cbc879a9001e4cb376d1d6bc2a7..c5b221e94cad5b3adddf5cc2843f87b9
              return `import type { ${IMPORT_TYPES} } from '${normalizePath(outputTarget.componentCorePackage)}${dirPath}';\n`;
          }
          return `import type { ${IMPORT_TYPES} } from '${normalizePath(componentsTypeFile)}';\n`;
-@@ -175,10 +177,9 @@ import { createReactComponent } from './react-component-lib';\n`;
+@@ -175,19 +177,18 @@ import { createReactComponent } from './react-component-lib';\n`;
       * Component that takes in the Web Component as a parameter.
       */
      if (outputTarget.includeImportCustomElements && outputTarget.componentCorePackage !== undefined) {
@@ -113,6 +124,17 @@ index 280cba2bee732cbc879a9001e4cb376d1d6bc2a7..c5b221e94cad5b3adddf5cc2843f87b9
          });
          sourceImports = cmpImports.join('\n');
      }
+     else if (outputTarget.includePolyfills && outputTarget.includeDefineCustomElements) {
+-        sourceImports = `import { ${APPLY_POLYFILLS}, ${REGISTER_CUSTOM_ELEMENTS} } from '${pathToCorePackageLoader}';\n`;
++        sourceImports = `import { ${APPLY_POLYFILLS}, ${REGISTER_CUSTOM_ELEMENTS} } from '${pathToCorePackageLoader}/index.js';\n`;
+         registerCustomElements = `${APPLY_POLYFILLS}().then(() => ${REGISTER_CUSTOM_ELEMENTS}());`;
+     }
+     else if (!outputTarget.includePolyfills && outputTarget.includeDefineCustomElements) {
+-        sourceImports = `import { ${REGISTER_CUSTOM_ELEMENTS} } from '${pathToCorePackageLoader}';\n`;
++        sourceImports = `import { ${REGISTER_CUSTOM_ELEMENTS} } from '${pathToCorePackageLoader}/index.js';\n`;
+         registerCustomElements = `${REGISTER_CUSTOM_ELEMENTS}();`;
+     }
+     const final = [
 @@ -195,7 +196,9 @@ import { createReactComponent } from './react-component-lib';\n`;
          typeImports,
          sourceImports,
@@ -147,7 +169,7 @@ index 280cba2bee732cbc879a9001e4cb376d1d6bc2a7..c5b221e94cad5b3adddf5cc2843f87b9
      return normalizePath(path.join(basePkg, loaderDir));
  }
 diff --git a/dist/output-react.js b/dist/output-react.js
-index 43284218127e75e9dd599aabf313eed04a3bb46a..8c39e0b81deead89abee3a77e03d055022ecf39b 100644
+index 43284218127e75e9dd599aabf313eed04a3bb46a..502848a0d0f0c56a335fb31b00eb86b7f0b356d5 100644
 --- a/dist/output-react.js
 +++ b/dist/output-react.js
 @@ -1,5 +1,5 @@
@@ -177,7 +199,7 @@ index 43284218127e75e9dd599aabf313eed04a3bb46a..8c39e0b81deead89abee3a77e03d0550
              return `import type { ${IMPORT_TYPES} } from '${normalizePath(outputTarget.componentCorePackage)}${dirPath}';\n`;
          }
          return `import type { ${IMPORT_TYPES} } from '${normalizePath(componentsTypeFile)}';\n`;
-@@ -64,10 +66,9 @@ import { createReactComponent } from './react-component-lib';\n`;
+@@ -64,19 +66,18 @@ import { createReactComponent } from './react-component-lib';\n`;
       * Component that takes in the Web Component as a parameter.
       */
      if (outputTarget.includeImportCustomElements && outputTarget.componentCorePackage !== undefined) {
@@ -190,6 +212,17 @@ index 43284218127e75e9dd599aabf313eed04a3bb46a..8c39e0b81deead89abee3a77e03d0550
          });
          sourceImports = cmpImports.join('\n');
      }
+     else if (outputTarget.includePolyfills && outputTarget.includeDefineCustomElements) {
+-        sourceImports = `import { ${APPLY_POLYFILLS}, ${REGISTER_CUSTOM_ELEMENTS} } from '${pathToCorePackageLoader}';\n`;
++        sourceImports = `import { ${APPLY_POLYFILLS}, ${REGISTER_CUSTOM_ELEMENTS} } from '${pathToCorePackageLoader}/index.js';\n`;
+         registerCustomElements = `${APPLY_POLYFILLS}().then(() => ${REGISTER_CUSTOM_ELEMENTS}());`;
+     }
+     else if (!outputTarget.includePolyfills && outputTarget.includeDefineCustomElements) {
+-        sourceImports = `import { ${REGISTER_CUSTOM_ELEMENTS} } from '${pathToCorePackageLoader}';\n`;
++        sourceImports = `import { ${REGISTER_CUSTOM_ELEMENTS} } from '${pathToCorePackageLoader}/index.js';\n`;
+         registerCustomElements = `${REGISTER_CUSTOM_ELEMENTS}();`;
+     }
+     const final = [
 @@ -84,7 +85,9 @@ import { createReactComponent } from './react-component-lib';\n`;
          typeImports,
          sourceImports,

--- a/.yarn/patches/@stencil-vue-output-target-npm-0.6.2-a9b3828cb9.patch
+++ b/.yarn/patches/@stencil-vue-output-target-npm-0.6.2-a9b3828cb9.patch
@@ -28,7 +28,7 @@ index f92d53a2caa5d462194440120a551bd3d6f24f22..370c840d054f66d1c56f3303efe10ac8
          templateString += `, [
    ${props.length > 0 ? props.join(',\n  ') : ''}
 diff --git a/dist/index.cjs.js b/dist/index.cjs.js
-index ce0fad05e3bfe0e6bec389a96060e00617daf410..7a7cfaaa65070251d9c26de47d918c7818152e21 100644
+index ce0fad05e3bfe0e6bec389a96060e00617daf410..5611538c9acb1e625e2aefdc3d80d14c963d1f62 100644
 --- a/dist/index.cjs.js
 +++ b/dist/index.cjs.js
 @@ -89,20 +89,17 @@ const SLASH_REGEX = /\\/g;
@@ -55,7 +55,7 @@ index ce0fad05e3bfe0e6bec389a96060e00617daf410..7a7cfaaa65070251d9c26de47d918c78
      if (props.length > 0) {
          templateString += `, [
    ${props.length > 0 ? props.join(',\n  ') : ''}
-@@ -161,22 +158,23 @@ function generateProxies(config, components, pkgData, outputTarget, rootDir) {
+@@ -161,31 +158,32 @@ function generateProxies(config, components, pkgData, outputTarget, rootDir) {
      const imports = `/* eslint-disable */
  /* tslint:disable */
  /* auto-generated vue proxies */
@@ -85,6 +85,17 @@ index ce0fad05e3bfe0e6bec389a96060e00617daf410..7a7cfaaa65070251d9c26de47d918c78
          });
          sourceImports = cmpImports.join('\n');
      }
+     else if (outputTarget.includePolyfills && outputTarget.includeDefineCustomElements) {
+-        sourceImports = `import { ${APPLY_POLYFILLS}, ${REGISTER_CUSTOM_ELEMENTS} } from '${pathToCorePackageLoader}';\n`;
++        sourceImports = `import { ${APPLY_POLYFILLS}, ${REGISTER_CUSTOM_ELEMENTS} } from '${pathToCorePackageLoader}/index.js';\n`;
+         registerCustomElements = `${APPLY_POLYFILLS}().then(() => ${REGISTER_CUSTOM_ELEMENTS}());`;
+     }
+     else if (!outputTarget.includePolyfills && outputTarget.includeDefineCustomElements) {
+-        sourceImports = `import { ${REGISTER_CUSTOM_ELEMENTS} } from '${pathToCorePackageLoader}';\n`;
++        sourceImports = `import { ${REGISTER_CUSTOM_ELEMENTS} } from '${pathToCorePackageLoader}/index.js';\n`;
+         registerCustomElements = `${REGISTER_CUSTOM_ELEMENTS}();`;
+     }
+     const final = [
 @@ -221,9 +219,7 @@ function getPathToCorePackageLoader(config, outputTarget) {
      const distAbsEsmLoaderPath = (distOutputTarget === null || distOutputTarget === void 0 ? void 0 : distOutputTarget.esmLoaderPath) && path__default['default'].isAbsolute(distOutputTarget.esmLoaderPath)
          ? distOutputTarget.esmLoaderPath
@@ -105,7 +116,7 @@ index 26cb893e90a3fc9a0a2ea3ce598196d7f99ffc59..535829157b12216bd0f2651ab209549a
 +export { vueOutputTarget } from './plugin.js';
  export type { OutputTargetVue, ComponentModelConfig } from './types';
 diff --git a/dist/index.js b/dist/index.js
-index aa686db09e35a595b65bee010034c3f4f7517001..bec938e6e85923f00c83d24d02260012cc294cd4 100644
+index aa686db09e35a595b65bee010034c3f4f7517001..e57d4f57c6dfdb0eb487ff01c380dfe098da96a1 100644
 --- a/dist/index.js
 +++ b/dist/index.js
 @@ -80,20 +80,17 @@ const SLASH_REGEX = /\\/g;
@@ -132,7 +143,7 @@ index aa686db09e35a595b65bee010034c3f4f7517001..bec938e6e85923f00c83d24d02260012
      if (props.length > 0) {
          templateString += `, [
    ${props.length > 0 ? props.join(',\n  ') : ''}
-@@ -152,22 +149,23 @@ function generateProxies(config, components, pkgData, outputTarget, rootDir) {
+@@ -152,31 +149,32 @@ function generateProxies(config, components, pkgData, outputTarget, rootDir) {
      const imports = `/* eslint-disable */
  /* tslint:disable */
  /* auto-generated vue proxies */
@@ -162,6 +173,17 @@ index aa686db09e35a595b65bee010034c3f4f7517001..bec938e6e85923f00c83d24d02260012
          });
          sourceImports = cmpImports.join('\n');
      }
+     else if (outputTarget.includePolyfills && outputTarget.includeDefineCustomElements) {
+-        sourceImports = `import { ${APPLY_POLYFILLS}, ${REGISTER_CUSTOM_ELEMENTS} } from '${pathToCorePackageLoader}';\n`;
++        sourceImports = `import { ${APPLY_POLYFILLS}, ${REGISTER_CUSTOM_ELEMENTS} } from '${pathToCorePackageLoader}/index.js';\n`;
+         registerCustomElements = `${APPLY_POLYFILLS}().then(() => ${REGISTER_CUSTOM_ELEMENTS}());`;
+     }
+     else if (!outputTarget.includePolyfills && outputTarget.includeDefineCustomElements) {
+-        sourceImports = `import { ${REGISTER_CUSTOM_ELEMENTS} } from '${pathToCorePackageLoader}';\n`;
++        sourceImports = `import { ${REGISTER_CUSTOM_ELEMENTS} } from '${pathToCorePackageLoader}/index.js';\n`;
+         registerCustomElements = `${REGISTER_CUSTOM_ELEMENTS}();`;
+     }
+     const final = [
 @@ -212,9 +210,7 @@ function getPathToCorePackageLoader(config, outputTarget) {
      const distAbsEsmLoaderPath = (distOutputTarget === null || distOutputTarget === void 0 ? void 0 : distOutputTarget.esmLoaderPath) && path.isAbsolute(distOutputTarget.esmLoaderPath)
          ? distOutputTarget.esmLoaderPath
@@ -174,7 +196,7 @@ index aa686db09e35a595b65bee010034c3f4f7517001..bec938e6e85923f00c83d24d02260012
      return normalizePath(path.join(basePkg, loaderDir));
  }
 diff --git a/dist/output-vue.js b/dist/output-vue.js
-index 63aff6cc9e8364ef0b64af2601590813a40583b9..50b5901fe2dd1ed29b0c8d248e97ad7050ed6fa4 100644
+index 63aff6cc9e8364ef0b64af2601590813a40583b9..5b4a763ea7c7bb84be0b6758bb0eb455653a1012 100644
 --- a/dist/output-vue.js
 +++ b/dist/output-vue.js
 @@ -1,6 +1,6 @@
@@ -186,7 +208,7 @@ index 63aff6cc9e8364ef0b64af2601590813a40583b9..50b5901fe2dd1ed29b0c8d248e97ad70
  export async function vueProxyOutput(config, compilerCtx, outputTarget, components) {
      const filteredComponents = getFilteredComponents(outputTarget.excludeComponents, components);
      const rootDir = config.rootDir;
-@@ -20,22 +20,23 @@ export function generateProxies(config, components, pkgData, outputTarget, rootD
+@@ -20,31 +20,32 @@ export function generateProxies(config, components, pkgData, outputTarget, rootD
      const imports = `/* eslint-disable */
  /* tslint:disable */
  /* auto-generated vue proxies */
@@ -216,6 +238,17 @@ index 63aff6cc9e8364ef0b64af2601590813a40583b9..50b5901fe2dd1ed29b0c8d248e97ad70
          });
          sourceImports = cmpImports.join('\n');
      }
+     else if (outputTarget.includePolyfills && outputTarget.includeDefineCustomElements) {
+-        sourceImports = `import { ${APPLY_POLYFILLS}, ${REGISTER_CUSTOM_ELEMENTS} } from '${pathToCorePackageLoader}';\n`;
++        sourceImports = `import { ${APPLY_POLYFILLS}, ${REGISTER_CUSTOM_ELEMENTS} } from '${pathToCorePackageLoader}/index.js';\n`;
+         registerCustomElements = `${APPLY_POLYFILLS}().then(() => ${REGISTER_CUSTOM_ELEMENTS}());`;
+     }
+     else if (!outputTarget.includePolyfills && outputTarget.includeDefineCustomElements) {
+-        sourceImports = `import { ${REGISTER_CUSTOM_ELEMENTS} } from '${pathToCorePackageLoader}';\n`;
++        sourceImports = `import { ${REGISTER_CUSTOM_ELEMENTS} } from '${pathToCorePackageLoader}/index.js';\n`;
+         registerCustomElements = `${REGISTER_CUSTOM_ELEMENTS}();`;
+     }
+     const final = [
 @@ -80,9 +81,7 @@ export function getPathToCorePackageLoader(config, outputTarget) {
      const distAbsEsmLoaderPath = (distOutputTarget === null || distOutputTarget === void 0 ? void 0 : distOutputTarget.esmLoaderPath) && path.isAbsolute(distOutputTarget.esmLoaderPath)
          ? distOutputTarget.esmLoaderPath

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -12,12 +12,12 @@ export const config: Config = {
     reactOutputTarget({
       componentCorePackage: '..',
       proxiesFile: './src/react.ts',
-      includeDefineCustomElements: false,
+      includeDefineCustomElements: true,
     }),
     vueOutputTarget({
       componentCorePackage: '..',
       proxiesFile: './src/vue.ts',
-      includeDefineCustomElements: false,
+      includeDefineCustomElements: true,
     }),
     {
       type: 'dist',


### PR DESCRIPTION
# Description

Sets the output target for vue and react to use `includeDefineCustomElements: true`.
This PR is also updating the patch as the import did not use index.js.

```
import { defineCustomElements } from '../dist/loader/index.js';
defineCustomElements();
```

This will influence the documentation which is still pending.

## Type of change

Please delete options that are not relevant.

- [x] Build related changes

## Is it a breaking change?

- [ ] Yes
- [x] No

# How Has This Been Tested?

The output target was tested in respective react sandboxes. 
Due to the missing patch there was an issue with vitest and jest.

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] New and existing tests pass locally with my changes
