### PR TITLE
fix(ld-input): disabled color on safari

### DIFF
--- a/src/liquid/components/ld-input/ld-input.css
+++ b/src/liquid/components/ld-input/ld-input.css
@@ -24,7 +24,6 @@
   --ld-input-time-min-width-lg: 7.5rem;
 
   /* colors */
-  --ld-input-col: var(--ld-col-neutral-900);
   --ld-input-bg-col-disabled: var(--ld-col-neutral-010);
   --ld-input-bg-col-invalid-focus: var(--ld-col-wht);
   --ld-input-bg-col-invalid: var(--ld-thm-error-disabled);
@@ -91,9 +90,10 @@
   }
 
   > input {
-    color: var(--ld-input-col);
+    color: var(--ld-input-text-col);
     align-self: stretch;
     max-height: var(--ld-input-max-height-md);
+    -webkit-text-fill-color: var(--ld-input-text-col);
 
     &[type='file'] {
       opacity: 0;
@@ -413,6 +413,7 @@
   ) {
   background-color: var(--ld-input-bg-col-invalid);
   color: var(--ld-input-text-col-invalid);
+  -webkit-text-fill-color: var(--ld-input-text-col-invalid);
 }
 
 :host(.ld-input--invalid:not(.ld-input--disabled, [aria-disabled='true'])),
@@ -424,6 +425,7 @@
   > input,
   > textarea {
     color: var(--ld-input-text-col-invalid);
+    -webkit-text-fill-color: var(--ld-input-text-col-invalid);
 
     &::placeholder {
       color: var(--ld-input-placeholder-col-invalid);
@@ -458,6 +460,7 @@
   > input,
   > textarea {
     color: var(--ld-input-text-col-invalid-focus);
+    -webkit-text-fill-color: var(--ld-input-text-col-invalid-focus);
   }
 }
 
@@ -474,8 +477,9 @@
 
   input,
   textarea {
-    color: currentColor;
+    color: var(--ld-input-text-col-disabled);
     caret-color: transparent;
+    -webkit-text-fill-color: var(--ld-input-text-col-disabled);
 
     &::placeholder {
       opacity: 0.25;


### PR DESCRIPTION
# Description

This PR fixes an issue where disabled input fields have a slightly lighter text color on Safari than they should.

## Type of change

- [x] Bugfix

## Is it a breaking change?

- [x] No

# How Has This Been Tested?

- [x] tested manually

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes
