### PR TITLE
feat(ld-notification): allow setting timeout on type alert notifications

### DIFF
--- a/src/liquid/components/ld-notification/ld-notification.tsx
+++ b/src/liquid/components/ld-notification/ld-notification.tsx
@@ -53,7 +53,16 @@ export class LdNotification {
     clearTimeout(this.dismissTimeout)
 
     if (!this.currentNotification) return
-    if (this.currentNotification.type === 'alert') return
+
+    // Do not dismiss, if alert has no explicit timeout.
+    if (
+      this.currentNotification.type === 'alert' &&
+      !this.currentNotification.timeout
+    ) {
+      return
+    }
+
+    // Do not dismiss, if timeout is disabled explicitly.
     if (this.currentNotification.timeout === 0) return
 
     this.dismissTimeout = setTimeout(() => {

--- a/src/liquid/components/ld-notification/readme.md
+++ b/src/liquid/components/ld-notification/readme.md
@@ -34,11 +34,13 @@ dispatchEvent(new CustomEvent('ldNotificationAdd', {
 
 Each notification item that appears on the screen has either the ARIA role `status` or `alert`, so that assistive technology should announce the notification content to the user.
 
-Keep in mind that focus is not explicitly changed when a notification appears. This means that users with visual disabilities may have problems navigating to a notification. This is especially the case for notifications which time out. And even more for notifications containing interaction elements, such as confirmation buttons etc. Thus, we recommend you avoid using notifications for critical information that users need to act on immediately. In summary, notifications may be difficult for users with low vision or low dexterity to access because they
+Keep in mind that focus is not explicitly changed when a notification appears. This means that users with visual disabilities may have problems navigating to a notification. This is especially the case for notifications which time out. And even more for notifications containing interaction elements, such as confirmation buttons and the like. Thus, we recommend that you avoid using notifications for critical information that users need to act on immediately. In summary, notifications may be difficult for users with low vision or low dexterity to access because they
 
 - Disappear automatically
 - Can’t be easily accessed with the keyboard
 - Might appear outside the proximity of the user’s current focus
+
+For more information on this topic, please read the [WCAG Understanding SC 4.1.3: Status Messages](https://www.w3.org/WAI/WCAG21/Understanding/status-messages.html) docs.
 
 ### Notifications with interactive content
 
@@ -52,7 +54,7 @@ Notifications of type `'alert'` take precedence of notifications of type `'info'
 
 ## Notification timeout
 
-While notifications with type `'alert'` do not time out, notifications of type `'info'` and `'warn'` have a default timeout of **six seconds** after which they disappear automatically. You can customize this timeout by attaching a timeout value of your choice to the appropriate property on the event detail object: 
+While notifications with type `'alert'` do not time out by default, notifications of type `'info'` and `'warn'` have a default timeout of **six seconds** after which they disappear automatically. You can customize the timeout for each notification type by attaching a timeout value of your choice to the appropriate property on the event detail object:
 
 ```js
 dispatchEvent(new CustomEvent('ldNotificationAdd', {

--- a/src/liquid/components/ld-notification/test/ld-notification.spec.ts
+++ b/src/liquid/components/ld-notification/test/ld-notification.spec.ts
@@ -431,6 +431,37 @@ describe('ld-notification', () => {
       expect(notifications.length).toEqual(1)
     })
 
+    it('dismisses a notification of type "alert" after explicit timeout', async () => {
+      const page = await newSpecPage({
+        components: [LdNotification],
+        html: `<ld-notification></ld-notification>`,
+      })
+      page.win.dispatchEvent(
+        new CustomEvent('ldNotificationAdd', {
+          detail: {
+            content: 'Ooops.',
+            type: 'alert',
+            timeout: DEFAULT_NOTIFICATION_TIMEOUT,
+          },
+        })
+      )
+      await page.waitForChanges()
+
+      let notifications = page.root.shadowRoot.querySelectorAll(
+        '.ld-notification__item:not(.ld-notification__item--dismissed)'
+      )
+      expect(notifications.length).toEqual(1)
+
+      // Fast-forward until the timer has been executed.
+      jest.advanceTimersByTime(DEFAULT_NOTIFICATION_TIMEOUT)
+      await page.waitForChanges()
+
+      notifications = page.root.shadowRoot.querySelectorAll(
+        '.ld-notification__item:not(.ld-notification__item--dismissed)'
+      )
+      expect(notifications.length).toEqual(0)
+    })
+
     it('does not dismiss a notification of type "info" if it is in queue behind another notification', async () => {
       const page = await newSpecPage({
         components: [LdNotification],


### PR DESCRIPTION
# Description

This PR changes how timeouts can be set on the `ld-notification` component, by adding the ability to set an explicit timeout on notifications with type `"alert"`. Notifications with type `"alert"` still do not timeout by default, making sure that important messages stay accessible with the initial configuration. However, we add the possibility to set a timeout for use cases where alert messages are very frequent, but do not carry important information.

Resolves #629

## Type of change

- [x] Feature

## Is it a breaking change?

- [x] No

# How Has This Been Tested?

- [x] unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes
