### PR TITLE
feat(ld-select): render option html content in trigger button

### DIFF
--- a/src/liquid/components/ld-select/ld-select.tsx
+++ b/src/liquid/components/ld-select/ld-select.tsx
@@ -405,7 +405,7 @@ export class LdSelect implements InnerFocusable {
     this.selected = selectedChildren.map((child) => {
       return {
         value: child.value,
-        text: child.textContent,
+        text: child.innerHTML,
       }
     })
 
@@ -1147,9 +1147,8 @@ export class LdSelect implements InnerFocusable {
                               class="ld-select__selection-label-text"
                               title={selection.text}
                               part="selection-label-text"
-                            >
-                              {selection.text}
-                            </span>
+                              innerHTML={selection.text}
+                            ></span>
 
                             <button
                               disabled={
@@ -1201,9 +1200,11 @@ export class LdSelect implements InnerFocusable {
                   title={triggerText}
                   part="trigger-text-wrapper"
                 >
-                  <span class="ld-select__btn-trigger-text" part="trigger-text">
-                    {triggerText}
-                  </span>
+                  <span
+                    class="ld-select__btn-trigger-text"
+                    part="trigger-text"
+                    innerHTML={triggerText}
+                  ></span>
                 </span>
               )}
 

--- a/src/liquid/components/ld-select/test/ld-select.spec.ts
+++ b/src/liquid/components/ld-select/test/ld-select.spec.ts
@@ -372,6 +372,60 @@ describe('ld-select', () => {
     })
   })
 
+  describe('HTML rendering', () => {
+    it('renders HTML in trigger button in single select mode', async () => {
+      const page = await newSpecPage({
+        components,
+        html: `
+          <ld-select placeholder="Pick some colors" name="colors" mode="inline">
+            <ld-option value="red">
+              <span id="red" style="background: red; width: 0.75rem; height: 0.75rem; margin-right: 0.5rem; display: inline-flex"></span> 
+            </ld-option>
+            <ld-option value="blue" selected>
+              <span id="blue" style="background: blue; width: 0.75rem; height: 0.75rem; margin-right: 0.5rem; display: inline-flex"></span> 
+            </ld-option>
+          </ld-select>
+        `,
+      })
+
+      const ldSelect = page.root
+      const btnTrigger = ldSelect.shadowRoot.querySelector<HTMLElement>(
+        '.ld-select__btn-trigger'
+      )
+
+      expect(btnTrigger.querySelector('#red')).toBeFalsy()
+      expect(btnTrigger.querySelector('#blue')).toBeTruthy()
+    })
+
+    it('renders HTML in trigger button in multiple select mode', async () => {
+      const page = await newSpecPage({
+        components,
+        html: `
+          <ld-select placeholder="Pick some colors" name="colors" mode="inline" multiple>
+            <ld-option value="red">
+              <span id="red" style="background: red; width: 0.75rem; height: 0.75rem; margin-right: 0.5rem; display: inline-flex"></span> 
+            </ld-option>
+            <ld-option value="blue" selected>
+              <span id="blue" style="background: blue; width: 0.75rem; height: 0.75rem; margin-right: 0.5rem; display: inline-flex"></span> 
+            </ld-option>
+            <ld-option value="green" selected>
+              <span id="green" style="background: green; width: 0.75rem; height: 0.75rem; margin-right: 0.5rem; display: inline-flex"></span> 
+            </ld-option>
+          </ld-select>
+        `,
+      })
+
+      const ldSelect = page.root
+      const btnTrigger = ldSelect.shadowRoot.querySelector<HTMLElement>(
+        '.ld-select__btn-trigger'
+      )
+
+      expect(btnTrigger.querySelector('#red')).toBeFalsy()
+      expect(btnTrigger.querySelector('#blue')).toBeTruthy()
+      expect(btnTrigger.querySelector('#green')).toBeTruthy()
+    })
+  })
+
   describe('css classes', () => {
     it('applies size prop', async () => {
       const page = await newSpecPage({


### PR DESCRIPTION
# Description

This PR adds a feature to the `ld-select` component, enabling it to render HTML content from selected options in the select trigger button. Previously the component only rendered the text content of the options. This feature allows for more customization of the select component.

Resolves #633

## Type of change

- [x] Feature

## Is it a breaking change?

- [x] No

# How Has This Been Tested?

Please describe the tests that you've added and run to verify your changes. 
Provide instructions, so we can reproduce.

- [x] unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes
