### PR TITLE
docs(ld-input): add date format explainer

### DIFF
--- a/src/liquid/components/ld-input/readme.md
+++ b/src/liquid/components/ld-input/readme.md
@@ -166,7 +166,7 @@ By default, the `ld-input` component is of [type `text`](https://developer.mozil
 ### Type datetime-local
 
 <ld-notice headline="Note" mode="info">
-  Just like the <code>ld-input</code> component of <code>type="date"</code> the <code>type="datetime-local"</code> version acts as a wrapper around its native <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local"><code>input</code> counterpart</a>, fully relying on its built-in features and only enhancing it visually. Its date and time format is intentionally <strong>not</strong> configurable via a prop, but instead depends on the user's <abbr title="operating system">OS</abbr> settings.
+  The <code>ld-input</code> component of <code>type="datetime-local"</code> acts as a wrapper around the native <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local"><code>input</code> element of<code>type="datetime-local"</code></a>, fully relying on its built-in features and only enhancing it visually.<br />The component is lightweight, respects the user preferences for display format configured in the user's <abbr title="operating system">OS</abbr> settings, separates presentation format from wire format and is accessible out of the box by offering a familiar <abbr title="user interface">UI</abbr>.
 </ld-notice>
 
 {% example %}

--- a/src/liquid/components/ld-input/readme.md
+++ b/src/liquid/components/ld-input/readme.md
@@ -145,6 +145,10 @@ By default, the `ld-input` component is of [type `text`](https://developer.mozil
 
 ### Type date
 
+<ld-notice headline="Note" mode="info">
+  The <code>ld-input</code> component of <code>type="date"</code> acts as a wrapper around the native <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/date"><code>input</code> element of<code>type="date"</code></a>, fully relying on its built-in features and only enhancing it visually. This means that the component respects the user's preferences in regards to the display format configured in the operating system settings. Moreover, it is lightweight, separates presentation format from wire format and is accessible out of the box by offering the user a familiar <abbr title="user interface">UI</abbr>.
+</ld-notice>
+
 {% example %}
 <ld-input placeholder="Birthday" type="date" value="2017-06-01"></ld-input>
 
@@ -160,6 +164,10 @@ By default, the `ld-input` component is of [type `text`](https://developer.mozil
 {% endexample %}
 
 ### Type datetime-local
+
+<ld-notice headline="Note" mode="info">
+  Just like the <code>ld-input</code> component of <code>type="date"</code> the <code>type="datetime-local"</code> version acts as a wrapper around its native <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local"><code>input</code> counterpart</a>, fully relying on its built-in features and only enhancing it visually. Its date and time format is intentionally <strong>not</strong> configurable via a prop, but instead depends on the user's <abbr title="operating system">OS</abbr> settings.
+</ld-notice>
 
 {% example %}
 <ld-input placeholder="Birthday" type="datetime-local" value="2017-06-01T19:30"></ld-input>

--- a/src/liquid/components/ld-input/readme.md
+++ b/src/liquid/components/ld-input/readme.md
@@ -146,7 +146,7 @@ By default, the `ld-input` component is of [type `text`](https://developer.mozil
 ### Type date
 
 <ld-notice headline="Note" mode="info">
-  The <code>ld-input</code> component of <code>type="date"</code> acts as a wrapper around the native <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/date"><code>input</code> element of<code>type="date"</code></a>, fully relying on its built-in features and only enhancing it visually. This means that the component respects the user's preferences in regards to the display format configured in the operating system settings. Moreover, it is lightweight, separates presentation format from wire format and is accessible out of the box by offering the user a familiar <abbr title="user interface">UI</abbr>.
+  The <code>ld-input</code> component of <code>type="date"</code> acts as a wrapper around the native <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/date"><code>input</code> element of<code>type="date"</code></a>, fully relying on its built-in features and only enhancing it visually.<br />The component is lightweight, respects the user preferences for display format configured in the user's <abbr title="operating system">OS</abbr> settings, separates presentation format from wire format and is accessible out of the box by offering a familiar <abbr title="user interface">UI</abbr>.
 </ld-notice>
 
 {% example %}


### PR DESCRIPTION
# Description

This PR adds a short explainer on the date format topic to the `ld-input` docs.

Resolves #553

## Type of change

- [x] Documentation content changes

## Is it a breaking change?

- [x] No