### PR TITLE
fix(ld-table): selectable table without table head throws exception

### DIFF
--- a/src/liquid/components/ld-table/ld-table.tsx
+++ b/src/liquid/components/ld-table/ld-table.tsx
@@ -104,6 +104,8 @@ export class LdTable {
       (tr) => !tr.selected
     )
     const ldTableHead = this.el.querySelector('ld-table-head')
+    if (!ldTableHead) return
+
     const firstRowInHead = ldTableHead.querySelector('ld-table-row')
     firstRowInHead.selected = allSelected
     firstRowInHead.indeterminate = !allSelected && !noneSelected

--- a/src/liquid/components/ld-table/test/ld-table.spec.tsx
+++ b/src/liquid/components/ld-table/test/ld-table.spec.tsx
@@ -606,6 +606,36 @@ describe('ld-table', () => {
       expect(checkboxes[0].indeterminate).toBeTruthy()
     })
 
+    it('does not throw updating select all checkbox on load if there is no table head', async () => {
+      const page = await newSpecPage({
+        components,
+        template: () => (
+          <ld-table>
+            <ld-table-body>
+              <ld-table-row selectable>
+                <ld-table-cell>1</ld-table-cell>
+              </ld-table-row>
+              <ld-table-row selectable selected>
+                <ld-table-cell>2</ld-table-cell>
+              </ld-table-row>
+              <ld-table-row selectable>
+                <ld-table-cell>3</ld-table-cell>
+              </ld-table-row>
+            </ld-table-body>
+          </ld-table>
+        ),
+      })
+
+      await page.waitForChanges()
+      const getCheckboxes = () =>
+        Array.from(page.root.querySelectorAll('ld-table-row')).map((row) =>
+          row.shadowRoot.querySelector('ld-checkbox')
+        )
+      const checkboxes = getCheckboxes()
+
+      expect(checkboxes.length).toEqual(3)
+    })
+
     it('disabled select all if at least one row has a disabled selection', async () => {
       const page = await newSpecPage({
         components,


### PR DESCRIPTION
# Description

This PR fixes a null pointer exception thrown on selectable tables without table-head by adding a guard.

Fixes #635

## Type of change

- [x] Bugfix

## Is it a breaking change?

- [x] No

# How Has This Been Tested?

- [x] unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes
