### PR TITLE
fix(ld-circular-progress): safari requires width to be set to 100% on svg

### DIFF
--- a/src/liquid/components/ld-circular-progress/ld-circular-progress.css
+++ b/src/liquid/components/ld-circular-progress/ld-circular-progress.css
@@ -101,6 +101,7 @@
   inset: 0;
   fill: none;
   mask-image: var(--ld-circular-progress-stroke-mask);
+  width: 100%; /* required in Safari */
   z-index: 1;
 
   circle {


### PR DESCRIPTION
# Description

This PR fixes a layout issue in the circular progress component which occurs on Safari.

Fixes #544

## Type of change

- [x] Bugfix

## Is it a breaking change?

- [x] No

# How Has This Been Tested?

- [x] manually

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes
