### PR TITLE
fix(ld-switch): use display inline-flex on host element

### DIFF
--- a/src/liquid/components/ld-switch/ld-switch.css
+++ b/src/liquid/components/ld-switch/ld-switch.css
@@ -41,6 +41,10 @@
   }
 }
 
+:host {
+  display: inline-flex;
+}
+
 .ld-switch,
 :host fieldset {
   border: 0;


### PR DESCRIPTION
# Description

Fixes this:

<img width="783" alt="Screenshot 2023-03-08 at 15 30 36" src="https://user-images.githubusercontent.com/527049/223740023-f09c1a5c-8875-4ac7-ae5a-fda9ad943418.png">

## Type of change

- [x] Bugfix

## Is it a breaking change?

- [x] No

# How Has This Been Tested?

- [x] tested manually

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes
