### PR TITLE
fix(closest): account for closest method being undefined on document

### DIFF
--- a/src/liquid/utils/closest.ts
+++ b/src/liquid/utils/closest.ts
@@ -1,9 +1,9 @@
 // This helper function is similar to Element.closest(),
 // however it also traverses shadow DOM boundaries.
-export const closest = (selector: string, el: Element) => {
+export const closest = (selector: string, el: Element | Document) => {
   return (
     el &&
-    (el.closest(selector) ||
+    (('closest' in el && el.closest(selector)) ||
       closest(selector, (el.getRootNode() as unknown as ShadowRoot).host))
   )
 }

--- a/src/liquid/utils/test/closest.spec.tsx
+++ b/src/liquid/utils/test/closest.spec.tsx
@@ -1,0 +1,40 @@
+import { closest } from '../closest'
+
+describe('closest', () => {
+  it('returns undefined if element has no closest method', () => {
+    // Document has no closest method. However, in js-dom it has.
+    // So we need to use a fake Document to have a realistic test.
+    const docWithoutClosest = {
+      getRootNode: document.getRootNode,
+    } as Document
+
+    expect(closest('html', docWithoutClosest)).toBe(undefined)
+  })
+
+  it('returns closest element if there is a closest element', () => {
+    expect(closest('html', document.body)).toBe(document.documentElement)
+  })
+
+  it('returns closest element traversing shadow DOM boundaries', () => {
+    class CustomElement extends HTMLElement {
+      constructor() {
+        super()
+        const shadow = this.attachShadow({ mode: 'closed' })
+
+        const inner = document.createElement('span')
+        inner.classList.add('inner')
+
+        shadow.appendChild(inner)
+      }
+    }
+
+    customElements.define('custom-element', CustomElement)
+
+    const el = document.createElement('custom-element')
+    document.body.appendChild(el)
+
+    expect(closest('html', el.shadowRoot.querySelector('.inner'))).toBe(
+      document.documentElement
+    )
+  })
+})


### PR DESCRIPTION
# Description

We encountered an issue with the `ld-sidenav` component throwing an error when listening for a `'focusout'` event on `window`. The `relatedTarget` of the event was `document`. The sidenav checked if the focus was inside the sidenav by calling the `closest` utility function. The `closest` utility function tried to execute the `closest` method on the `document` which was passed in as an argument, which lead to an exception being thrown.
This PR addresses the issue by fixing the `closest` utility function in a way that it returns `undefined` when passed an element that does not have a `closest` method (i.e. the `document`).

## Type of change

- [x] Bugfix

## Is it a breaking change?

- [x] No

# How Has This Been Tested?

- [x] unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes
