### PR TITLE
fix(ld-select): wait for popper to be visible before focusing filter

### DIFF
--- a/src/liquid/components/ld-badge/test/ld-badge.spec.tsx
+++ b/src/liquid/components/ld-badge/test/ld-badge.spec.tsx
@@ -1,9 +1,14 @@
 import { newSpecPage } from '@stencil/core/testing'
 import { LdIcon } from '../../ld-icon/ld-icon'
 import { LdBadge } from '../ld-badge'
-import { getTriggerableMutationObserver } from '../../../utils/mutationObserver'
+import {
+  clearTriggerableMutationObservers,
+  getTriggerableMutationObservers,
+} from '../../../utils/mutationObserver'
 
 describe('ld-badge', () => {
+  afterEach(clearTriggerableMutationObservers)
+
   it('renders', async () => {
     const page = await newSpecPage({
       components: [LdBadge, LdIcon],
@@ -55,7 +60,7 @@ describe('ld-badge', () => {
     icon.setAttribute('name', 'placeholder')
 
     page.root.appendChild(icon)
-    getTriggerableMutationObserver().trigger([])
+    getTriggerableMutationObservers()[0].trigger([])
     await page.waitForChanges()
 
     expect(page.root).toMatchSnapshot()
@@ -71,7 +76,7 @@ describe('ld-badge', () => {
     span.innerHTML = 'Badge'
 
     page.root.appendChild(span)
-    getTriggerableMutationObserver().trigger([])
+    getTriggerableMutationObservers()[0].trigger([])
     await page.waitForChanges()
 
     expect(page.root).toMatchSnapshot()

--- a/src/liquid/components/ld-breadcrumbs/test/ld-breadcrumbs.spec.tsx
+++ b/src/liquid/components/ld-breadcrumbs/test/ld-breadcrumbs.spec.tsx
@@ -1,9 +1,14 @@
 import { newSpecPage } from '@stencil/core/testing'
 import { LdBreadcrumbs } from '../ld-breadcrumbs'
 import { LdCrumb } from '../ld-crumb/ld-crumb'
-import { getTriggerableMutationObserver } from '../../../utils/mutationObserver'
+import {
+  clearTriggerableMutationObservers,
+  getTriggerableMutationObservers,
+} from '../../../utils/mutationObserver'
 
 describe('ld-breadcrumbs', () => {
+  afterEach(clearTriggerableMutationObservers)
+
   it('renders', async () => {
     const page = await newSpecPage({
       components: [LdBreadcrumbs, LdCrumb],
@@ -35,7 +40,7 @@ describe('ld-breadcrumbs', () => {
     crumb.innerHTML = 'baz'
 
     page.root.appendChild(crumb)
-    getTriggerableMutationObserver().trigger([])
+    getTriggerableMutationObservers()[0].trigger([])
     await page.waitForChanges()
 
     expect(page.root).toMatchSnapshot()
@@ -53,7 +58,7 @@ describe('ld-breadcrumbs', () => {
     await page.waitForChanges()
 
     page.root.removeChild(page.root.querySelector('ld-crumb:last-of-type'))
-    getTriggerableMutationObserver().trigger([])
+    getTriggerableMutationObservers()[0].trigger([])
     await page.waitForChanges()
 
     expect(page.root).toMatchSnapshot()

--- a/src/liquid/components/ld-context-menu/ld-menuitem/test/ld-menuitem.spec.tsx
+++ b/src/liquid/components/ld-context-menu/ld-menuitem/test/ld-menuitem.spec.tsx
@@ -1,8 +1,13 @@
 import { newSpecPage } from '@stencil/core/testing'
 import { LdMenuitem } from '../ld-menuitem'
-import { getTriggerableMutationObserver } from '../../../../utils/mutationObserver'
+import {
+  clearTriggerableMutationObservers,
+  getTriggerableMutationObservers,
+} from '../../../../utils/mutationObserver'
 
 describe('ld-menuitem', () => {
+  afterEach(clearTriggerableMutationObservers)
+
   it('renders default', async () => {
     const page = await newSpecPage({
       components: [LdMenuitem],
@@ -50,7 +55,7 @@ describe('ld-menuitem', () => {
     })
 
     page.root.setAttribute('data-attribute', 'test')
-    getTriggerableMutationObserver().trigger([
+    getTriggerableMutationObservers()[0].trigger([
       { attributeName: 'data-attribute' },
     ])
     await page.waitForChanges()

--- a/src/liquid/components/ld-input/test/ld-input.spec.ts
+++ b/src/liquid/components/ld-input/test/ld-input.spec.ts
@@ -1,8 +1,13 @@
 import { newSpecPage } from '@stencil/core/testing'
 import { LdInput } from '../ld-input'
-import { getTriggerableMutationObserver } from '../../../utils/mutationObserver'
+import {
+  clearTriggerableMutationObservers,
+  getTriggerableMutationObservers,
+} from '../../../utils/mutationObserver'
 
 describe('ld-input', () => {
+  afterEach(clearTriggerableMutationObservers)
+
   it('renders', async () => {
     const page = await newSpecPage({
       components: [LdInput],
@@ -511,7 +516,7 @@ describe('ld-input', () => {
     })
 
     root.setAttribute('name', 'test')
-    getTriggerableMutationObserver().trigger([{ attributeName: 'name' }])
+    getTriggerableMutationObservers()[0].trigger([{ attributeName: 'name' }])
     await waitForChanges()
     expect(root).toMatchSnapshot()
   })
@@ -531,7 +536,7 @@ describe('ld-input', () => {
     })
 
     root.setAttribute('form', 'test')
-    getTriggerableMutationObserver().trigger([{ attributeName: 'form' }])
+    getTriggerableMutationObservers()[0].trigger([{ attributeName: 'form' }])
     await waitForChanges()
     expect(root).toMatchSnapshot()
   })
@@ -604,7 +609,7 @@ describe('ld-input', () => {
     root.setAttribute('form', 'test')
     root.setAttribute('name', 'test')
     root.setAttribute('value', 'test')
-    getTriggerableMutationObserver().trigger([
+    getTriggerableMutationObservers()[0].trigger([
       { attributeName: 'dirname' },
       { attributeName: 'form' },
       { attributeName: 'name' },
@@ -627,7 +632,7 @@ describe('ld-input', () => {
     ldInput.removeAttribute('dirname')
     ldInput.removeAttribute('form')
     ldInput.removeAttribute('value')
-    getTriggerableMutationObserver().trigger([
+    getTriggerableMutationObservers()[0].trigger([
       { attributeName: 'dirname' },
       { attributeName: 'form' },
       { attributeName: 'value' },
@@ -645,7 +650,7 @@ describe('ld-input', () => {
     })
 
     root.removeAttribute('name')
-    getTriggerableMutationObserver().trigger([{ attributeName: 'name' }])
+    getTriggerableMutationObservers()[0].trigger([{ attributeName: 'name' }])
     await waitForChanges()
     expect(root).toMatchSnapshot()
   })
@@ -657,7 +662,7 @@ describe('ld-input', () => {
     })
 
     root.removeAttribute('form')
-    getTriggerableMutationObserver().trigger([{ attributeName: 'form' }])
+    getTriggerableMutationObservers()[0].trigger([{ attributeName: 'form' }])
     await waitForChanges()
     expect(root).toMatchSnapshot()
   })

--- a/src/liquid/components/ld-select/ld-select.tsx
+++ b/src/liquid/components/ld-select/ld-select.tsx
@@ -951,6 +951,16 @@ export class LdSelect implements InnerFocusable {
     }
   }
 
+  private focusFilterAsSoonAsVisible = (filterInput: HTMLInputElement) => {
+    setTimeout(() => {
+      if (this.listboxRef.style.display === 'none') {
+        this.focusFilterAsSoonAsVisible(filterInput)
+      } else {
+        filterInput.focus()
+      }
+    })
+  }
+
   private handleTriggerClick = (ev: Event) => {
     ev.preventDefault()
 
@@ -960,9 +970,13 @@ export class LdSelect implements InnerFocusable {
 
     this.togglePopper()
 
-    setTimeout(() => {
-      this.getFilterInput()?.focus()
-    })
+    // At this point the popper element may still have display none
+    // (which happens quite rarely - but it does happen!), and we need
+    // to "wait" for it to be visible before setting focus.
+    const filterInput = this.getFilterInput()
+    if (filterInput) {
+      this.focusFilterAsSoonAsVisible(filterInput)
+    }
   }
 
   private handleClearClick = (ev: MouseEvent) => {

--- a/src/liquid/components/ld-select/test/ld-select.spec.ts
+++ b/src/liquid/components/ld-select/test/ld-select.spec.ts
@@ -4,7 +4,10 @@ import { LdSelectPopper } from '../ld-select-popper/ld-select-popper'
 import { LdLabel } from '../../ld-label/ld-label'
 import { LdOption } from '../ld-option/ld-option'
 import { LdOptionInternal } from '../ld-option-internal/ld-option-internal'
-import { getTriggerableMutationObserver } from '../../../utils/mutationObserver'
+import {
+  clearTriggerableMutationObservers,
+  getTriggerableMutationObservers,
+} from '../../../utils/mutationObserver'
 import { LdIcon } from '../../ld-icon/ld-icon'
 
 const components = [
@@ -70,6 +73,7 @@ function getShadow(page: SpecPage) {
 describe('ld-select', () => {
   afterEach(() => {
     jest.advanceTimersToNextTimer()
+    clearTriggerableMutationObservers()
   })
 
   it('renders popper element with copies of slotted options', async () => {
@@ -1023,7 +1027,10 @@ describe('ld-select', () => {
         new KeyboardEvent('keydown', { key: 'ArrowDown', metaKey: true })
       )
       await page.waitForChanges()
-      jest.advanceTimersByTime(0)
+
+      getTriggerableMutationObservers()[0].trigger([
+        { oldValue: 'display: none;' },
+      ])
 
       expect(btnTrigger.getAttribute('aria-expanded')).toEqual('true')
       expect(internalOption2.focus).toHaveBeenCalledTimes(1)
@@ -1395,7 +1402,7 @@ describe('ld-select', () => {
 
       await triggerPopperWithClick(page)
 
-      const ldSelect = page.root
+      const ldSelect = page.root as HTMLLdSelectElement
       const { ldInternalOptions, internalOptions } = getInternalOptions(page)
       const [ldInternalOption1, ldInternalOption2] = ldInternalOptions
       const [, internalOption2] = internalOptions
@@ -1419,7 +1426,10 @@ describe('ld-select', () => {
 
       window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }))
       await page.waitForChanges()
-      jest.advanceTimersByTime(0)
+
+      getTriggerableMutationObservers()[0].trigger([
+        { oldValue: 'display: none;' },
+      ])
 
       expect(btnTrigger.getAttribute('aria-expanded')).toEqual('true')
       expect(internalOption2.focus).toHaveBeenCalledTimes(1)
@@ -2235,7 +2245,9 @@ describe('ld-select', () => {
 
       slottedOptions[2].setAttribute('selected', '')
       await page.waitForChanges()
-      getTriggerableMutationObserver().trigger([{ target: slottedOptions[2] }])
+      getTriggerableMutationObservers()[0].trigger([
+        { target: slottedOptions[2] },
+      ])
 
       await page.waitForChanges()
 
@@ -2265,7 +2277,7 @@ describe('ld-select', () => {
       ldIcon.setAttribute('name', 'bottle')
 
       await page.waitForChanges()
-      getTriggerableMutationObserver().trigger([{ target: ldIcon }])
+      getTriggerableMutationObservers()[0].trigger([{ target: ldIcon }])
 
       await page.waitForChanges()
 
@@ -2381,7 +2393,9 @@ describe('ld-select', () => {
       window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }))
       await page.waitForChanges()
 
-      jest.advanceTimersByTime(0)
+      getTriggerableMutationObservers()[0].trigger([
+        { oldValue: 'display: none;' },
+      ])
 
       expect(btnTrigger.getAttribute('aria-expanded')).toEqual('true')
       expect(filterInput.focus).toHaveBeenCalledTimes(1)
@@ -2504,7 +2518,9 @@ describe('ld-select', () => {
       await triggerPopperWithClick(page)
       expect(btnTrigger.getAttribute('aria-expanded')).toEqual('true')
 
-      jest.advanceTimersByTime(0)
+      getTriggerableMutationObservers()[0].trigger([
+        { oldValue: 'display: none;' },
+      ])
       expect(filterInput.focus).toHaveBeenCalledTimes(1)
 
       const { doc, shadowDoc, popperShadowDoc } = getShadow(page)
@@ -2620,7 +2636,9 @@ describe('ld-select', () => {
       await triggerPopperWithClick(page)
       expect(btnTrigger.getAttribute('aria-expanded')).toEqual('true')
 
-      jest.advanceTimersByTime(0)
+      getTriggerableMutationObservers()[0].trigger([
+        { oldValue: 'display: none;' },
+      ])
       expect(filterInput.focus).toHaveBeenCalledTimes(1)
 
       const { ldInternalOptions, internalOptions } = getInternalOptions(page)
@@ -2923,7 +2941,9 @@ describe('ld-select', () => {
       await triggerPopperWithClick(page)
       expect(btnTrigger.getAttribute('aria-expanded')).toEqual('true')
 
-      jest.advanceTimersByTime(0)
+      getTriggerableMutationObservers()[0].trigger([
+        { oldValue: 'display: none;' },
+      ])
       expect(filterInput.focus).toHaveBeenCalledTimes(1)
 
       const { ldInternalOptions } = getInternalOptions(page)
@@ -3091,7 +3111,7 @@ describe('ld-select', () => {
       ldSelect.prepend(option)
 
       await page.waitForChanges()
-      getTriggerableMutationObserver().trigger([{ target: option }])
+      getTriggerableMutationObservers()[1].trigger([{ target: option }])
       await page.waitForChanges()
 
       ldInternalOptions = getInternalOptions(page).ldInternalOptions

--- a/src/liquid/components/ld-tabs/ld-tablist/test/ld-tablist.spec.ts
+++ b/src/liquid/components/ld-tabs/ld-tablist/test/ld-tablist.spec.ts
@@ -2,7 +2,10 @@ import { newSpecPage } from '@stencil/core/testing'
 import { LdTablist } from '../ld-tablist'
 import { LdTab } from '../../ld-tab/ld-tab'
 import '../../../../utils/resizeObserver'
-import { getTriggerableMutationObserver } from '../../../../utils/mutationObserver'
+import {
+  clearTriggerableMutationObservers,
+  getTriggerableMutationObservers,
+} from '../../../../utils/mutationObserver'
 import { LdIcon } from '../../../ld-icon/ld-icon'
 
 const components = [LdTablist, LdTab, LdIcon]
@@ -11,6 +14,7 @@ describe('ld-tablist', () => {
   beforeEach(() => {
     jest.clearAllTimers()
   })
+  afterEach(clearTriggerableMutationObservers)
 
   describe('modifiers', () => {
     it('size', async () => {
@@ -140,7 +144,7 @@ describe('ld-tablist', () => {
       expect((indicator as HTMLElement).style.opacity).toEqual('1')
 
       page.root.querySelectorAll('ld-tab')[0].remove()
-      getTriggerableMutationObserver().trigger([])
+      getTriggerableMutationObservers()[0].trigger([])
       page.waitForChanges()
       expect((indicator as HTMLElement).style.opacity).toEqual('0')
     })

--- a/src/liquid/components/ld-tooltip/test/ld-tooltip.spec.ts
+++ b/src/liquid/components/ld-tooltip/test/ld-tooltip.spec.ts
@@ -5,7 +5,10 @@ import { newSpecPage } from '@stencil/core/testing'
 import { LdIcon } from '../../ld-icon/ld-icon'
 import { LdTooltip } from '../ld-tooltip'
 import { LdTooltipPopper } from '../ld-tooltip-popper/ld-tooltip-popper'
-import { getTriggerableMutationObserver } from '../../../utils/mutationObserver'
+import {
+  clearTriggerableMutationObservers,
+  getTriggerableMutationObservers,
+} from '../../../utils/mutationObserver'
 
 const positions = [
   'bottom center',
@@ -25,6 +28,7 @@ const positions = [
 describe('ld-tooltip', () => {
   afterEach(() => {
     jest.advanceTimersToNextTimer()
+    clearTriggerableMutationObservers()
   })
 
   it('renders default', async () => {
@@ -629,7 +633,7 @@ describe('ld-tooltip', () => {
     mockAssignedNodesOnDefaultSlot()
 
     await page.waitForChanges()
-    getTriggerableMutationObserver().trigger([])
+    getTriggerableMutationObservers()[0].trigger([])
     await page.waitForChanges()
 
     expect(page.body.querySelector('ld-tooltip-popper p').textContent).toBe(

--- a/src/liquid/utils/mutationObserver.ts
+++ b/src/liquid/utils/mutationObserver.ts
@@ -1,14 +1,19 @@
 import MutationObserver from 'mutation-observer'
 
-let triggerableMutationObserver
+let triggerableMutationObservers = []
 const TriggerableMutationObserver = function (cb) {
-  triggerableMutationObserver = new MutationObserver(cb)
+  const triggerableMutationObserver = new MutationObserver(cb)
   triggerableMutationObserver.trigger = cb
+  triggerableMutationObservers.push(triggerableMutationObserver)
   return triggerableMutationObserver
 }
 
 global.MutationObserver = TriggerableMutationObserver as MutationObserver
 
-export function getTriggerableMutationObserver() {
-  return triggerableMutationObserver
+export function getTriggerableMutationObservers() {
+  return triggerableMutationObservers
+}
+
+export function clearTriggerableMutationObservers() {
+  triggerableMutationObservers = []
 }


### PR DESCRIPTION
# Description

It looks like the Tether enable method returns before the actual popper element is visible. So we need to "wait" for it to become visible before setting the focus on the filter input element.

Fixes #813

## Type of change

- [x] Bugfix

## Is it a breaking change?

- [x] No

# How Has This Been Tested?

- [x] tested manually

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes
