### PR TITLE
fix(ld-sidenav): icon not showing in tooltips

### DIFF
--- a/src/liquid/components/ld-badge/test/__snapshots__/ld-badge.spec.tsx.snap
+++ b/src/liquid/components/ld-badge/test/__snapshots__/ld-badge.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ld-badge renders 1`] = `
 <ld-badge class="ld-badge" icon="checkmark">
   <mock:shadow-root>
-    <ld-icon class="ld-badge__icon ld-icon" part="icon" role="presentation">
+    <ld-icon class="ld-badge__icon ld-icon" name="checkmark" part="icon" role="presentation">
       <mock:shadow-root>
         Not Found
       </mock:shadow-root>
@@ -17,7 +17,7 @@ exports[`ld-badge renders 1`] = `
 exports[`ld-badge renders on brand color 1`] = `
 <ld-badge brand-color="" class="ld-badge ld-badge--brand-color" icon="checkmark">
   <mock:shadow-root>
-    <ld-icon class="ld-badge__icon ld-icon" part="icon" role="presentation">
+    <ld-icon class="ld-badge__icon ld-icon" name="checkmark" part="icon" role="presentation">
       <mock:shadow-root>
         Not Found
       </mock:shadow-root>
@@ -48,7 +48,7 @@ exports[`ld-badge renders with custom icon 1`] = `
 exports[`ld-badge renders with size lg 1`] = `
 <ld-badge class="ld-badge ld-badge--lg" icon="checkmark" size="lg">
   <mock:shadow-root>
-    <ld-icon class="ld-badge__icon ld-icon" part="icon" role="presentation">
+    <ld-icon class="ld-badge__icon ld-icon" name="checkmark" part="icon" role="presentation">
       <mock:shadow-root>
         Not Found
       </mock:shadow-root>
@@ -91,7 +91,7 @@ exports[`ld-badge updates after addition of an icon 1`] = `
 exports[`ld-badge updates after addition of text 1`] = `
 <ld-badge class="ld-badge ld-badge--with-text" icon="checkmark">
   <mock:shadow-root>
-    <ld-icon class="ld-badge__icon ld-icon" part="icon" role="presentation">
+    <ld-icon class="ld-badge__icon ld-icon" name="checkmark" part="icon" role="presentation">
       <mock:shadow-root>
         Not Found
       </mock:shadow-root>

--- a/src/liquid/components/ld-icon/ld-icon.tsx
+++ b/src/liquid/components/ld-icon/ld-icon.tsx
@@ -18,7 +18,7 @@ export class LdIcon {
   @Element() el: HTMLElement
 
   /** The icon name. */
-  @Prop() name?: string = null
+  @Prop({ reflect: true }) name?: string = null
 
   /** Size of the icon. */
   @Prop() size?: 'sm' | 'lg'

--- a/src/liquid/components/ld-icon/test/__snapshots__/ld-icon.spec.tsx.snap
+++ b/src/liquid/components/ld-icon/test/__snapshots__/ld-icon.spec.tsx.snap
@@ -2,17 +2,17 @@
 
 exports[`ld-icon renders multiple 1`] = `
 <body>
-  <ld-icon class="ld-icon" role="presentation">
+  <ld-icon class="ld-icon" name="add" role="presentation">
     <mock:shadow-root>
       Not Found
     </mock:shadow-root>
   </ld-icon>
-  <ld-icon class="ld-icon" role="presentation">
+  <ld-icon class="ld-icon" name="education" role="presentation">
     <mock:shadow-root>
       Not Found
     </mock:shadow-root>
   </ld-icon>
-  <ld-icon class="ld-icon" role="presentation">
+  <ld-icon class="ld-icon" name="add" role="presentation">
     <mock:shadow-root>
       Not Found
     </mock:shadow-root>
@@ -21,7 +21,7 @@ exports[`ld-icon renders multiple 1`] = `
 `;
 
 exports[`ld-icon renders with name prop 1`] = `
-<ld-icon class="ld-icon" role="presentation">
+<ld-icon class="ld-icon" name="add" role="presentation">
   <mock:shadow-root>
     Not Found
   </mock:shadow-root>
@@ -29,7 +29,7 @@ exports[`ld-icon renders with name prop 1`] = `
 `;
 
 exports[`ld-icon renders with size prop 1`] = `
-<ld-icon class="ld-icon ld-icon--sm" role="presentation">
+<ld-icon class="ld-icon ld-icon--sm" name="atom" role="presentation">
   <mock:shadow-root>
     Not Found
   </mock:shadow-root>

--- a/src/liquid/components/ld-stepper/ld-step/test/__snapshots__/ld-step.spec.tsx.snap
+++ b/src/liquid/components/ld-stepper/ld-step/test/__snapshots__/ld-step.spec.tsx.snap
@@ -180,7 +180,7 @@ exports[`ld-step renders with custom icon 1`] = `
       <button class="ld-step__focusable-element" part="button focusable" type="button">
         <slot></slot>
       </button>
-      <ld-icon class="ld-icon" role="presentation">
+      <ld-icon class="ld-icon" name="favorite" role="presentation">
         <mock:shadow-root>
           Not Found
         </mock:shadow-root>

--- a/src/liquid/components/ld-tooltip/ld-tooltip.tsx
+++ b/src/liquid/components/ld-tooltip/ld-tooltip.tsx
@@ -14,6 +14,7 @@ import {
 } from '@stencil/core'
 import { getClassNames } from '../../utils/getClassNames'
 import { focusableSelector, isInnerFocusable } from '../../utils/focus'
+import { isElement, isSlot } from '../../utils/type-checking'
 
 export type Position =
   | 'bottom center'
@@ -30,9 +31,6 @@ export type Position =
   | 'top right'
 
 let tooltipCount = 0
-const isElement = (node: Node): node is Element => 'classList' in node
-const isSlot = (element: Element): element is HTMLSlotElement =>
-  element && element.tagName === 'SLOT'
 
 const mapPositionToAttachment = (position: Position) => {
   return {
@@ -64,14 +62,14 @@ const mapPositionToTargetAttachment = (position: Position) => {
   )
 }
 
-const copySlottedNodes = (node: Element) => {
+const copySlottedNodes = (node: Node) => {
   // text node
-  if (!('querySelectorAll' in node)) {
+  if (!isElement(node)) {
     return
   }
 
   node.querySelectorAll('slot').forEach((slot) => {
-    slot.assignedNodes().forEach((childNode: Element) => {
+    slot.assignedNodes().forEach((childNode) => {
       copySlottedNodes(childNode)
       slot.parentElement.insertBefore(childNode, slot)
     })
@@ -162,7 +160,7 @@ export class LdTooltip {
   private syncContent = () => {
     const tooltipContent = this.contentRef.querySelector('slot').assignedNodes()
 
-    tooltipContent.forEach((node: Element) => {
+    tooltipContent.forEach((node) => {
       copySlottedNodes(node)
       const clonedNode = node.cloneNode(true)
       this.tooltipRef.appendChild(clonedNode)
@@ -331,9 +329,9 @@ export class LdTooltip {
   }
 
   private findFirstSlottedTrigger = () => {
-    let triggerInSlot: Element = this.el.querySelector('[slot="trigger"]')
+    let triggerInSlot = this.el.querySelector('[slot="trigger"]')
 
-    while (isSlot(triggerInSlot)) {
+    while (triggerInSlot && isSlot(triggerInSlot)) {
       triggerInSlot = triggerInSlot.assignedElements()[0]
     }
 


### PR DESCRIPTION
# Description

Fixes the missing icons in the tooltips of the collapsed `ld-sidenav` component.

## Type of change

- [x] Bugfix

## Is it a breaking change?

- [ ] Yes
- [x] No

# How Has This Been Tested?

- [x] tested manually

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes