### PR TITLE
fix(ld-label): throws on click when without child

### DIFF
--- a/src/liquid/components/ld-label/ld-label.tsx
+++ b/src/liquid/components/ld-label/ld-label.tsx
@@ -32,15 +32,15 @@ export class LdLabel implements ClonesAttributes {
     const inputElement: HTMLElement = this.el.querySelector(
       'ld-input, ld-textarea, ld-toggle, ld-select, ld-button, ld-checkbox, ld-radio, input, textarea, button, select'
     )
-    const clickedInsideInputElement =
-      event.target === inputElement ||
-      inputElement.contains(event.target as Node)
-
-    if (
+    const notClickedInsideNotDisabled =
       inputElement &&
-      !clickedInsideInputElement &&
+      !(
+        event.target === inputElement ||
+        inputElement.contains(event.target as Node)
+      ) &&
       !inputElement['disabled']
-    ) {
+
+    if (notClickedInsideNotDisabled) {
       if ('focusInner' in inputElement) {
         await (inputElement as unknown as InnerFocusable).focusInner()
       } else {

--- a/src/liquid/components/ld-label/test/ld-label.spec.ts
+++ b/src/liquid/components/ld-label/test/ld-label.spec.ts
@@ -117,4 +117,13 @@ describe('ld-label', () => {
     expect(ldInput.focus).not.toHaveBeenCalled()
     expect(ldInput.focusInner).toHaveBeenCalledTimes(1)
   })
+
+  it('does not throw, when label without child elements is clicked', async () => {
+    const page = await newSpecPage({
+      components: [LdLabel],
+      html: '<ld-label>Label text</ld-label>',
+    })
+    await page.root.shadowRoot.querySelector('slot').click()
+    // No need to assert anything here.
+  })
 })


### PR DESCRIPTION
# Description

This PR includes a fix which makes sure that an `ld-label` component, which does not have any child element, doesn't throw an error, when clicked.

Fixes #578

## Type of change

- [x] Bugfix

## Is it a breaking change?

- [x] No

# How Has This Been Tested?

- [x] unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes
