### PR TITLE
fix(ld-card): throws if there is no parent element

### DIFF
--- a/src/liquid/components/ld-card/ld-card.tsx
+++ b/src/liquid/components/ld-card/ld-card.tsx
@@ -26,7 +26,7 @@ export class LdCard {
   @Prop() size?: 'sm'
 
   componentWillLoad() {
-    if (this.el.parentElement.tagName === 'LD-CARD-STACK') {
+    if (this.el.parentElement?.tagName === 'LD-CARD-STACK') {
       this.el.setAttribute('role', 'listitem')
     }
   }

--- a/src/liquid/components/ld-card/test/ld-card.spec.tsx
+++ b/src/liquid/components/ld-card/test/ld-card.spec.tsx
@@ -1,5 +1,6 @@
 import { newSpecPage } from '@stencil/core/testing'
 import { LdCard } from '../ld-card'
+import { h } from '@stencil/core'
 
 describe('ld-card', () => {
   it('renders', async () => {
@@ -33,6 +34,41 @@ describe('ld-card', () => {
         html: `<ld-card shadow-interactive="sticky">Hello</ld-card>`,
       })
       expect(page.root).toHaveClass('ld-card--interactive-sticky')
+    })
+  })
+
+  describe('as listitem', () => {
+    it('adds listitem role if in card stack', async () => {
+      const page = await newSpecPage({
+        components: [LdCard],
+        template: () => (
+          <ld-card-stack>
+            <ld-card>Card A</ld-card>
+          </ld-card-stack>
+        ),
+      })
+      expect(page.body.querySelector('ld-card').getAttribute('role')).toEqual(
+        'listitem'
+      )
+    })
+
+    it('does not add listitem role if not in card stack', async () => {
+      const page = await newSpecPage({
+        components: [LdCard],
+        template: () => (
+          <div>
+            <ld-card>Card A</ld-card>
+          </div>
+        ),
+      })
+      expect(
+        page.body.querySelector('ld-card').getAttribute('role')
+      ).not.toEqual('listitem')
+    })
+
+    it('does not throw if there is no parent element', async () => {
+      const component = new LdCard()
+      component.componentWillLoad()
     })
   })
 })


### PR DESCRIPTION
# Description

This PR includes a small fix which makes sure that the `ld-card` component doesn't throw an exception if there is no parent element available. This can happen if the `componentWillLoad` lifecycle hook is executed after removal of the Node from the DOM.

## Type of change

- [x] Bugfix

## Is it a breaking change?

- [x] No

# How Has This Been Tested?

- [x] unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes
