### PR TITLE
build: add an explicit start docs script for watching docs related resources

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
     "lint:styles:fix": "stylelint ./src/**/*css --fix",
     "lint:ts": "tsc --noemit -p config/tsconfig.docs.json",
     "prepare": "husky install",
-    "start": "run-s start:watch",
-    "start:watch": "run-p serve 'build:styles:docs:*' 'watch:**' start:info",
+    "start": "run-p serve 'watch:eleventy' 'watch:stencil' 'watch:global_styles:liquid' 'watch:styles:components' start:info",
+    "start:docs": "run-p serve 'watch:eleventy' 'watch:stencil:docs' 'watch:global_styles:liquid' 'watch:global_styles:docs' 'watch:styles:components' start:info",
     "start:info": "echo 'serving on http://localhost:8080'",
     "serve": "nc -z 127.0.0.1 8080 && exit 0 || live-server --port=8080 dist_docs --no-browser --no-css-inject --quiet",
     "test": "stencil test --config=stencil.config.ts --spec --coverage",
@@ -73,7 +73,8 @@
     "watch:eleventy": "dotenv -e .env -- node ./scripts/eleventy.cjs --incremental --watch",
     "watch:global_styles:liquid": "chokidar src/liquid/global/styles/**/*.css -c 'yarn build:styles:docs:liquid'",
     "watch:global_styles:docs": "chokidar src/docs/global/styles/**/*.css -c 'yarn build:styles:docs:docs'",
-    "watch:stencil": "stencil build --config=config/stencil.config.docs.ts --docs --watch --dev --no-open",
+    "watch:stencil": "stencil build --config=stencil.config.ts --docs --watch --dev --no-open",
+    "watch:stencil:docs": "stencil build --config=config/stencil.config.docs.ts --docs --watch --dev --no-open",
     "watch:styles:components": "chokidar src/liquid/components/**/*.css -i 'src/liquid/components/**/*.shadow.css' -c 'yarn build:styles:docs:components'"
   },
   "dependencies": {

--- a/src/docs/pages/guides/contributing.md
+++ b/src/docs/pages/guides/contributing.md
@@ -134,6 +134,14 @@ yarn start
   As an alternative, you can start developing instantly within <a href="https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=344421806&machine=standardLinux32gb&location=WestEurope">GitHub Codespaces</a>. For more information on Codespaces head over to the <a href="https://github.com/features/codespaces">Codespaces docs on GitHub</a>.
 </ld-notice>
 
+#### Working on the documentation page
+
+If you wish to make code changes to the documentation page (by modifying code within the `src/docs` directory), you can utilize the following command, which will launch the development server, actively monitors documentation-related resources. Consequently, you will be able to observe your changes taking effect as you code.
+
+```sh
+yarn start:docs
+```
+
 ### Project structure
 
 This project consists of different parts and pieces, each with its own purpose. Familiarize yourself with these parts and pieces, so that you find your way quicker to the relevant spot where you would like to contribute.


### PR DESCRIPTION
# Description

When working on components, it is sometimes annoying to undo changes in readme files of components which are unrelated to the actual changes. These unrelated changes originate from running stencil using the docs specific config (`config/stencil.config.docs.ts`) which takes into account dependencies between liquid components and docs components.

The start script now uses the `stencil.config.ts` configuration, effectively solving that problem. The start:docs script is now dedicated to working on documentation related changes.

## Type of change

- [x] Build related changes
- [x] Documentation content changes

## Is it a breaking change?

- [x] No

# How Has This Been Tested?

- [x] tested manually

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes
