### PR TITLE
feat(ld-crumb): switch last/non-last crumb link styles

### DIFF
--- a/src/liquid/components/ld-breadcrumbs/ld-crumb/ld-crumb.css
+++ b/src/liquid/components/ld-breadcrumbs/ld-crumb/ld-crumb.css
@@ -7,26 +7,13 @@
 
 .ld-breadcrumbs li:not(:last-of-type) .ld-link,
 .ld-crumb__link:not(.ld-crumb__link--current)::part(anchor) {
-  --ld-link-col: var(--ld-col-neutral-600);
-
-  font-weight: normal;
   margin-right: calc(var(--ld-crumb-gap) + 0.5em);
-
-  &:hover {
-    --ld-link-col: var(--ld-thm-primary-hover);
-  }
-
-  &:focus:focus-visible {
-    --ld-link-col: var(--ld-thm-primary-focus);
-  }
-
-  &:active {
-    --ld-link-col: var(--ld-thm-primary-active);
-  }
 }
 
 .ld-breadcrumbs li:last-of-type .ld-link,
-.ld-crumb__link--current {
+.ld-crumb__link--current::part(anchor) {
+  --ld-link-col: var(--ld-col-neutral-600);
   cursor: default;
+  font-weight: normal;
   pointer-events: none;
 }


### PR DESCRIPTION
# Description

The styles of the last breadcrumb item is now switched with the style of the other breadcrumb items, to have a more persistent style for links across components.

## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Is it a breaking change?

- [ ] Yes
- [x] No

# How Has This Been Tested?

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes