### PR TITLE
fix(types): mark props with default value as optional

### DIFF
--- a/src/liquid/components/ld-accordion/ld-accordion-toggle/ld-accordion-toggle.tsx
+++ b/src/liquid/components/ld-accordion/ld-accordion-toggle/ld-accordion-toggle.tsx
@@ -46,7 +46,7 @@ export class LdAccordionToggle implements InnerFocusable {
   @Prop() split?: boolean
 
   /** Used as aria-label value on the toggle trigger element. */
-  @Prop() toggleLabel?: string = 'Toggle'
+  @Prop() toggleLabel? = 'Toggle'
 
   @State() expanded: boolean
   @State() hasCustomIcon = false

--- a/src/liquid/components/ld-accordion/ld-accordion-toggle/ld-accordion-toggle.tsx
+++ b/src/liquid/components/ld-accordion/ld-accordion-toggle/ld-accordion-toggle.tsx
@@ -33,7 +33,7 @@ export class LdAccordionToggle implements InnerFocusable {
    * This prop is especially usefull, if you want to place
    * your own focusable element inside the toggle label element.
    */
-  @Prop() labelTag: 'button' | 'div' = 'button'
+  @Prop() labelTag?: 'button' | 'div' = 'button'
 
   /** Tab index of the toggle. */
   @Prop() ldTabindex: number | undefined

--- a/src/liquid/components/ld-accordion/ld-accordion-toggle/ld-accordion-toggle.tsx
+++ b/src/liquid/components/ld-accordion/ld-accordion-toggle/ld-accordion-toggle.tsx
@@ -46,7 +46,7 @@ export class LdAccordionToggle implements InnerFocusable {
   @Prop() split?: boolean
 
   /** Used as aria-label value on the toggle trigger element. */
-  @Prop() toggleLabel = 'Toggle'
+  @Prop() toggleLabel?: string = 'Toggle'
 
   @State() expanded: boolean
   @State() hasCustomIcon = false

--- a/src/liquid/components/ld-accordion/ld-accordion.tsx
+++ b/src/liquid/components/ld-accordion/ld-accordion.tsx
@@ -30,13 +30,13 @@ export class LdAccordion {
   @Prop() brandColor?: boolean
 
   /** Sets a small gap between each accordion section. */
-  @Prop() detached = false
+  @Prop() detached?: boolean = false
 
   /** Applies rounded corners. */
-  @Prop() rounded = false
+  @Prop() rounded?: boolean = false
 
   /** When set to true, an open accordion element closes, if anthorer one opens. */
-  @Prop() single = false
+  @Prop() single?: boolean = false
 
   /**
    * Use `'dark'` on white backgrounds. Default is a light tone.

--- a/src/liquid/components/ld-accordion/ld-accordion.tsx
+++ b/src/liquid/components/ld-accordion/ld-accordion.tsx
@@ -30,13 +30,13 @@ export class LdAccordion {
   @Prop() brandColor?: boolean
 
   /** Sets a small gap between each accordion section. */
-  @Prop() detached?: boolean = false
+  @Prop() detached? = false
 
   /** Applies rounded corners. */
-  @Prop() rounded?: boolean = false
+  @Prop() rounded? = false
 
   /** When set to true, an open accordion element closes, if anthorer one opens. */
-  @Prop() single?: boolean = false
+  @Prop() single? = false
 
   /**
    * Use `'dark'` on white backgrounds. Default is a light tone.

--- a/src/liquid/components/ld-bg-cells/ld-bg-cells.tsx
+++ b/src/liquid/components/ld-bg-cells/ld-bg-cells.tsx
@@ -41,10 +41,10 @@ export class LdBgCells {
   @Prop() type: CellType = 'hexagon'
 
   /** Use 3 color layers */
-  @Prop() threeLayers?: boolean = false
+  @Prop() threeLayers? = false
 
   /** Animate the pattern */
-  @Prop() animated?: boolean = false
+  @Prop() animated? = false
 
   @Watch('type')
   private async loadPatternPathData(): Promise<void> {

--- a/src/liquid/components/ld-bg-cells/ld-bg-cells.tsx
+++ b/src/liquid/components/ld-bg-cells/ld-bg-cells.tsx
@@ -41,10 +41,10 @@ export class LdBgCells {
   @Prop() type: CellType = 'hexagon'
 
   /** Use 3 color layers */
-  @Prop() threeLayers = false
+  @Prop() threeLayers?: boolean = false
 
   /** Animate the pattern */
-  @Prop() animated = false
+  @Prop() animated?: boolean = false
 
   @Watch('type')
   private async loadPatternPathData(): Promise<void> {

--- a/src/liquid/components/ld-button/ld-button.tsx
+++ b/src/liquid/components/ld-button/ld-button.tsx
@@ -92,7 +92,7 @@ export class LdButton implements InnerFocusable, ClonesAttributes {
   @Prop() target?: '_blank' | '_self' | '_parent' | '_top'
 
   /** Specifies the default behavior of the button. */
-  @Prop() type: 'button' | 'reset' | 'submit' = 'submit'
+  @Prop() type?: 'button' | 'reset' | 'submit' = 'submit'
 
   /** Defines the value associated with the button’s `name` when it’s submitted with the form data. */
   @Prop() value?: string

--- a/src/liquid/components/ld-card/ld-card.tsx
+++ b/src/liquid/components/ld-card/ld-card.tsx
@@ -14,7 +14,7 @@ export class LdCard {
   @Element() el: HTMLLdCardElement
 
   /** Simulates card elevation by setting the size of the card box shadow. */
-  @Prop() shadow: 'active' | 'hover' | 'stacked' | 'sticky' = 'stacked'
+  @Prop() shadow?: 'active' | 'hover' | 'stacked' | 'sticky' = 'stacked'
 
   /**
    * Adds hover and focus-within states using an elevation transition from

--- a/src/liquid/components/ld-checkbox/ld-checkbox.tsx
+++ b/src/liquid/components/ld-checkbox/ld-checkbox.tsx
@@ -36,7 +36,7 @@ export class LdCheckbox implements InnerFocusable, ClonesAttributes {
   @Prop({ reflect: true }) autofocus: boolean
 
   /** Indicates whether the checkbox is checked. */
-  @Prop({ mutable: true }) checked?: boolean = false
+  @Prop({ mutable: true }) checked? = false
 
   /** Disabled state of the checkbox. */
   @Prop() disabled?: boolean

--- a/src/liquid/components/ld-checkbox/ld-checkbox.tsx
+++ b/src/liquid/components/ld-checkbox/ld-checkbox.tsx
@@ -36,10 +36,10 @@ export class LdCheckbox implements InnerFocusable, ClonesAttributes {
   @Prop({ reflect: true }) autofocus: boolean
 
   /** Indicates whether the checkbox is checked. */
-  @Prop({ mutable: true }) checked = false
+  @Prop({ mutable: true }) checked?: boolean = false
 
   /** Disabled state of the checkbox. */
-  @Prop() disabled: boolean
+  @Prop() disabled?: boolean
 
   /** Associates the control with a form element. */
   @Prop() form?: string
@@ -51,7 +51,7 @@ export class LdCheckbox implements InnerFocusable, ClonesAttributes {
   @Prop({ mutable: true }) indeterminate?: boolean
 
   /** Set this property to `true` in order to mark the checkbox visually as invalid. */
-  @Prop() invalid: boolean
+  @Prop() invalid?: boolean
 
   /** Tab index of the input. */
   @Prop() ldTabindex: number | undefined
@@ -66,7 +66,7 @@ export class LdCheckbox implements InnerFocusable, ClonesAttributes {
   @Prop() readonly?: boolean
 
   /** Set this property to `true` in order to mark the checkbox as required. */
-  @Prop() required: boolean
+  @Prop() required?: boolean
 
   /** Checkbox tone. Use `'dark'` on white backgrounds. Default is a light tone. */
   @Prop() tone: 'dark'

--- a/src/liquid/components/ld-checkbox/ld-checkbox.tsx
+++ b/src/liquid/components/ld-checkbox/ld-checkbox.tsx
@@ -69,7 +69,7 @@ export class LdCheckbox implements InnerFocusable, ClonesAttributes {
   @Prop() required?: boolean
 
   /** Checkbox tone. Use `'dark'` on white backgrounds. Default is a light tone. */
-  @Prop() tone: 'dark'
+  @Prop() tone?: 'dark'
 
   /** The input value. */
   @Prop() value: string

--- a/src/liquid/components/ld-circular-progress/ld-circular-progress.tsx
+++ b/src/liquid/components/ld-circular-progress/ld-circular-progress.tsx
@@ -21,13 +21,13 @@ export class LdCircularProgress {
    * Set to a decimal value representing the maximum value, and greater
    * than aria-valuemin. If not present, the default value is 100.
    */
-  @Prop({ reflect: true }) ariaValuemax?: number = 100
+  @Prop({ reflect: true }) ariaValuemax? = 100
 
   /**
    * Set to a decimal value representing the minimum value, and less
    * than aria-valuemax. If not present, the default value is 0.
    */
-  @Prop({ reflect: true }) ariaValuemin?: number = 0
+  @Prop({ reflect: true }) ariaValuemin? = 0
 
   /**
    * Only present and required if the value is not indeterminate.

--- a/src/liquid/components/ld-circular-progress/ld-circular-progress.tsx
+++ b/src/liquid/components/ld-circular-progress/ld-circular-progress.tsx
@@ -21,13 +21,13 @@ export class LdCircularProgress {
    * Set to a decimal value representing the maximum value, and greater
    * than aria-valuemin. If not present, the default value is 100.
    */
-  @Prop({ reflect: true }) ariaValuemax = 100
+  @Prop({ reflect: true }) ariaValuemax?: number = 100
 
   /**
    * Set to a decimal value representing the minimum value, and less
    * than aria-valuemax. If not present, the default value is 0.
    */
-  @Prop({ reflect: true }) ariaValuemin = 0
+  @Prop({ reflect: true }) ariaValuemin?: number = 0
 
   /**
    * Only present and required if the value is not indeterminate.

--- a/src/liquid/components/ld-header/ld-header.tsx
+++ b/src/liquid/components/ld-header/ld-header.tsx
@@ -28,7 +28,7 @@ export class LdHeader {
   @Prop({ mutable: true }) hidden = false
 
   /** Hide the header when the user scrolls down and show it again, when the user scrolls up. */
-  @Prop() hideOnScroll?: boolean = false
+  @Prop() hideOnScroll? = false
 
   /** Title attribute of the logo link. */
   @Prop() logoTitle?: string
@@ -37,7 +37,7 @@ export class LdHeader {
   @Prop() logoUrl?: string
 
   /** Make the header sticky. */
-  @Prop() sticky?: boolean = false
+  @Prop() sticky? = false
 
   /** Name shown on the right side of the logo. */
   @Prop() siteName?: string

--- a/src/liquid/components/ld-header/ld-header.tsx
+++ b/src/liquid/components/ld-header/ld-header.tsx
@@ -28,7 +28,7 @@ export class LdHeader {
   @Prop({ mutable: true }) hidden = false
 
   /** Hide the header when the user scrolls down and show it again, when the user scrolls up. */
-  @Prop() hideOnScroll = false
+  @Prop() hideOnScroll?: boolean = false
 
   /** Title attribute of the logo link. */
   @Prop() logoTitle?: string
@@ -37,7 +37,7 @@ export class LdHeader {
   @Prop() logoUrl?: string
 
   /** Make the header sticky. */
-  @Prop() sticky = false
+  @Prop() sticky?: boolean = false
 
   /** Name shown on the right side of the logo. */
   @Prop() siteName?: string

--- a/src/liquid/components/ld-input-message/ld-input-message.tsx
+++ b/src/liquid/components/ld-input-message/ld-input-message.tsx
@@ -13,7 +13,7 @@ import { Component, h, Prop, Host } from '@stencil/core'
 })
 export class LdInputMessage {
   /** Input message mode. */
-  @Prop() mode: 'error' | 'info' | 'valid' = 'error'
+  @Prop() mode?: 'error' | 'info' | 'valid' = 'error'
 
   render() {
     return (

--- a/src/liquid/components/ld-label/ld-label.tsx
+++ b/src/liquid/components/ld-label/ld-label.tsx
@@ -18,7 +18,7 @@ export class LdLabel implements ClonesAttributes {
   private attributesObserver: MutationObserver
 
   /** Align input message with input position. */
-  @Prop() alignMessage: boolean
+  @Prop() alignMessage?: boolean
 
   /** Relative position to labeled element. Default is top. */
   @Prop() position: 'left' | 'right'

--- a/src/liquid/components/ld-label/ld-label.tsx
+++ b/src/liquid/components/ld-label/ld-label.tsx
@@ -21,10 +21,10 @@ export class LdLabel implements ClonesAttributes {
   @Prop() alignMessage?: boolean
 
   /** Relative position to labeled element. Default is top. */
-  @Prop() position: 'left' | 'right'
+  @Prop() position?: 'left' | 'right'
 
   /** Size of the label. Default is small. */
-  @Prop() size: 'm'
+  @Prop() size?: 'm'
 
   @State() clonedAttributes
 

--- a/src/liquid/components/ld-loading/ld-loading.tsx
+++ b/src/liquid/components/ld-loading/ld-loading.tsx
@@ -12,7 +12,7 @@ import { getClassNames } from '../../utils/getClassNames'
 })
 export class LdLoading {
   /** Used as svg title element content. */
-  @Prop() label = 'Loading'
+  @Prop() label?: string = 'Loading'
 
   /** Uses neutral colors. */
   @Prop() neutral?: boolean

--- a/src/liquid/components/ld-loading/ld-loading.tsx
+++ b/src/liquid/components/ld-loading/ld-loading.tsx
@@ -12,7 +12,7 @@ import { getClassNames } from '../../utils/getClassNames'
 })
 export class LdLoading {
   /** Used as svg title element content. */
-  @Prop() label?: string = 'Loading'
+  @Prop() label? = 'Loading'
 
   /** Uses neutral colors. */
   @Prop() neutral?: boolean

--- a/src/liquid/components/ld-modal/ld-modal.tsx
+++ b/src/liquid/components/ld-modal/ld-modal.tsx
@@ -30,13 +30,13 @@ export class LdModal {
   private dialogRef: HTMLDialogElement
 
   /** The modal is cancelable by default. However, you can change this using this prop. */
-  @Prop() cancelable = true
+  @Prop() cancelable?: boolean = true
 
   /** Indicates that the modal dialog is active and can be interacted with. */
   @Prop({ mutable: true, reflect: true }) open?: boolean
 
   /** Use a blurry backdrop. */
-  @Prop() blurryBackdrop = false
+  @Prop() blurryBackdrop?: boolean = false
 
   /** Emitted when modal is opening (before transition). */
   @Event() ldmodalopening: EventEmitter

--- a/src/liquid/components/ld-modal/ld-modal.tsx
+++ b/src/liquid/components/ld-modal/ld-modal.tsx
@@ -30,13 +30,13 @@ export class LdModal {
   private dialogRef: HTMLDialogElement
 
   /** The modal is cancelable by default. However, you can change this using this prop. */
-  @Prop() cancelable?: boolean = true
+  @Prop() cancelable? = true
 
   /** Indicates that the modal dialog is active and can be interacted with. */
   @Prop({ mutable: true, reflect: true }) open?: boolean
 
   /** Use a blurry backdrop. */
-  @Prop() blurryBackdrop?: boolean = false
+  @Prop() blurryBackdrop? = false
 
   /** Emitted when modal is opening (before transition). */
   @Event() ldmodalopening: EventEmitter

--- a/src/liquid/components/ld-notice/ld-notice.tsx
+++ b/src/liquid/components/ld-notice/ld-notice.tsx
@@ -20,7 +20,7 @@ export class LdNotice {
   @Prop() headline?: string
 
   /** Mode of the notice. */
-  @Prop() mode: 'error' | 'info' | 'warning' | 'success' = 'info'
+  @Prop() mode?: 'error' | 'info' | 'warning' | 'success' = 'info'
 
   render() {
     return (

--- a/src/liquid/components/ld-notification/ld-notification.tsx
+++ b/src/liquid/components/ld-notification/ld-notification.tsx
@@ -18,7 +18,7 @@ export class LdNotification {
   /**
    * Notification placement within the screen.
    */
-  @Prop() placement: 'top' | 'bottom' = 'top'
+  @Prop() placement?: 'top' | 'bottom' = 'top'
 
   @State() queue: Notification[] = []
   @State() queueDismissed: Notification[] = []

--- a/src/liquid/components/ld-pagination/ld-pagination.tsx
+++ b/src/liquid/components/ld-pagination/ld-pagination.tsx
@@ -44,16 +44,16 @@ export class LdPagination {
   @Prop() endLabel?: string
 
   /** Hide the buttons to navigate forward/backward. */
-  @Prop() hidePrevNext = false
+  @Prop() hidePrevNext?: boolean = false
 
   /** Hide the buttons to navigate to the first/last item. */
-  @Prop() hideStartEnd = false
+  @Prop() hideStartEnd?: boolean = false
 
   /** Label to communicate the type of an item. */
-  @Prop() itemLabel = 'Page'
+  @Prop() itemLabel?: string = 'Page'
 
   /** The number of items/pages available for pagination (required to let the user jump to the last item/page). */
-  @Prop({ mutable: true }) length = Infinity
+  @Prop({ mutable: true }) length?: number = Infinity
 
   /** Items display mode, default as numbers. */
   @Prop() mode?: 'numbers' | 'dots' = 'numbers'
@@ -62,13 +62,13 @@ export class LdPagination {
   @Prop() nextLabel?: string
 
   /** Number of next/previous items visible. */
-  @Prop() offset = 2
+  @Prop() offset?: number = 2
 
   /** Label text for the backward button (replaces the icon). */
   @Prop() prevLabel?: string
 
   /** The currently selected item (an index of `-1` means nothing is selected). */
-  @Prop({ mutable: true }) selectedIndex = 0
+  @Prop({ mutable: true }) selectedIndex?: number = 0
 
   /** Size of the pagination. */
   @Prop() size?: 'sm' | 'lg'
@@ -80,7 +80,7 @@ export class LdPagination {
   @Prop() startLabel?: string
 
   /** Number of items permanently visible at the start/end. */
-  @Prop() sticky = 0
+  @Prop() sticky?: number = 0
 
   @State() maxSliderColumns = 0
   @State() renderMoreIndicators = false

--- a/src/liquid/components/ld-pagination/ld-pagination.tsx
+++ b/src/liquid/components/ld-pagination/ld-pagination.tsx
@@ -44,16 +44,16 @@ export class LdPagination {
   @Prop() endLabel?: string
 
   /** Hide the buttons to navigate forward/backward. */
-  @Prop() hidePrevNext?: boolean = false
+  @Prop() hidePrevNext? = false
 
   /** Hide the buttons to navigate to the first/last item. */
-  @Prop() hideStartEnd?: boolean = false
+  @Prop() hideStartEnd? = false
 
   /** Label to communicate the type of an item. */
-  @Prop() itemLabel?: string = 'Page'
+  @Prop() itemLabel? = 'Page'
 
   /** The number of items/pages available for pagination (required to let the user jump to the last item/page). */
-  @Prop({ mutable: true }) length?: number = Infinity
+  @Prop({ mutable: true }) length? = Infinity
 
   /** Items display mode, default as numbers. */
   @Prop() mode?: 'numbers' | 'dots' = 'numbers'
@@ -62,13 +62,13 @@ export class LdPagination {
   @Prop() nextLabel?: string
 
   /** Number of next/previous items visible. */
-  @Prop() offset?: number = 2
+  @Prop() offset? = 2
 
   /** Label text for the backward button (replaces the icon). */
   @Prop() prevLabel?: string
 
   /** The currently selected item (an index of `-1` means nothing is selected). */
-  @Prop({ mutable: true }) selectedIndex?: number = 0
+  @Prop({ mutable: true }) selectedIndex? = 0
 
   /** Size of the pagination. */
   @Prop() size?: 'sm' | 'lg'
@@ -80,7 +80,7 @@ export class LdPagination {
   @Prop() startLabel?: string
 
   /** Number of items permanently visible at the start/end. */
-  @Prop() sticky?: number = 0
+  @Prop() sticky? = 0
 
   @State() maxSliderColumns = 0
   @State() renderMoreIndicators = false

--- a/src/liquid/components/ld-progress/ld-progress.tsx
+++ b/src/liquid/components/ld-progress/ld-progress.tsx
@@ -21,13 +21,13 @@ export class LdProgress {
    * Set to a decimal value representing the maximum value, and greater
    * than aria-valuemin. If not present, the default value is 100.
    */
-  @Prop({ reflect: true }) ariaValuemax?: number = 100
+  @Prop({ reflect: true }) ariaValuemax? = 100
 
   /**
    * Set to a decimal value representing the minimum value, and less
    * than aria-valuemax. If not present, the default value is 0.
    */
-  @Prop({ reflect: true }) ariaValuemin?: number = 0
+  @Prop({ reflect: true }) ariaValuemin? = 0
 
   /**
    * Only present and required if the value is not indeterminate.

--- a/src/liquid/components/ld-progress/ld-progress.tsx
+++ b/src/liquid/components/ld-progress/ld-progress.tsx
@@ -21,13 +21,13 @@ export class LdProgress {
    * Set to a decimal value representing the maximum value, and greater
    * than aria-valuemin. If not present, the default value is 100.
    */
-  @Prop({ reflect: true }) ariaValuemax = 100
+  @Prop({ reflect: true }) ariaValuemax?: number = 100
 
   /**
    * Set to a decimal value representing the minimum value, and less
    * than aria-valuemax. If not present, the default value is 0.
    */
-  @Prop({ reflect: true }) ariaValuemin = 0
+  @Prop({ reflect: true }) ariaValuemin?: number = 0
 
   /**
    * Only present and required if the value is not indeterminate.

--- a/src/liquid/components/ld-radio/ld-radio.tsx
+++ b/src/liquid/components/ld-radio/ld-radio.tsx
@@ -36,22 +36,22 @@ export class LdRadio implements InnerFocusable, ClonesAttributes {
    * @internal
    * States that this radio button or another radio button with the same name is checked.
    */
-  @Prop() groupChecked = false
+  @Prop() groupChecked?: boolean = false
 
   /** Automatically focus the form control when the page is loaded. */
   @Prop({ reflect: true }) autofocus: boolean
 
   /** Indicates whether the radio button is selected. */
-  @Prop({ mutable: true }) checked = false
+  @Prop({ mutable: true }) checked?: boolean = false
 
   /** Disabled state of the radio. */
-  @Prop() disabled: boolean
+  @Prop() disabled?: boolean
 
   /** Associates the control with a form element. */
   @Prop() form?: string
 
   /** Set this property to `true` in order to mark the radio visually as invalid. */
-  @Prop() invalid: boolean
+  @Prop() invalid?: boolean
 
   /** Tab index of the input. */
   @Prop() ldTabindex: number | undefined
@@ -66,7 +66,7 @@ export class LdRadio implements InnerFocusable, ClonesAttributes {
   @Prop() readonly?: boolean
 
   /** Set this property to `true` in order to mark the radio button as required. */
-  @Prop() required: boolean
+  @Prop() required?: boolean
 
   /** radio tone. Use `'dark'` on white backgrounds. Default is a light tone. */
   @Prop() tone: 'dark'

--- a/src/liquid/components/ld-radio/ld-radio.tsx
+++ b/src/liquid/components/ld-radio/ld-radio.tsx
@@ -36,13 +36,13 @@ export class LdRadio implements InnerFocusable, ClonesAttributes {
    * @internal
    * States that this radio button or another radio button with the same name is checked.
    */
-  @Prop() groupChecked?: boolean = false
+  @Prop() groupChecked? = false
 
   /** Automatically focus the form control when the page is loaded. */
   @Prop({ reflect: true }) autofocus: boolean
 
   /** Indicates whether the radio button is selected. */
-  @Prop({ mutable: true }) checked?: boolean = false
+  @Prop({ mutable: true }) checked? = false
 
   /** Disabled state of the radio. */
   @Prop() disabled?: boolean

--- a/src/liquid/components/ld-radio/ld-radio.tsx
+++ b/src/liquid/components/ld-radio/ld-radio.tsx
@@ -69,7 +69,7 @@ export class LdRadio implements InnerFocusable, ClonesAttributes {
   @Prop() required?: boolean
 
   /** radio tone. Use `'dark'` on white backgrounds. Default is a light tone. */
-  @Prop() tone: 'dark'
+  @Prop() tone?: 'dark'
 
   /** The input value. */
   @Prop() value: string

--- a/src/liquid/components/ld-select/ld-option-internal/ld-option-internal.tsx
+++ b/src/liquid/components/ld-select/ld-option-internal/ld-option-internal.tsx
@@ -33,12 +33,12 @@ export class LdOptionInternal {
   /**
    * If present, this boolean attribute indicates that the option is selected.
    */
-  @Prop({ mutable: true, reflect: true }) selected?: boolean = false
+  @Prop({ mutable: true, reflect: true }) selected? = false
 
   /**
    * Disables the option.
    */
-  @Prop() disabled?: boolean = false
+  @Prop() disabled? = false
 
   /**
    * Prevents deselection of a selected options when the selected option
@@ -55,7 +55,7 @@ export class LdOptionInternal {
   @Prop() size?: 'sm' | 'lg'
 
   /** Set to true on filtering via select input. */
-  @Prop() filtered?: boolean = false
+  @Prop() filtered? = false
 
   /**
    * Sets focus internally.

--- a/src/liquid/components/ld-select/ld-option-internal/ld-option-internal.tsx
+++ b/src/liquid/components/ld-select/ld-option-internal/ld-option-internal.tsx
@@ -33,18 +33,18 @@ export class LdOptionInternal {
   /**
    * If present, this boolean attribute indicates that the option is selected.
    */
-  @Prop({ mutable: true, reflect: true }) selected = false
+  @Prop({ mutable: true, reflect: true }) selected?: boolean = false
 
   /**
    * Disables the option.
    */
-  @Prop() disabled = false
+  @Prop() disabled?: boolean = false
 
   /**
    * Prevents deselection of a selected options when the selected option
    * is clicked in single select mode.
    */
-  @Prop() preventDeselection: boolean
+  @Prop() preventDeselection?: boolean
 
   /**
    * Display mode.
@@ -55,7 +55,7 @@ export class LdOptionInternal {
   @Prop() size?: 'sm' | 'lg'
 
   /** Set to true on filtering via select input. */
-  @Prop() filtered = false
+  @Prop() filtered?: boolean = false
 
   /**
    * Sets focus internally.

--- a/src/liquid/components/ld-select/ld-option/ld-option.tsx
+++ b/src/liquid/components/ld-select/ld-option/ld-option.tsx
@@ -19,21 +19,17 @@ export class LdOption {
    */
   @Prop() value: string
 
-  /**
-   * If present, this boolean attribute indicates that the option is selected.
-   */
-  @Prop() selected: boolean
+  /** If present, this boolean attribute indicates that the option is selected. */
+  @Prop() selected?: boolean
 
-  /**
-   * Disables the option.
-   */
-  @Prop() disabled: boolean
+  /** Disables the option. */
+  @Prop() disabled?: boolean
 
   /**
    * @internal
    * Set to true on filtering via select input.
    */
-  @Prop() filtered = false
+  @Prop() filtered?: boolean = false
 
   componentWillLoad() {
     // Setting selected via prop directly triggers the mutation observer to fire twice on attribute chage.

--- a/src/liquid/components/ld-select/ld-option/ld-option.tsx
+++ b/src/liquid/components/ld-select/ld-option/ld-option.tsx
@@ -29,7 +29,7 @@ export class LdOption {
    * @internal
    * Set to true on filtering via select input.
    */
-  @Prop() filtered?: boolean = false
+  @Prop() filtered? = false
 
   componentWillLoad() {
     // Setting selected via prop directly triggers the mutation observer to fire twice on attribute chage.

--- a/src/liquid/components/ld-select/ld-select-popper/ld-select-popper.tsx
+++ b/src/liquid/components/ld-select/ld-select-popper/ld-select-popper.tsx
@@ -43,7 +43,7 @@ export class LdSelectPopper {
   @Prop() detached?: boolean
 
   /** Indicates if select element is expanded. */
-  @Prop() expanded?: boolean = false
+  @Prop() expanded? = false
 
   /** Set this property to `true` in order to enable an input field for filtering options. */
   @Prop() filter?: boolean

--- a/src/liquid/components/ld-select/ld-select-popper/ld-select-popper.tsx
+++ b/src/liquid/components/ld-select/ld-select-popper/ld-select-popper.tsx
@@ -22,7 +22,7 @@ export class LdSelectPopper {
   @Element() el: HTMLElement
 
   /** Indicates that all options are filtered (used in creatable mode) */
-  @Prop() allOptionsFiltered: boolean
+  @Prop() allOptionsFiltered?: boolean
 
   /** A watcher is applied to the CSS class in order to be able to react to tether changes. */
   @Prop({ reflect: true }) class: string
@@ -31,7 +31,7 @@ export class LdSelectPopper {
    * Creatable mode can be enabled when the filter prop is set to true.
    * This mode allows the user to create new options using the filter input field.
    */
-  @Prop() creatable: boolean
+  @Prop() creatable?: boolean
 
   /** The "create" input label (creatable mode). */
   @Prop() createInputLabel: string
@@ -40,16 +40,16 @@ export class LdSelectPopper {
   @Prop() createButtonLabel: string
 
   /** Popper is visually detached from the select trigger element (there's a gap between the two). */
-  @Prop() detached: boolean
+  @Prop() detached?: boolean
 
   /** Indicates if select element is expanded. */
-  @Prop() expanded = false
+  @Prop() expanded?: boolean = false
 
   /** Set this property to `true` in order to enable an input field for filtering options. */
-  @Prop() filter: boolean
+  @Prop() filter?: boolean
 
   /** The filter input value matches an option (do not allow to create the option). */
-  @Prop() filterMatchesOption: boolean
+  @Prop() filterMatchesOption?: boolean
 
   /** The filter input placeholder. */
   @Prop() filterPlaceholder: string

--- a/src/liquid/components/ld-select/ld-select.tsx
+++ b/src/liquid/components/ld-select/ld-select.tsx
@@ -51,28 +51,28 @@ export class LdSelect implements InnerFocusable {
    * Creatable mode can be enabled when the filter prop is set to true.
    * This mode allows the user to create new options using the filter input field.
    */
-  @Prop() creatable: boolean
+  @Prop() creatable?: boolean
 
   /** The "create" input label (creatable mode). */
-  @Prop() createInputLabel = 'Press Enter to create option'
+  @Prop() createInputLabel?: string = 'Press Enter to create option'
 
   /** The "create" button label (creatable mode). */
-  @Prop() createButtonLabel = 'Create option'
+  @Prop() createButtonLabel?: string = 'Create option'
 
   /** Disabled state of the component. */
-  @Prop() disabled: boolean
+  @Prop() disabled?: boolean
 
   /** The form element to associate the select with (its form owner). */
   @Prop() form?: string
 
   /** Set this property to `true` in order to enable an input field for filtering options. */
-  @Prop() filter: boolean
+  @Prop() filter?: boolean
 
   /** The filter input placeholder. */
-  @Prop() filterPlaceholder = 'Filter options'
+  @Prop() filterPlaceholder?: string = 'Filter options'
 
   /** Set this property to `true` in order to mark the select visually as invalid. */
-  @Prop() invalid: boolean
+  @Prop() invalid?: boolean
 
   /** Tab index of the trigger button. */
   @Prop() ldTabindex = 0
@@ -89,7 +89,7 @@ export class LdSelect implements InnerFocusable {
     | 'ghost' //    = inline   + transparent background and borders
 
   /** Multiselect mode. */
-  @Prop() multiple: boolean
+  @Prop() multiple?: boolean
 
   /** Used to specify the name of the control. */
   @Prop() name: string
@@ -101,7 +101,7 @@ export class LdSelect implements InnerFocusable {
   @Prop() popperClass?: string
 
   /** Prevents a state with no options selected after initial selection in single select mode. */
-  @Prop() preventDeselection: boolean
+  @Prop() preventDeselection?: boolean
 
   /** A Boolean attribute indicating that an option with a non-empty string value must be selected. */
   @Prop() required?: boolean

--- a/src/liquid/components/ld-select/ld-select.tsx
+++ b/src/liquid/components/ld-select/ld-select.tsx
@@ -54,10 +54,10 @@ export class LdSelect implements InnerFocusable {
   @Prop() creatable?: boolean
 
   /** The "create" input label (creatable mode). */
-  @Prop() createInputLabel?: string = 'Press Enter to create option'
+  @Prop() createInputLabel? = 'Press Enter to create option'
 
   /** The "create" button label (creatable mode). */
-  @Prop() createButtonLabel?: string = 'Create option'
+  @Prop() createButtonLabel? = 'Create option'
 
   /** Disabled state of the component. */
   @Prop() disabled?: boolean
@@ -69,7 +69,7 @@ export class LdSelect implements InnerFocusable {
   @Prop() filter?: boolean
 
   /** The filter input placeholder. */
-  @Prop() filterPlaceholder?: string = 'Filter options'
+  @Prop() filterPlaceholder? = 'Filter options'
 
   /** Set this property to `true` in order to mark the select visually as invalid. */
   @Prop() invalid?: boolean

--- a/src/liquid/components/ld-sidenav/ld-sidenav-accordion/ld-sidenav-accordion.tsx
+++ b/src/liquid/components/ld-sidenav/ld-sidenav-accordion/ld-sidenav-accordion.tsx
@@ -44,7 +44,7 @@ export class LdSidenavAccordion {
    * Set to false to make the accordion collapse on sidenav collapse
    * or slide change.
    */
-  @Prop() preserveState = true
+  @Prop() preserveState?: boolean = true
 
   /**
    * Split the accordion toggle in two parts with the second part containing

--- a/src/liquid/components/ld-sidenav/ld-sidenav-accordion/ld-sidenav-accordion.tsx
+++ b/src/liquid/components/ld-sidenav/ld-sidenav-accordion/ld-sidenav-accordion.tsx
@@ -44,7 +44,7 @@ export class LdSidenavAccordion {
    * Set to false to make the accordion collapse on sidenav collapse
    * or slide change.
    */
-  @Prop() preserveState?: boolean = true
+  @Prop() preserveState? = true
 
   /**
    * Split the accordion toggle in two parts with the second part containing

--- a/src/liquid/components/ld-sidenav/ld-sidenav-back/ld-sidenav-back.tsx
+++ b/src/liquid/components/ld-sidenav/ld-sidenav-back/ld-sidenav-back.tsx
@@ -29,7 +29,7 @@ export class LdSidenavBack {
   @Event() ldSidenavBack: EventEmitter
 
   /** Used as aria-label for the back button */
-  @Prop() backLabel?: string = 'Back'
+  @Prop() backLabel? = 'Back'
 
   @State() parentLabel = ''
   @State() rounded = false

--- a/src/liquid/components/ld-sidenav/ld-sidenav-back/ld-sidenav-back.tsx
+++ b/src/liquid/components/ld-sidenav/ld-sidenav-back/ld-sidenav-back.tsx
@@ -29,7 +29,7 @@ export class LdSidenavBack {
   @Event() ldSidenavBack: EventEmitter
 
   /** Used as aria-label for the back button */
-  @Prop() backLabel = 'Back'
+  @Prop() backLabel?: string = 'Back'
 
   @State() parentLabel = ''
   @State() rounded = false

--- a/src/liquid/components/ld-sidenav/ld-sidenav-header/ld-sidenav-header.tsx
+++ b/src/liquid/components/ld-sidenav/ld-sidenav-header/ld-sidenav-header.tsx
@@ -35,9 +35,9 @@ export class LdSidenavHeader {
   @Prop() ariaLabel: string
 
   /** Label to be used for the toggle button when navigation is expanded. */
-  @Prop() labelCollapse = 'Collapse side navigation'
+  @Prop() labelCollapse?: string = 'Collapse side navigation'
   /** Label to be used for the toggle button when navigation is collapsed. */
-  @Prop() labelExpand = 'Expand side navigation'
+  @Prop() labelExpand?: string = 'Expand side navigation'
 
   /** Tooltip tether options object to be merged with the default options (optionally stringified). */
   @Prop() tetherOptions?: Partial<Tether.ITetherOptions> | string

--- a/src/liquid/components/ld-sidenav/ld-sidenav-header/ld-sidenav-header.tsx
+++ b/src/liquid/components/ld-sidenav/ld-sidenav-header/ld-sidenav-header.tsx
@@ -35,9 +35,9 @@ export class LdSidenavHeader {
   @Prop() ariaLabel: string
 
   /** Label to be used for the toggle button when navigation is expanded. */
-  @Prop() labelCollapse?: string = 'Collapse side navigation'
+  @Prop() labelCollapse? = 'Collapse side navigation'
   /** Label to be used for the toggle button when navigation is collapsed. */
-  @Prop() labelExpand?: string = 'Expand side navigation'
+  @Prop() labelExpand? = 'Expand side navigation'
 
   /** Tooltip tether options object to be merged with the default options (optionally stringified). */
   @Prop() tetherOptions?: Partial<Tether.ITetherOptions> | string

--- a/src/liquid/components/ld-sidenav/ld-sidenav-navitem/ld-sidenav-navitem.tsx
+++ b/src/liquid/components/ld-sidenav/ld-sidenav-navitem/ld-sidenav-navitem.tsx
@@ -34,7 +34,7 @@ export class LdSidenavNavitem implements InnerFocusable {
   private slotContainerRef: HTMLElement
 
   /** Sets visual indicator to denote that the nav item is currently selected. */
-  @Prop() selected?: boolean = false
+  @Prop() selected? = false
 
   /**
    * Transforms the nav item to an anchor element.
@@ -52,7 +52,7 @@ export class LdSidenavNavitem implements InnerFocusable {
   @Prop() mode?: 'primary' | 'secondary' | 'tertiary' = 'primary'
 
   /** Applies full border-radius. */
-  @Prop({ reflect: true }) rounded?: boolean = false
+  @Prop({ reflect: true }) rounded? = false
 
   /** Tab index of the button. */
   @Prop() ldTabindex: number | undefined

--- a/src/liquid/components/ld-sidenav/ld-sidenav-navitem/ld-sidenav-navitem.tsx
+++ b/src/liquid/components/ld-sidenav/ld-sidenav-navitem/ld-sidenav-navitem.tsx
@@ -34,7 +34,7 @@ export class LdSidenavNavitem implements InnerFocusable {
   private slotContainerRef: HTMLElement
 
   /** Sets visual indicator to denote that the nav item is currently selected. */
-  @Prop() selected = false
+  @Prop() selected?: boolean = false
 
   /**
    * Transforms the nav item to an anchor element.
@@ -52,7 +52,7 @@ export class LdSidenavNavitem implements InnerFocusable {
   @Prop() mode?: 'primary' | 'secondary' | 'tertiary' = 'primary'
 
   /** Applies full border-radius. */
-  @Prop({ reflect: true }) rounded = false
+  @Prop({ reflect: true }) rounded?: boolean = false
 
   /** Tab index of the button. */
   @Prop() ldTabindex: number | undefined

--- a/src/liquid/components/ld-sidenav/ld-sidenav-subnav/ld-sidenav-subnav.tsx
+++ b/src/liquid/components/ld-sidenav/ld-sidenav-subnav/ld-sidenav-subnav.tsx
@@ -32,21 +32,21 @@ export class LdSidenavSubnav {
    * Internal prop indicating that the subnav is about to become active which
    * may happen before a transition finishes after which it actually becomes active.
    */
-  @Prop() activeBeforeTransition = false
+  @Prop() activeBeforeTransition?: boolean = false
 
   /**
    * @internal
    * Internal prop indicating that the subnav is either ancestor of the
    * currently visible subnav or the currently visible subnav itself.
    */
-  @Prop() active = false
+  @Prop() active?: boolean = false
 
   /**
    * @internal
    * Internal prop indicating that the subnav is ancestor of the
    * currently visible subnav.
    */
-  @Prop() ancestor = false
+  @Prop() ancestor?: boolean = false
 
   /** Used in the ld-sidenav-back component to display parent nav label. */
   @Prop() label: string

--- a/src/liquid/components/ld-sidenav/ld-sidenav-subnav/ld-sidenav-subnav.tsx
+++ b/src/liquid/components/ld-sidenav/ld-sidenav-subnav/ld-sidenav-subnav.tsx
@@ -32,21 +32,21 @@ export class LdSidenavSubnav {
    * Internal prop indicating that the subnav is about to become active which
    * may happen before a transition finishes after which it actually becomes active.
    */
-  @Prop() activeBeforeTransition?: boolean = false
+  @Prop() activeBeforeTransition? = false
 
   /**
    * @internal
    * Internal prop indicating that the subnav is either ancestor of the
    * currently visible subnav or the currently visible subnav itself.
    */
-  @Prop() active?: boolean = false
+  @Prop() active? = false
 
   /**
    * @internal
    * Internal prop indicating that the subnav is ancestor of the
    * currently visible subnav.
    */
-  @Prop() ancestor?: boolean = false
+  @Prop() ancestor? = false
 
   /** Used in the ld-sidenav-back component to display parent nav label. */
   @Prop() label: string

--- a/src/liquid/components/ld-sidenav/ld-sidenav-toggle-outside/ld-sidenav-toggle-outside.tsx
+++ b/src/liquid/components/ld-sidenav/ld-sidenav-toggle-outside/ld-sidenav-toggle-outside.tsx
@@ -26,7 +26,7 @@ export class LdSidenavToggleOutside implements InnerFocusable {
   private toggle: HTMLButtonElement
 
   /** Label to be used for the toggle button when navigation is collapsed. */
-  @Prop() labelExpand?: string = 'Expand side navigation'
+  @Prop() labelExpand? = 'Expand side navigation'
 
   /** Tab index of the toggle. */
   @Prop() ldTabindex: number | undefined

--- a/src/liquid/components/ld-sidenav/ld-sidenav-toggle-outside/ld-sidenav-toggle-outside.tsx
+++ b/src/liquid/components/ld-sidenav/ld-sidenav-toggle-outside/ld-sidenav-toggle-outside.tsx
@@ -26,7 +26,7 @@ export class LdSidenavToggleOutside implements InnerFocusable {
   private toggle: HTMLButtonElement
 
   /** Label to be used for the toggle button when navigation is collapsed. */
-  @Prop() labelExpand = 'Expand side navigation'
+  @Prop() labelExpand?: string = 'Expand side navigation'
 
   /** Tab index of the toggle. */
   @Prop() ldTabindex: number | undefined

--- a/src/liquid/components/ld-sidenav/ld-sidenav.tsx
+++ b/src/liquid/components/ld-sidenav/ld-sidenav.tsx
@@ -39,10 +39,10 @@ export class LdSidenav {
    * opened and closed as opposed to being expanded and collapsed.
    * The prop value is used in a max-width media query.
    */
-  @Prop() breakpoint?: string = '23.4375rem'
+  @Prop() breakpoint? = '23.4375rem'
 
   /** Indicates that the navigation is collapsed to the side of its container. */
-  @Prop({ mutable: true }) collapsed?: boolean = false
+  @Prop({ mutable: true }) collapsed? = false
 
   /**
    * Makes the navigation collapse either on
@@ -58,7 +58,7 @@ export class LdSidenav {
   /**
    * Allows the side navigation to be collapsed to the side of its container.
    */
-  @Prop() collapsible?: boolean = false
+  @Prop() collapsible? = false
 
   /**
    * Makes the navigation expand either on
@@ -70,20 +70,20 @@ export class LdSidenav {
   @Prop() expandTrigger?: 'toggle' | 'mouseenter' = 'toggle'
 
   /** Label to be used for the landmark element (the sidenav itself). */
-  @Prop() label?: string = 'Side navigation'
+  @Prop() label? = 'Side navigation'
 
   /**
    * Set to true if you'd like to have a sidenav which partially
    * collapses in way, that slotted ld-navitem components are displayed
    * as icon buttons.
    */
-  @Prop() narrow?: boolean = false
+  @Prop() narrow? = false
 
   /**
    * Indicates that the navigation is visible in a viewport
    * which is smaller than the value of the `breakpoint` prop.
    */
-  @Prop({ mutable: true }) open?: boolean = false
+  @Prop({ mutable: true }) open? = false
 
   /**
    * Disables transitions on collapsing and expansion of the sidenav.
@@ -91,7 +91,7 @@ export class LdSidenav {
    * the side on sidenav expansion, and you want to prevent too many
    * layout shifts during the transition.
    */
-  @Prop() toggleTransitionDisabled?: boolean = false
+  @Prop() toggleTransitionDisabled? = false
 
   /**
    * Enables focus trapping. Accespts a CSS selector which indicates

--- a/src/liquid/components/ld-sidenav/ld-sidenav.tsx
+++ b/src/liquid/components/ld-sidenav/ld-sidenav.tsx
@@ -476,10 +476,7 @@ export class LdSidenav {
     ).filter(
       (child) =>
         child.tagName === 'LD-SIDENAV-NAVITEM' &&
-        ((child as HTMLLdSidenavNavitemElement).mode as
-          | 'primary'
-          | 'secondary'
-          | 'tertiary') === 'primary'
+        (child as HTMLLdSidenavNavitemElement).mode === 'primary'
     )
     const navitemsModePrimaryInAccordion = Array.from(
       activeSubnav.querySelectorAll(
@@ -487,10 +484,7 @@ export class LdSidenav {
       )
     ).filter(
       (child: HTMLLdSidenavNavitemElement) =>
-        ((child as HTMLLdSidenavNavitemElement).mode as
-          | 'primary'
-          | 'secondary'
-          | 'tertiary') === 'primary'
+        (child as HTMLLdSidenavNavitemElement).mode === 'primary'
     )
     const totalNavitemsModePrimary =
       navitemsModePrimaryChildren.length + navitemsModePrimaryInAccordion.length

--- a/src/liquid/components/ld-sidenav/ld-sidenav.tsx
+++ b/src/liquid/components/ld-sidenav/ld-sidenav.tsx
@@ -39,10 +39,10 @@ export class LdSidenav {
    * opened and closed as opposed to being expanded and collapsed.
    * The prop value is used in a max-width media query.
    */
-  @Prop() breakpoint = '23.4375rem'
+  @Prop() breakpoint?: string = '23.4375rem'
 
   /** Indicates that the navigation is collapsed to the side of its container. */
-  @Prop({ mutable: true }) collapsed = false
+  @Prop({ mutable: true }) collapsed?: boolean = false
 
   /**
    * Makes the navigation collapse either on
@@ -58,7 +58,7 @@ export class LdSidenav {
   /**
    * Allows the side navigation to be collapsed to the side of its container.
    */
-  @Prop() collapsible = false
+  @Prop() collapsible?: boolean = false
 
   /**
    * Makes the navigation expand either on
@@ -70,20 +70,20 @@ export class LdSidenav {
   @Prop() expandTrigger: 'toggle' | 'mouseenter' = 'toggle'
 
   /** Label to be used for the landmark element (the sidenav itself). */
-  @Prop() label = 'Side navigation'
+  @Prop() label?: string = 'Side navigation'
 
   /**
    * Set to true if you'd like to have a sidenav which partially
    * collapses in way, that slotted ld-navitem components are displayed
    * as icon buttons.
    */
-  @Prop() narrow = false
+  @Prop() narrow?: boolean = false
 
   /**
    * Indicates that the navigation is visible in a viewport
    * which is smaller than the value of the `breakpoint` prop.
    */
-  @Prop({ mutable: true }) open = false
+  @Prop({ mutable: true }) open?: boolean = false
 
   /**
    * Disables transitions on collapsing and expansion of the sidenav.
@@ -91,7 +91,7 @@ export class LdSidenav {
    * the side on sidenav expansion, and you want to prevent too many
    * layout shifts during the transition.
    */
-  @Prop() toggleTransitionDisabled = false
+  @Prop() toggleTransitionDisabled?: boolean = false
 
   /**
    * Enables focus trapping. Accespts a CSS selector which indicates
@@ -476,7 +476,10 @@ export class LdSidenav {
     ).filter(
       (child) =>
         child.tagName === 'LD-SIDENAV-NAVITEM' &&
-        (child as HTMLLdSidenavNavitemElement).mode === 'primary'
+        ((child as HTMLLdSidenavNavitemElement).mode as
+          | 'primary'
+          | 'secondary'
+          | 'tertiary') === 'primary'
     )
     const navitemsModePrimaryInAccordion = Array.from(
       activeSubnav.querySelectorAll(
@@ -484,7 +487,10 @@ export class LdSidenav {
       )
     ).filter(
       (child: HTMLLdSidenavNavitemElement) =>
-        (child as HTMLLdSidenavNavitemElement).mode === 'primary'
+        ((child as HTMLLdSidenavNavitemElement).mode as
+          | 'primary'
+          | 'secondary'
+          | 'tertiary') === 'primary'
     )
     const totalNavitemsModePrimary =
       navitemsModePrimaryChildren.length + navitemsModePrimaryInAccordion.length

--- a/src/liquid/components/ld-sidenav/ld-sidenav.tsx
+++ b/src/liquid/components/ld-sidenav/ld-sidenav.tsx
@@ -32,7 +32,7 @@ export class LdSidenav {
   private mediaQuery: MediaQueryList
 
   /** Whether the nav should be aligned to the left or the right side of its container. */
-  @Prop() align: 'left' | 'right' = 'left'
+  @Prop() align?: 'left' | 'right' = 'left'
 
   /**
    * The breakpoint at which the sidenav takes full width and can be
@@ -53,7 +53,7 @@ export class LdSidenav {
    * - clickoutside applies if the collapse trigger is set to mouseout
    * - toggle applies if the collapse trigger is set to clickoutside
    */
-  @Prop() collapseTrigger: 'toggle' | 'clickoutside' | 'mouseout' = 'toggle'
+  @Prop() collapseTrigger?: 'toggle' | 'clickoutside' | 'mouseout' = 'toggle'
 
   /**
    * Allows the side navigation to be collapsed to the side of its container.
@@ -67,7 +67,7 @@ export class LdSidenav {
    * The modes are inclusive from right to left:
    * - toggle applies if the expand trigger is set to mouseenter
    */
-  @Prop() expandTrigger: 'toggle' | 'mouseenter' = 'toggle'
+  @Prop() expandTrigger?: 'toggle' | 'mouseenter' = 'toggle'
 
   /** Label to be used for the landmark element (the sidenav itself). */
   @Prop() label?: string = 'Side navigation'

--- a/src/liquid/components/ld-slider/ld-slider.tsx
+++ b/src/liquid/components/ld-slider/ld-slider.tsx
@@ -58,25 +58,25 @@ export class LdSlider implements InnerFocusable {
   /** Alternative disabled state that keeps element focusable */
   @Prop() ariaDisabled: string
   /** Disabled state of the slider */
-  @Prop() disabled?: boolean = false
+  @Prop() disabled? = false
   /** Prevents rendering of the stop labels below the slider */
-  @Prop() hideStopLabels?: boolean = false
+  @Prop() hideStopLabels? = false
   /** Prevents rendering of the value labels below the slider */
-  @Prop() hideValueLabels?: boolean = false
+  @Prop() hideValueLabels? = false
   /** Makes the current values only visible on interaction */
-  @Prop() hideValues?: boolean = false
+  @Prop() hideValues? = false
   /** Specifies the legal number intervals */
-  @Prop() indicators?: boolean = false
+  @Prop() indicators? = false
   /** "From" value label (when exactly 2 values are given) */
-  @Prop() labelFrom?: string = 'From'
+  @Prop() labelFrom? = 'From'
   /** "To" value label (when exactly 2 values are given) */
-  @Prop() labelTo?: string = 'To'
+  @Prop() labelTo? = 'To'
   /** "Value" label (when exactly 2 values are given) */
-  @Prop() labelValue?: string = 'Value'
+  @Prop() labelValue? = 'Value'
   /** Specifies the maximum value allowed */
-  @Prop() max?: number = 100
+  @Prop() max? = 100
   /** Specifies the minimum value allowed */
-  @Prop() min?: number = 0
+  @Prop() min? = 0
   /** Swap which areas are being marked as selected and deselected */
   @Prop() negative? = false
   /** Size of the thumb(s). */
@@ -88,7 +88,7 @@ export class LdSlider implements InnerFocusable {
   /** Adds custom stop points to the slider (instead of steps) */
   @Prop() stops?: string
   /** Allows swapping of thumbs */
-  @Prop() swappable?: boolean = false
+  @Prop() swappable? = false
   /** Tab index of the input(s). */
   @Prop() ldTabindex: number | undefined
   /** Adds custom stop points to the slider (instead of steps) */

--- a/src/liquid/components/ld-slider/ld-slider.tsx
+++ b/src/liquid/components/ld-slider/ld-slider.tsx
@@ -58,25 +58,25 @@ export class LdSlider implements InnerFocusable {
   /** Alternative disabled state that keeps element focusable */
   @Prop() ariaDisabled: string
   /** Disabled state of the slider */
-  @Prop() disabled = false
+  @Prop() disabled?: boolean = false
   /** Prevents rendering of the stop labels below the slider */
-  @Prop() hideStopLabels = false
+  @Prop() hideStopLabels?: boolean = false
   /** Prevents rendering of the value labels below the slider */
-  @Prop() hideValueLabels = false
+  @Prop() hideValueLabels?: boolean = false
   /** Makes the current values only visible on interaction */
-  @Prop() hideValues = false
+  @Prop() hideValues?: boolean = false
   /** Specifies the legal number intervals */
-  @Prop() indicators = false
+  @Prop() indicators?: boolean = false
   /** "From" value label (when exactly 2 values are given) */
-  @Prop() labelFrom = 'From'
+  @Prop() labelFrom?: string = 'From'
   /** "To" value label (when exactly 2 values are given) */
-  @Prop() labelTo = 'To'
+  @Prop() labelTo?: string = 'To'
   /** "Value" label (when exactly 2 values are given) */
-  @Prop() labelValue = 'Value'
+  @Prop() labelValue?: string = 'Value'
   /** Specifies the maximum value allowed */
-  @Prop() max = 100
+  @Prop() max?: number = 100
   /** Specifies the minimum value allowed */
-  @Prop() min = 0
+  @Prop() min?: number = 0
   /** Swap which areas are being marked as selected and deselected */
   @Prop() negative? = false
   /** Size of the thumb(s). */
@@ -88,7 +88,7 @@ export class LdSlider implements InnerFocusable {
   /** Adds custom stop points to the slider (instead of steps) */
   @Prop() stops?: string
   /** Allows swapping of thumbs */
-  @Prop() swappable = false
+  @Prop() swappable?: boolean = false
   /** Tab index of the input(s). */
   @Prop() ldTabindex: number | undefined
   /** Adds custom stop points to the slider (instead of steps) */

--- a/src/liquid/components/ld-stepper/ld-step/ld-step.tsx
+++ b/src/liquid/components/ld-stepper/ld-step/ld-step.tsx
@@ -34,43 +34,43 @@ export class LdStep implements InnerFocusable {
   private focusableElement: HTMLButtonElement | HTMLAnchorElement
 
   /** Switch colors for brand background */
-  @Prop() brandColor?: boolean = false
+  @Prop() brandColor? = false
   /** Step is the current step */
-  @Prop() current?: boolean = false
+  @Prop() current? = false
   /** Description text to display below the step name (vertical mode only) */
   @Prop() description: string
   /** Step is not clickable */
-  @Prop() disabled?: boolean = false
+  @Prop() disabled? = false
   /** Step is done */
-  @Prop() done?: boolean = false
+  @Prop() done? = false
   /** Link to the step (makes the step an anchor instead of a button) */
   @Prop() href?: string
   /** Permanently show a custom icon inside the dot */
   @Prop() icon?: HTMLLdIconElement['name']
   /** Label for current step (scree-reader only) */
-  @Prop() labelCurrent?: string = 'Current'
+  @Prop() labelCurrent? = 'Current'
   /** Label for step that is done (scree-reader only) */
-  @Prop() labelDone?: string = 'Done'
+  @Prop() labelDone? = 'Done'
   /** Label for step that is optional (scree-reader only) */
-  @Prop() labelOptional?: string = 'Optional'
+  @Prop() labelOptional? = 'Optional'
   /** Label for step that was skipped (scree-reader only) */
-  @Prop() labelSkipped?: string = 'Skipped'
+  @Prop() labelSkipped? = 'Skipped'
   /** Additional hint in label for step that is done and was optional (scree-reader only) */
-  @Prop() labelWasOptional?: string = 'was optional'
+  @Prop() labelWasOptional? = 'was optional'
   /** Indicates that the next step is not active */
-  @Prop() lastActive?: boolean = false
+  @Prop() lastActive? = false
   /** Tab index of the step */
   @Prop() ldTabindex: number | undefined
   /** Step can be processed next */
-  @Prop() next?: boolean = false
+  @Prop() next? = false
   /** Step may be skipped */
-  @Prop() optional?: boolean = false
+  @Prop() optional? = false
   /** Step size */
   @Prop() size?: 'sm' | 'lg'
   /** Step was skipped */
-  @Prop() skipped?: boolean = false
+  @Prop() skipped? = false
   /** Vertical layout */
-  @Prop() vertical?: boolean = false
+  @Prop() vertical? = false
 
   /** Emitted when the focusable element is clicked and step is neither current nor disabled */
   @Event() ldstepselected: EventEmitter<SelectedDetail>

--- a/src/liquid/components/ld-stepper/ld-step/ld-step.tsx
+++ b/src/liquid/components/ld-stepper/ld-step/ld-step.tsx
@@ -34,43 +34,43 @@ export class LdStep implements InnerFocusable {
   private focusableElement: HTMLButtonElement | HTMLAnchorElement
 
   /** Switch colors for brand background */
-  @Prop() brandColor = false
+  @Prop() brandColor?: boolean = false
   /** Step is the current step */
-  @Prop() current = false
+  @Prop() current?: boolean = false
   /** Description text to display below the step name (vertical mode only) */
   @Prop() description: string
   /** Step is not clickable */
-  @Prop() disabled = false
+  @Prop() disabled?: boolean = false
   /** Step is done */
-  @Prop() done = false
+  @Prop() done?: boolean = false
   /** Link to the step (makes the step an anchor instead of a button) */
   @Prop() href?: string
   /** Permanently show a custom icon inside the dot */
   @Prop() icon?: HTMLLdIconElement['name']
   /** Label for current step (scree-reader only) */
-  @Prop() labelCurrent = 'Current'
+  @Prop() labelCurrent?: string = 'Current'
   /** Label for step that is done (scree-reader only) */
-  @Prop() labelDone = 'Done'
+  @Prop() labelDone?: string = 'Done'
   /** Label for step that is optional (scree-reader only) */
-  @Prop() labelOptional = 'Optional'
+  @Prop() labelOptional?: string = 'Optional'
   /** Label for step that was skipped (scree-reader only) */
-  @Prop() labelSkipped = 'Skipped'
+  @Prop() labelSkipped?: string = 'Skipped'
   /** Additional hint in label for step that is done and was optional (scree-reader only) */
-  @Prop() labelWasOptional = 'was optional'
+  @Prop() labelWasOptional?: string = 'was optional'
   /** Indicates that the next step is not active */
-  @Prop() lastActive = false
+  @Prop() lastActive?: boolean = false
   /** Tab index of the step */
   @Prop() ldTabindex: number | undefined
   /** Step can be processed next */
-  @Prop() next = false
+  @Prop() next?: boolean = false
   /** Step may be skipped */
-  @Prop() optional = false
+  @Prop() optional?: boolean = false
   /** Step size */
   @Prop() size?: 'sm' | 'lg'
   /** Step was skipped */
-  @Prop() skipped = false
+  @Prop() skipped?: boolean = false
   /** Vertical layout */
-  @Prop() vertical = false
+  @Prop() vertical?: boolean = false
 
   /** Emitted when the focusable element is clicked and step is neither current nor disabled */
   @Event() ldstepselected: EventEmitter<SelectedDetail>

--- a/src/liquid/components/ld-stepper/ld-stepper.tsx
+++ b/src/liquid/components/ld-stepper/ld-stepper.tsx
@@ -27,17 +27,17 @@ export class LdStepper {
   @Element() el: HTMLLdStepperElement
 
   /** Switch colors for brand background. */
-  @Prop() brandColor?: boolean = false
+  @Prop() brandColor? = false
   /** Indicates whether the steps should be evenly distributed or fit to their content */
-  @Prop() fitContent?: boolean = false
+  @Prop() fitContent? = false
   /** Template for the screen-reader label, containing the label of the current step and the steps summary */
-  @Prop() labelTemplate?: string = '$1, $2'
+  @Prop() labelTemplate? = '$1, $2'
   /** Step summary template for the screen-reader label, containing the index of the current step and the overall number of steps */
-  @Prop() labelSummaryTemplate?: string = 'step $1 of $2'
+  @Prop() labelSummaryTemplate? = 'step $1 of $2'
   /** Step size */
   @Prop() size?: HTMLLdStepElement['size']
   /** Vertical layout */
-  @Prop() vertical?: boolean = false
+  @Prop() vertical? = false
 
   // The following event is not used within the ld-stepper component itself.
   // Its only purpose is to create a type definition on the ld-stepper component,

--- a/src/liquid/components/ld-stepper/ld-stepper.tsx
+++ b/src/liquid/components/ld-stepper/ld-stepper.tsx
@@ -27,17 +27,17 @@ export class LdStepper {
   @Element() el: HTMLLdStepperElement
 
   /** Switch colors for brand background. */
-  @Prop() brandColor = false
+  @Prop() brandColor?: boolean = false
   /** Indicates whether the steps should be evenly distributed or fit to their content */
-  @Prop() fitContent = false
+  @Prop() fitContent?: boolean = false
   /** Template for the screen-reader label, containing the label of the current step and the steps summary */
-  @Prop() labelTemplate = '$1, $2'
+  @Prop() labelTemplate?: string = '$1, $2'
   /** Step summary template for the screen-reader label, containing the index of the current step and the overall number of steps */
-  @Prop() labelSummaryTemplate = 'step $1 of $2'
+  @Prop() labelSummaryTemplate?: string = 'step $1 of $2'
   /** Step size */
   @Prop() size?: HTMLLdStepElement['size']
   /** Vertical layout */
-  @Prop() vertical = false
+  @Prop() vertical?: boolean = false
 
   // The following event is not used within the ld-stepper component itself.
   // Its only purpose is to create a type definition on the ld-stepper component,

--- a/src/liquid/components/ld-switch/ld-switch-item/ld-switch-item.tsx
+++ b/src/liquid/components/ld-switch/ld-switch-item/ld-switch-item.tsx
@@ -38,7 +38,7 @@ export class LdSwitchItem implements InnerFocusable, ClonesAttributes {
   @Prop({ reflect: true }) ariaDisabled: string
 
   /** Indicates whether the switch item is selected. */
-  @Prop({ mutable: true }) checked = false
+  @Prop({ mutable: true }) checked?: boolean = false
 
   /** Disabled state of the switch item. */
   @Prop() disabled?: boolean

--- a/src/liquid/components/ld-switch/ld-switch-item/ld-switch-item.tsx
+++ b/src/liquid/components/ld-switch/ld-switch-item/ld-switch-item.tsx
@@ -38,7 +38,7 @@ export class LdSwitchItem implements InnerFocusable, ClonesAttributes {
   @Prop({ reflect: true }) ariaDisabled: string
 
   /** Indicates whether the switch item is selected. */
-  @Prop({ mutable: true }) checked?: boolean = false
+  @Prop({ mutable: true }) checked? = false
 
   /** Disabled state of the switch item. */
   @Prop() disabled?: boolean

--- a/src/liquid/components/ld-switch/ld-switch.tsx
+++ b/src/liquid/components/ld-switch/ld-switch.tsx
@@ -42,10 +42,10 @@ export class LdSwitch implements InnerFocusable {
   @Prop({ reflect: true }) autofocus: boolean
 
   /** Disabled state of the switch. */
-  @Prop() disabled: boolean
+  @Prop() disabled?: boolean
 
   /** Make each switch item take up as little space as its content requires. */
-  @Prop() fitContent = false
+  @Prop() fitContent?: boolean = false
 
   /** Associates the control with a form element. */
   @Prop() form?: string
@@ -60,7 +60,7 @@ export class LdSwitch implements InnerFocusable {
   @Prop() readonly?: boolean
 
   /** Set this property to `true` in order to mark the switch as required. */
-  @Prop() required: boolean
+  @Prop() required?: boolean
 
   /** Tab index of the input. */
   @Prop() ldTabindex: number | undefined

--- a/src/liquid/components/ld-switch/ld-switch.tsx
+++ b/src/liquid/components/ld-switch/ld-switch.tsx
@@ -45,7 +45,7 @@ export class LdSwitch implements InnerFocusable {
   @Prop() disabled?: boolean
 
   /** Make each switch item take up as little space as its content requires. */
-  @Prop() fitContent?: boolean = false
+  @Prop() fitContent? = false
 
   /** Associates the control with a form element. */
   @Prop() form?: string

--- a/src/liquid/components/ld-table/ld-table-header/ld-table-header.tsx
+++ b/src/liquid/components/ld-table/ld-table-header/ld-table-header.tsx
@@ -50,7 +50,7 @@ export class LdTableHeader {
   @Prop() scope?: HTMLTableCellElement['scope']
 
   /** Defines whether the column is sortable. */
-  @Prop() sortable?: boolean = false
+  @Prop() sortable? = false
 
   /** Defines whether the column is sorted and in which order. */
   @Prop({ mutable: true }) sortOrder?: 'asc' | 'desc'

--- a/src/liquid/components/ld-table/ld-table-header/ld-table-header.tsx
+++ b/src/liquid/components/ld-table/ld-table-header/ld-table-header.tsx
@@ -50,7 +50,7 @@ export class LdTableHeader {
   @Prop() scope?: HTMLTableCellElement['scope']
 
   /** Defines whether the column is sortable. */
-  @Prop() sortable = false
+  @Prop() sortable?: boolean = false
 
   /** Defines whether the column is sorted and in which order. */
   @Prop({ mutable: true }) sortOrder?: 'asc' | 'desc'

--- a/src/liquid/components/ld-table/ld-table-row/ld-table-row.tsx
+++ b/src/liquid/components/ld-table/ld-table-row/ld-table-row.tsx
@@ -22,10 +22,10 @@ export class LdTableRow {
   @Prop() selectable?: boolean
 
   /** In selectable mode the checkbox is sticky by default. */
-  @Prop() selectionSticky?: boolean = true
+  @Prop() selectionSticky? = true
 
   /** Makes the row selectable by adding a checkbox to the start of the row. */
-  @Prop() selectionLabel?: string = 'Row selection'
+  @Prop() selectionLabel? = 'Row selection'
 
   /** Indicates that the row is selected. */
   @Prop({ mutable: true }) selected?: boolean

--- a/src/liquid/components/ld-table/ld-table-row/ld-table-row.tsx
+++ b/src/liquid/components/ld-table/ld-table-row/ld-table-row.tsx
@@ -22,10 +22,10 @@ export class LdTableRow {
   @Prop() selectable?: boolean
 
   /** In selectable mode the checkbox is sticky by default. */
-  @Prop() selectionSticky = true
+  @Prop() selectionSticky?: boolean = true
 
   /** Makes the row selectable by adding a checkbox to the start of the row. */
-  @Prop() selectionLabel = 'Row selection'
+  @Prop() selectionLabel?: string = 'Row selection'
 
   /** Indicates that the row is selected. */
   @Prop({ mutable: true }) selected?: boolean

--- a/src/liquid/components/ld-toggle/ld-toggle.tsx
+++ b/src/liquid/components/ld-toggle/ld-toggle.tsx
@@ -44,7 +44,7 @@ export class LdToggle implements InnerFocusable, ClonesAttributes {
   @Prop({ reflect: true }) autofocus: boolean
 
   /** Indicates whether the toggle is "on". */
-  @Prop({ mutable: true }) checked?: boolean = false
+  @Prop({ mutable: true }) checked? = false
 
   /** Disabled state of the checkbox. */
   @Prop() disabled?: boolean

--- a/src/liquid/components/ld-toggle/ld-toggle.tsx
+++ b/src/liquid/components/ld-toggle/ld-toggle.tsx
@@ -44,16 +44,16 @@ export class LdToggle implements InnerFocusable, ClonesAttributes {
   @Prop({ reflect: true }) autofocus: boolean
 
   /** Indicates whether the toggle is "on". */
-  @Prop({ mutable: true }) checked = false
+  @Prop({ mutable: true }) checked?: boolean = false
 
   /** Disabled state of the checkbox. */
-  @Prop() disabled: boolean
+  @Prop() disabled?: boolean
 
   /** Associates the control with a form element. */
   @Prop() form?: string
 
   /** Set this property to `true` in order to mark the checkbox visually as invalid. */
-  @Prop() invalid: boolean
+  @Prop() invalid?: boolean
 
   /** Tab index of the input. */
   @Prop() ldTabindex: number | undefined
@@ -65,7 +65,7 @@ export class LdToggle implements InnerFocusable, ClonesAttributes {
   @Prop() readonly?: boolean
 
   /** Set this property to `true` in order to mark the checkbox as required. */
-  @Prop() required: boolean
+  @Prop() required?: boolean
 
   /** Size of the toggle. */
   @Prop() size?: 'sm' | 'lg'

--- a/src/liquid/components/ld-tooltip/ld-tooltip-popper/ld-tooltip-popper.tsx
+++ b/src/liquid/components/ld-tooltip/ld-tooltip-popper/ld-tooltip-popper.tsx
@@ -13,7 +13,7 @@ export class LdTooltipPopper {
   @State() initialized = false
 
   /** Show arrow */
-  @Prop() arrow: boolean
+  @Prop() arrow?: boolean
 
   /** The tooltip size (effects tooltip padding only) */
   @Prop() size?: 'sm'
@@ -22,7 +22,7 @@ export class LdTooltipPopper {
   @Prop() triggerType: 'click' | 'hover' = 'hover'
 
   /** Whether the tooltip has a custom trigger or not */
-  @Prop() hasDefaultTrigger: boolean
+  @Prop() hasDefaultTrigger?: boolean
 
   componentDidLoad() {
     setTimeout(() => {

--- a/src/liquid/components/ld-tooltip/ld-tooltip-popper/ld-tooltip-popper.tsx
+++ b/src/liquid/components/ld-tooltip/ld-tooltip-popper/ld-tooltip-popper.tsx
@@ -19,7 +19,7 @@ export class LdTooltipPopper {
   @Prop() size?: 'sm'
 
   /** Event type that triggers the tooltip */
-  @Prop() triggerType: 'click' | 'hover' = 'hover'
+  @Prop() triggerType?: 'click' | 'hover' = 'hover'
 
   /** Whether the tooltip has a custom trigger or not */
   @Prop() hasDefaultTrigger?: boolean

--- a/src/liquid/components/ld-tooltip/ld-tooltip.tsx
+++ b/src/liquid/components/ld-tooltip/ld-tooltip.tsx
@@ -57,19 +57,19 @@ export class LdTooltip {
   @Prop() disabled?: boolean
 
   /** Delay in ms until tooltip hides (only when trigger type is 'hover') */
-  @Prop() hideDelay?: number = 0
+  @Prop() hideDelay? = 0
 
   /** Position of the tooltip relative to the trigger element (also affects the arrow position) */
   @Prop() position: Position = 'top center'
 
   /** Delay in ms until tooltip shows (only when trigger type is 'hover') */
-  @Prop() showDelay?: number = 0
+  @Prop() showDelay? = 0
 
   /** The tooltip size (effects tooltip padding only) */
   @Prop() size?: 'sm'
 
   /** The rendered HTML tag for the tooltip trigger. */
-  @Prop() tag?: string = 'button'
+  @Prop() tag? = 'button'
 
   /** Tether options object to be merged with the default options (optionally stringified). */
   @Prop() tetherOptions?: Partial<Tether.ITetherOptions> | string

--- a/src/liquid/components/ld-tooltip/ld-tooltip.tsx
+++ b/src/liquid/components/ld-tooltip/ld-tooltip.tsx
@@ -75,7 +75,7 @@ export class LdTooltip {
   @Prop() tetherOptions?: Partial<Tether.ITetherOptions> | string
 
   /** Event type that triggers the tooltip */
-  @Prop() triggerType: 'click' | 'hover' = 'hover'
+  @Prop() triggerType?: 'click' | 'hover' = 'hover'
 
   @State() hasDefaultTrigger = true
   @State() visible = false

--- a/src/liquid/components/ld-tooltip/ld-tooltip.tsx
+++ b/src/liquid/components/ld-tooltip/ld-tooltip.tsx
@@ -51,25 +51,25 @@ export class LdTooltip {
   private triggerRef!: HTMLSpanElement
 
   /** Show arrow */
-  @Prop() arrow: boolean
+  @Prop() arrow?: boolean
 
   /** Disable tooltip trigger */
-  @Prop() disabled: boolean
+  @Prop() disabled?: boolean
 
   /** Delay in ms until tooltip hides (only when trigger type is 'hover') */
-  @Prop() hideDelay = 0
+  @Prop() hideDelay?: number = 0
 
   /** Position of the tooltip relative to the trigger element (also affects the arrow position) */
   @Prop() position: Position = 'top center'
 
   /** Delay in ms until tooltip shows (only when trigger type is 'hover') */
-  @Prop() showDelay = 0
+  @Prop() showDelay?: number = 0
 
   /** The tooltip size (effects tooltip padding only) */
   @Prop() size?: 'sm'
 
   /** The rendered HTML tag for the tooltip trigger. */
-  @Prop() tag = 'button'
+  @Prop() tag?: string = 'button'
 
   /** Tether options object to be merged with the default options (optionally stringified). */
   @Prop() tetherOptions?: Partial<Tether.ITetherOptions> | string


### PR DESCRIPTION
# Description

This PR fixes an issue where component props with a default value are marked as required, although they are not. This has effects in some environments such as in Plotly Dash, where we see error messages, such as:

> TypeError: Required argument `detached` was not specified.

This PR fixes the issue, changing the type definition of each prop with a default value by marking it as _optional_ with `?`.

## Type of change

Please delete options that are not relevant.

- [x] Bugfix

## Is it a breaking change?

- [x] No

# How Has This Been Tested?

- [x] unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes
