### PR TITLE
fix(loader): use ES2017 loader

### DIFF
--- a/scripts/patchLoader.ts
+++ b/scripts/patchLoader.ts
@@ -3,7 +3,7 @@ const fs = require('fs')
 const packageJSON = require('../dist/loader/package.json')
 const patchedPackageJSON = {
   ...packageJSON,
-  main: packageJSON.main.replace('.cjs', ''),
+  main: packageJSON.main.replace('.cjs', '.es2017'),
   type: 'module',
 }
 fs.writeFileSync(

--- a/scripts/patchReactOutput.ts
+++ b/scripts/patchReactOutput.ts
@@ -14,7 +14,7 @@ fs.readFile(filename, 'utf8', function (err, data) {
     )
     .replace(
       "import { defineCustomElements } from '../dist/components/dist/loader/index.js';",
-      "import { defineCustomElements } from '../dist/loader/index.js';"
+      "import { defineCustomElements } from '../dist/loader/index.es2017.js';"
     )
 
   fs.writeFile(filename, result, 'utf8', function (err) {

--- a/scripts/patchVueOutput.ts
+++ b/scripts/patchVueOutput.ts
@@ -14,7 +14,7 @@ fs.readFile(filename, 'utf8', function (err, data) {
     )
     .replace(
       "import { defineCustomElements } from '../dist/components/dist/loader/index.js';",
-      "import { defineCustomElements } from '../dist/loader/index.js';"
+      "import { defineCustomElements } from '../dist/loader/index.es2017.js';"
     )
 
   fs.writeFile(filename, result, 'utf8', function (err) {


### PR DESCRIPTION
# Description

The ES5 polyfill included in the default loader messes with prettyDOM, which is used by testing-library. To fix this, we patch the loader package.json, the react and the vue output target imports to use the ES2017 code.

Fixes #699

## Type of change

- [x] Bugfix

## Is it a breaking change?

- [x] No

# How Has This Been Tested?

- [x] tested manually

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes
