### PR TITLE
feat: introduces default asset path to jsDelivr

### DIFF
--- a/src/liquid/utils/assetPath.ts
+++ b/src/liquid/utils/assetPath.ts
@@ -1,4 +1,7 @@
 import { Build } from '@stencil/core'
+import { version } from '../../../package.json'
+
+let missingAssetPathWarningDisplayed = false
 
 /**
  * Reads components asset path config from meta tag or global variable.
@@ -7,12 +10,32 @@ import { Build } from '@stencil/core'
  * https://github.com/ionic-team/stencil-ds-output-targets/issues/186
  */
 export const getAssetPath = (path: string) => {
+  // Get asset path from meta tag if available
+  const metaLdAssetPath = document.head.querySelector<HTMLMetaElement>(
+    'meta[data-ld-asset-path]'
+  )?.dataset.ldAssetPath
+  // Get asset path from window if available
+  const windowLdAssetPath = window.__LD_ASSET_PATH__
+  // Uses CDN as fallback if no asset path is set
+  const cdnAssetPath = `https://cdn.jsdelivr.net/npm/@emdgroup-liquid/liquid${
+    version ? '@' + version : ''
+  }/dist/liquid/`
+
   const assetBasePath = Build.isTesting
     ? '/dist/liquid'
-    : document.head.querySelector<HTMLMetaElement>('meta[data-ld-asset-path]')
-        ?.dataset.ldAssetPath ||
-      window.__LD_ASSET_PATH__ ||
-      '/'
+    : metaLdAssetPath || windowLdAssetPath || cdnAssetPath || '/'
+
+  // Display warning if assets are fetched from CDN. This is only displayed once.
+  if (
+    assetBasePath.startsWith('https://cdn.jsdelivr.net/npm/') &&
+    !missingAssetPathWarningDisplayed
+  ) {
+    missingAssetPathWarningDisplayed = true
+    console.warn(
+      `Fetching Liquid Oxygen assets from jsDelivr CDN.\n\nWe recommend bundling Liquid Oxygen assets with your application and setting the asset path accordingly.\n\nFor more information see the documentation:\nhttps://liquid.merck.design/liquid/guides/component-assets/`
+    )
+  }
+
   let assetPath = path
 
   if (path.startsWith('./')) {


### PR DESCRIPTION
# Description

This PR uses jsDelivr as default asset base path. 
It will improve the DX when Liquid gets introduced into a project. As this is not the recommended approach for production 
additional documentation will be provided. 

It's marked as feature as it improves the DX but does not actually fix anything.

Docuementation will be updated with [PR 506](https://github.com/emdgroup-liquid/liquid/pull/506).

## Type of change

Please delete options that are not relevant.

- [x] Feature

## Is it a breaking change?

- [ ] Yes
- [x] No

# How Has This Been Tested?

Please describe the tests that you've added and run to verify your changes. 
Provide instructions, so we can reproduce.

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes
