### PR TITLE
fix(ld-notification): sanitize html content passed to notification

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
   },
   "dependencies": {
     "@stencil/core": "^3.2.1",
+    "dompurify": "^3.0.1",
     "js-cookie": "^3.0.1",
     "tether": "^2.0.0"
   },
@@ -98,6 +99,7 @@
     "@stencil/postcss": "^2.1.0",
     "@stencil/react-output-target": "^0.4.0",
     "@stencil/vue-output-target": "^0.7.0",
+    "@types/dompurify": "^3.0.1",
     "@types/jest": "^27.5.2",
     "@types/js-cookie": "^3.0.2",
     "@types/node": "^18.13.0",

--- a/src/liquid/components/ld-notification/readme.md
+++ b/src/liquid/components/ld-notification/readme.md
@@ -95,6 +95,8 @@ dispatchEvent(new CustomEvent('ldNotificationAdd', {
 }))
 ```
 
+The `ld-notification` component will sanitize the HTML string before rendering it to prevent XSS attacks using the [DOMPurify](https://github.com/cure53/DOMPurify) package. You can change the config passed to DOMPurify according to your needs by providing your own config with the `sanitizeConfig` prop.
+
 ### Redundant notifications handling
 
 If a notification event is triggered containing the same content and type as another notification which already is queued for notification display, the event is ignored. If you still need to trigger another notification with the same content, you can append a zero-space character to your content.
@@ -404,9 +406,10 @@ return (
 
 ## Properties
 
-| Property    | Attribute   | Description                               | Type                | Default |
-| ----------- | ----------- | ----------------------------------------- | ------------------- | ------- |
-| `placement` | `placement` | Notification placement within the screen. | `"bottom" \| "top"` | `'top'` |
+| Property         | Attribute   | Description                                                                                                              | Type                                                            | Default     |
+| ---------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------- | ----------- |
+| `placement`      | `placement` | Notification placement within the screen.                                                                                | `"bottom" \| "top"`                                             | `'top'`     |
+| `sanitizeConfig` | --          | Sanitize config passed to DOMPurify's sanitize method. See https://github.com/cure53/DOMPurify#can-i-configure-dompurify | `{ RETURN_DOM_FRAGMENT?: false; RETURN_DOM?: false; } & Config` | `undefined` |
 
 
 ## Shadow Parts

--- a/src/liquid/components/ld-notification/test/__mocks__/dompurify.ts
+++ b/src/liquid/components/ld-notification/test/__mocks__/dompurify.ts
@@ -1,0 +1,11 @@
+import { JSDOM } from 'jsdom'
+import DOMPurify, { type Config } from 'dompurify/dist/purify.cjs'
+const win = new JSDOM('').window
+const CustomDOMPurify = DOMPurify(win)
+
+const dompurify = jest.genMockFromModule('dompurify')
+
+module.exports.sanitize = (source: string | Node, config?: Config) =>
+  CustomDOMPurify.sanitize(source, config)
+
+module.exports.default = dompurify

--- a/src/liquid/components/ld-notification/test/ld-notification.spec.ts
+++ b/src/liquid/components/ld-notification/test/ld-notification.spec.ts
@@ -773,5 +773,63 @@ describe('ld-notification', () => {
       const svg = notifications[0].querySelector('svg')
       expect(svg).toBeTruthy()
     })
+
+    it('it sanitizes notifications with HTML content', async () => {
+      const page = await newSpecPage({
+        components: [LdNotification, LdIcon],
+        html: `<ld-notification></ld-notification>`,
+      })
+      page.win.dispatchEvent(
+        new CustomEvent('ldNotificationAdd', {
+          detail: {
+            content: '<img alt=1 src=1 href=1 onerror="javascript:alert(1)">',
+            type: 'info',
+          },
+        })
+      )
+      await page.waitForChanges()
+
+      const notifications = page.root.shadowRoot.querySelectorAll(
+        '.ld-notification__item:not(.ld-notification__item--dismissed)'
+      )
+      expect(notifications.length).toEqual(1)
+
+      const img = notifications[0].querySelector('img')
+      expect(img).toBeTruthy()
+
+      expect(img.hasAttribute('alt')).toBeTruthy()
+      expect(img.hasAttribute('src')).toBeTruthy()
+      expect(img.hasAttribute('href')).toBeTruthy()
+      expect(img.hasAttribute('onerror')).toBeFalsy()
+    })
+
+    it('it sanitizes notifications with HTML content and custom sanitization options', async () => {
+      const page = await newSpecPage({
+        components: [LdNotification, LdIcon],
+        html: `<ld-notification sanitize-config='{"FORBID_ATTR": ["href"]}'></ld-notification>`,
+      })
+      page.win.dispatchEvent(
+        new CustomEvent('ldNotificationAdd', {
+          detail: {
+            content: '<img alt=1 src=1 href=1 onerror="javascript:alert(1)">',
+            type: 'info',
+          },
+        })
+      )
+      await page.waitForChanges()
+
+      const notifications = page.root.shadowRoot.querySelectorAll(
+        '.ld-notification__item:not(.ld-notification__item--dismissed)'
+      )
+      expect(notifications.length).toEqual(1)
+
+      const img = notifications[0].querySelector('img')
+      expect(img).toBeTruthy()
+
+      expect(img.hasAttribute('alt')).toBeTruthy()
+      expect(img.hasAttribute('src')).toBeTruthy()
+      expect(img.hasAttribute('href')).toBeFalsy()
+      expect(img.hasAttribute('onerror')).toBeFalsy()
+    })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1423,6 +1423,7 @@ __metadata:
     "@stencil/postcss": ^2.1.0
     "@stencil/react-output-target": ^0.4.0
     "@stencil/vue-output-target": ^0.7.0
+    "@types/dompurify": ^3.0.1
     "@types/jest": ^27.5.2
     "@types/js-cookie": ^3.0.2
     "@types/node": ^18.13.0
@@ -1435,6 +1436,7 @@ __metadata:
     cheerio: ^1.0.0-rc.12
     chokidar-cli: ^3.0.0
     cssnano: ^6.0.0
+    dompurify: ^3.0.1
     dotenv-cli: ^7.0.0
     eleventy-plugin-toc: ^1.1.5
     eslint: ^8.34.0
@@ -2848,6 +2850,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/dompurify@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@types/dompurify@npm:3.0.1"
+  dependencies:
+    "@types/jsdom": "*"
+    "@types/trusted-types": "*"
+  checksum: d4bf881845ac1f4619622b62945f0fda876e6c09d4c958bc7f3a84c4307f7258b9a15e334ae08c7ac5ecfcd0656415328df29d3fb737e9bce2849feaf180c6ab
+  languageName: node
+  linkType: hard
+
 "@types/graceful-fs@npm:^4.1.2":
   version: 4.1.5
   resolution: "@types/graceful-fs@npm:4.1.5"
@@ -2896,6 +2908,17 @@ __metadata:
   version: 3.0.3
   resolution: "@types/js-cookie@npm:3.0.3"
   checksum: 927254ec37ce4fbe4d9d54f53a446b4351259799d9933db5808ddb7c430396aa2496bdd0a4e47e1b56048ffbec98645cbd4daa9e3ed9a6fff55e25eb640fcb15
+  languageName: node
+  linkType: hard
+
+"@types/jsdom@npm:*":
+  version: 21.1.1
+  resolution: "@types/jsdom@npm:21.1.1"
+  dependencies:
+    "@types/node": "*"
+    "@types/tough-cookie": "*"
+    parse5: ^7.0.0
+  checksum: 7450d6e23aa31b837a1682f0e59b06838aacca85c9d030035f40e21d559169c773aee5cee9244f23c3004b78f7064f0c540ceb808d2f187deb3140f2b0449dee
   languageName: node
   linkType: hard
 
@@ -3014,6 +3037,20 @@ __metadata:
   version: 1.4.6
   resolution: "@types/tether@npm:1.4.6"
   checksum: 5047559f502e43c10a61420dc5c7dd4ca5abb3b1b0c61fb62414acef93a1ecc207ae8111b4cd0f5d93c4ab4a09b7a30ebf33a523c5885488818c4f9b4852937a
+  languageName: node
+  linkType: hard
+
+"@types/tough-cookie@npm:*":
+  version: 4.0.2
+  resolution: "@types/tough-cookie@npm:4.0.2"
+  checksum: e055556ffdaa39ad85ede0af192c93f93f986f4bd9e9426efdc2948e3e2632db3a4a584d4937dbf6d7620527419bc99e6182d3daf2b08685e710f2eda5291905
+  languageName: node
+  linkType: hard
+
+"@types/trusted-types@npm:*":
+  version: 2.0.3
+  resolution: "@types/trusted-types@npm:2.0.3"
+  checksum: 4794804bc4a4a173d589841b6d26cf455ff5dc4f3e704e847de7d65d215f2e7043d8757e4741ce3a823af3f08260a8d04a1a6e9c5ec9b20b7b04586956a6b005
   languageName: node
   linkType: hard
 
@@ -6109,6 +6146,13 @@ cors@latest:
   dependencies:
     domelementtype: ^2.3.0
   checksum: 0f58f4a6af63e6f3a4320aa446d28b5790a009018707bce2859dcb1d21144c7876482b5188395a188dfa974238c019e0a1e610d2fc269a12b2c192ea2b0b131c
+  languageName: node
+  linkType: hard
+
+"dompurify@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "dompurify@npm:3.0.1"
+  checksum: 19447e6d96415a8ad3a67bc9c76ffe671eb31cf7c1e0a538cbe5037c8b8b03afe144d64cf96c6e0f7fe63b83721a33b5b913394d20a85e96550e42e31f7c086b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

This PR resolves a security vulnerability which results from HTML content being rendered by the `ld-notification` component without prior sanitization. The issue is resolved by sanitizing the HTML string internally. Sanitization config options are provided.

Fixes #625

## Type of change

- [x] Bugfix

## Is it a breaking change?

- [x] No

# How Has This Been Tested?

- [x] unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes
