### PR TITLE
fix(ld-context-menu): do not open on right click if not enabled

### DIFF
--- a/src/liquid/components/ld-context-menu/test/ld-context-menu.spec.tsx
+++ b/src/liquid/components/ld-context-menu/test/ld-context-menu.spec.tsx
@@ -463,6 +463,33 @@ describe('ld-context-menu', () => {
     expect(firstMenuItemInTooltip.focusInner).toHaveBeenCalled()
   })
 
+  it('does not open on right-click if right-click is not enabled', async () => {
+    const page = await newSpecPage({
+      components: [LdContextMenu, LdMenuitem, LdTooltip, LdMenu, LdButton],
+      template: () => (
+        <ld-context-menu>
+          <ld-button slot="trigger">Open</ld-button>
+          <ld-menuitem>Menu item</ld-menuitem>
+        </ld-context-menu>
+      ),
+    })
+    const tooltip = page.root.shadowRoot.querySelector('ld-tooltip')
+    const menu = page.root.shadowRoot.querySelector('ld-menu')
+    const triggerButton = page.root.querySelector('ld-button')
+
+    const menuInTooltip = await prepareAndGetMenuInTooltip(
+      page,
+      [triggerButton],
+      [menu]
+    )
+    const firstMenuItemInTooltip = menuInTooltip.querySelector('ld-menuitem')
+
+    tooltip.handleContextMenu(new Event('contextMenu'))
+    await page.waitForChanges()
+
+    expect(firstMenuItemInTooltip.focusInner).not.toHaveBeenCalled()
+  })
+
   it('closes on right-click of other context menu', async () => {
     const page = await newSpecPage({
       components: [LdContextMenu, LdMenuitem, LdTooltip, LdMenu, LdButton],

--- a/src/liquid/components/ld-tooltip/ld-tooltip.tsx
+++ b/src/liquid/components/ld-tooltip/ld-tooltip.tsx
@@ -260,7 +260,7 @@ export class LdTooltip {
   /** @internal */
   @Method()
   async handleContextMenu(ev) {
-    if (this.disabled) return
+    if (!this.rightClick || this.disabled) return
 
     ev.preventDefault()
     this.toggleTooltip()


### PR DESCRIPTION
# Description

This PR fixes an issue with the ld-context-menu component where it always opens on right-click no matter if right-click is enabled or not.

## Type of change

- [x] Bugfix

## Is it a breaking change?

- [x] No

# How Has This Been Tested?

- [x] unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes
