### PR TITLE
fix(ld-breadcrumbs): allow empty breadcrumbs list

### DIFF
--- a/src/liquid/components/ld-breadcrumbs/ld-breadcrumbs.tsx
+++ b/src/liquid/components/ld-breadcrumbs/ld-breadcrumbs.tsx
@@ -18,6 +18,8 @@ export class LdBreadcrumbs {
 
   private updateCurrent = () => {
     const crumbs = this.el.querySelectorAll('ld-crumb')
+    if (!crumbs.length) return
+
     crumbs.forEach((crumb) => {
       crumb.current = undefined
     })

--- a/src/liquid/components/ld-breadcrumbs/test/__snapshots__/ld-breadcrumbs.spec.tsx.snap
+++ b/src/liquid/components/ld-breadcrumbs/test/__snapshots__/ld-breadcrumbs.spec.tsx.snap
@@ -1,5 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ld-breadcrumbs Does not throw with no crumbs 1`] = `
+<ld-breadcrumbs>
+  <mock:shadow-root>
+    <nav aria-label="Breadcrumbs" class="ld-breadcrumbs">
+      <ol class="ld-breadcrumbs__list" part="list">
+        <slot></slot>
+      </ol>
+    </nav>
+  </mock:shadow-root>
+</ld-breadcrumbs>
+`;
+
 exports[`ld-breadcrumbs renders 1`] = `
 <ld-breadcrumbs>
   <mock:shadow-root>

--- a/src/liquid/components/ld-breadcrumbs/test/ld-breadcrumbs.spec.tsx
+++ b/src/liquid/components/ld-breadcrumbs/test/ld-breadcrumbs.spec.tsx
@@ -58,4 +58,15 @@ describe('ld-breadcrumbs', () => {
 
     expect(page.root).toMatchSnapshot()
   })
+
+  it('Does not throw with no crumbs', async () => {
+    const page = await newSpecPage({
+      components: [LdBreadcrumbs, LdCrumb],
+      html: `<ld-breadcrumbs></ld-breadcrumbs>`,
+    })
+    await page.waitForChanges()
+    jest.advanceTimersByTime(0)
+
+    expect(page.root).toMatchSnapshot()
+  })
 })


### PR DESCRIPTION
# Description

This PR fixes an issue with `ld-breadcrumbs` throwing an exception when there are no `ld-crumb`s in the slot.

Fixes #532

## Type of change

- [x] Bugfix

## Is it a breaking change?

- [x] No

# How Has This Been Tested?

- [x] unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes
