### PR TITLE
fix(ld-sr-live): remove host element from layout

### DIFF
--- a/src/liquid/components/ld-sr-live/ld-sr-live.shadow.css
+++ b/src/liquid/components/ld-sr-live/ld-sr-live.shadow.css
@@ -1,0 +1,3 @@
+:host {
+  display: contents;
+}


### PR DESCRIPTION
# Description

This PR includes a fix to the `ld-sr-live` component making sure its host element, which is  the `ld-sr-live` element itself, doesn't become part of the page layout, by adding a `display: contents;` style to it. Its direct child element is an `ld-sr-only` component and hence does not participate in the page layout either.

## Type of change

Please delete options that are not relevant.

- [x] Bugfix

## Is it a breaking change?

- [x] No

# How Has This Been Tested?

- [x] tested manually

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes
