### PR TITLE
fix(ld-circular-progress): precision

### DIFF
--- a/src/liquid/components/ld-circular-progress/ld-circular-progress.css
+++ b/src/liquid/components/ld-circular-progress/ld-circular-progress.css
@@ -96,11 +96,20 @@
   --ld-circular-progress-wht-overlay-col: var(--ld-col-wht-alpha-low);
 }
 
+/* HACK: Safari 7.1+ */
+/* stylelint-disable selector-type-no-unknown */
+_::-webkit-full-page-media,
+_:future,
+:root {
+  --ld-circular-progress-bar-correction: 3.5px;
+}
+
 .ld-circular-progress__stroke {
   position: absolute;
   inset: 0;
   fill: none;
   mask-image: var(--ld-circular-progress-stroke-mask);
+  transform: rotate(-90deg);
   width: 100%; /* required in Safari */
   z-index: 1;
 
@@ -110,15 +119,14 @@
     stroke-dasharray: calc(100 / var(--ld-circular-progress-pi));
     transition: opacity var(--ld-circular-progress-transition-duration) linear,
       stroke-dashoffset var(--ld-circular-progress-transition-duration) ease;
-    transform: rotate(-90deg);
 
     &:first-of-type {
       stroke: var(--ld-circular-progress-bar-col);
       /* Safari does not support a negative stroke dash offset! */
       stroke-dashoffset: calc(
         -1 * min(0px, (
-                -100px + var(--ld-circular-progress-calc-relative-progress) * 100px -
-                  1px
+                -100px + var(--ld-circular-progress-calc-relative-progress) * (100px -
+                      var(--ld-circular-progress-bar-correction, 1px))
               ) / var(--ld-circular-progress-pi))
       );
       opacity: calc(1 - var(--ld-circular-progress-has-overflow));
@@ -130,7 +138,7 @@
         -1 * max(-100px / var(--ld-circular-progress-pi), min(0px, (
                   -100px + (
                       var(--ld-circular-progress-calc-relative-progress) - 1
-                    ) * 100px - 1px
+                    ) * (100px - var(--ld-circular-progress-bar-correction, 1px))
                 ) / var(--ld-circular-progress-pi)))
       );
       opacity: var(--ld-circular-progress-has-overflow);


### PR DESCRIPTION
# Description

This PR includes a fix for normal browsers and a special hack for Safari which resolves issues with the precision of the circular progress display.

Related to #544

## Type of change

- [x] Bugfix

## Is it a breaking change?

- [x] No

# How Has This Been Tested?

- [x] tested manually on Opera, Safari and Mobile Safari

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes
