### PR TITLE
Fix/ld notification

### DIFF
--- a/src/liquid/components/ld-circular-progress/ld-circular-progress.css
+++ b/src/liquid/components/ld-circular-progress/ld-circular-progress.css
@@ -103,6 +103,7 @@ _:future,
 :root {
   --ld-circular-progress-bar-correction: 3.5px;
 }
+/* stylelint-enable selector-type-no-unknown */
 
 .ld-circular-progress__stroke {
   position: absolute;

--- a/src/liquid/components/ld-notification/ld-notification.tsx
+++ b/src/liquid/components/ld-notification/ld-notification.tsx
@@ -114,7 +114,9 @@ export class LdNotification {
   }
 
   private renderNotification(notification: Notification, dismissed = false) {
-    let cl = `ld-notification__item ld-notification__item--${notification.type}`
+    let cl = `ld-notification__item ld-notification__item--${
+      notification.type || 'info'
+    }`
     if (dismissed) cl += ' ld-notification__item--dismissed'
 
     return (
@@ -165,6 +167,7 @@ export class LdNotification {
     )
   }
 
+  /* istanbul ignore next */
   disconnectedCallback() {
     clearTimeout(this.dismissTimeout)
     this.fadeoutTimeouts.forEach(clearTimeout)

--- a/src/liquid/components/ld-notification/test/ld-notification.spec.ts
+++ b/src/liquid/components/ld-notification/test/ld-notification.spec.ts
@@ -84,6 +84,28 @@ describe('ld-notification', () => {
       ).toBeFalsy()
     })
 
+    it('renders a notification of type "info" if type is omitted', async () => {
+      const page = await newSpecPage({
+        components: [LdNotification],
+        html: `<ld-notification></ld-notification>`,
+      })
+      page.win.dispatchEvent(
+        new CustomEvent('ldNotificationAdd', {
+          detail: {
+            content: 'I am an info message.',
+          },
+        })
+      )
+      await page.waitForChanges()
+
+      const notification = page.root.shadowRoot.querySelectorAll(
+        '.ld-notification__item'
+      )[0]
+      expect(
+        notification.classList.contains('ld-notification__item--info')
+      ).toBeTruthy()
+    })
+
     it('renders a notification of type "warn"', async () => {
       const page = await newSpecPage({
         components: [LdNotification],


### PR DESCRIPTION
# Description

This PR includes a minor fix to the `ld-notification` component. With the fix applied, it is possible to omit the notification `type`. The component then applies the `ld-notification__item--info` class to the notification as the default.

## Type of change

- [x] Bugfix

## Is it a breaking change?

- [x] No

# How Has This Been Tested?

- [x] unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes
